### PR TITLE
feat: add 'insanity' page to test layouts

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@
 //? of the Home page. All related CSS is in the file.css file
 export function Footer() {
 	return (
-		<footer>
+		<footer class="page-footer">
 			Built with
 			<a href="https://fresh.deno.dev/" target="_blank" rel="noopener noreferrer">
 				<img

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -8,7 +8,8 @@ import * as $1 from "./routes/[name].tsx";
 import * as $2 from "./routes/api/joke.ts";
 import * as $3 from "./routes/index.tsx";
 import * as $$0 from "./islands/BlogNavigationButtons.tsx";
-import * as $$1 from "./islands/ThemeSwitcher.tsx";
+import * as $$1 from "./islands/InsanitySection.tsx";
+import * as $$2 from "./islands/ThemeSwitcher.tsx";
 
 const manifest = {
   routes: {
@@ -19,7 +20,8 @@ const manifest = {
   },
   islands: {
     "./islands/BlogNavigationButtons.tsx": $$0,
-    "./islands/ThemeSwitcher.tsx": $$1,
+    "./islands/InsanitySection.tsx": $$1,
+    "./islands/ThemeSwitcher.tsx": $$2,
   },
   baseUrl: import.meta.url,
   config,

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -9,7 +9,8 @@ import * as $2 from "./routes/api/joke.ts";
 import * as $3 from "./routes/index.tsx";
 import * as $$0 from "./islands/BlogNavigationButtons.tsx";
 import * as $$1 from "./islands/InsanitySection.tsx";
-import * as $$2 from "./islands/ThemeSwitcher.tsx";
+import * as $$2 from "./islands/StyledButton.tsx";
+import * as $$3 from "./islands/ThemeSwitcher.tsx";
 
 const manifest = {
   routes: {
@@ -21,7 +22,8 @@ const manifest = {
   islands: {
     "./islands/BlogNavigationButtons.tsx": $$0,
     "./islands/InsanitySection.tsx": $$1,
-    "./islands/ThemeSwitcher.tsx": $$2,
+    "./islands/StyledButton.tsx": $$2,
+    "./islands/ThemeSwitcher.tsx": $$3,
   },
   baseUrl: import.meta.url,
   config,

--- a/heads/BlogHead.tsx
+++ b/heads/BlogHead.tsx
@@ -25,6 +25,7 @@ export function BlogHead() {
 				></link>
 				<link rel="stylesheet" href="/base.css" />
 				<link rel="stylesheet" href="/blog.css" />
+				<link rel="stylesheet" href="/styled-button.css" />
 			</Head>
 		</>
 	);

--- a/islands/InsanitySection.tsx
+++ b/islands/InsanitySection.tsx
@@ -1,5 +1,7 @@
 //? Import useState hook to manage the insanityArray
 import { useState } from 'preact/hooks';
+//? Imports the Styled Button template
+import StyledButton from './StyledButton.tsx';
 
 //? Exports a button that will add more Insanity text when clicked.
 //? Also ships with basic Insanity text by default
@@ -7,21 +9,19 @@ export default function InsanitySection() {
 	//? Simple array to track how many Insanity should be displayed
 	const [insanityArray, setInsanity] = useState([null]);
 
-	// { style }: { style: string }
 	return (
 		<>
-			{/* Button that adds another null to the insanityArray, which
-                then renders more Insanity to the page */}
-			<button
-				class="styled-button"
-				onClick={() => {
-					setInsanity((currentInsanity) => [...currentInsanity, null]);
-				}}
-			>
-				Dial ⤴️ the Insanity 🤪
-			</button>
-			{/* Insanity section. Can be expanded by clicking the button above */}
 			<section>
+				{/* Button that adds another null to the insanityArray, which
+                then renders more Insanity to the page */}
+				{/* Insanity section. Can be expanded by clicking the button above */}
+				<StyledButton
+					text="Dial ⤴️ the Insanity 🤪"
+					style="align-self: end; margin-bottom: 0.5rem;"
+					onClickFunction={() => {
+						setInsanity((currentInsanity) => [...currentInsanity, null]);
+					}}
+				/>
 				{/* Returns two labels and Radio buttons for Dark and Light themes */}
 				{insanityArray.map(() => (
 					<>

--- a/islands/InsanitySection.tsx
+++ b/islands/InsanitySection.tsx
@@ -1,0 +1,62 @@
+//? Import useState hook to manage the insanityArray
+import { useState } from 'preact/hooks';
+
+//? Exports a button that will add more Insanity text when clicked.
+//? Also ships with basic Insanity text by default
+export default function InsanitySection() {
+	//? Simple array to track how many Insanity should be displayed
+	const [insanityArray, setInsanity] = useState([null]);
+
+	// { style }: { style: string }
+	return (
+		<>
+			{/* Button that adds another null to the insanityArray, which
+                then renders more Insanity to the page */}
+			<button
+				class="styled-button"
+				onClick={() => {
+					setInsanity((currentInsanity) => [...currentInsanity, null]);
+				}}
+			>
+				Dial ⤴️ the Insanity 🤪
+			</button>
+			{/* Insanity section. Can be expanded by clicking the button above */}
+			<section>
+				{/* Returns two labels and Radio buttons for Dark and Light themes */}
+				{insanityArray.map(() => (
+					<>
+						<p>
+							Insanity is doing the exact... same fucking thing... 🔁 over and 🔁 over
+							again expecting... shit to change... ⏭️{' '}
+							<em>
+								That. Is. <strong>Crazy.</strong>
+							</em>{' '}
+							🤪
+						</p>
+						<p>
+							The first time somebody told me that, I dunno, I thought they were
+							bullshitting me, so 💥, I shot him 🔫. The thing is... He was right 🤔.
+							And then I started seeing, everywhere I looked 🔎, everywhere I looked
+							all these fucking pricks, everywhere I looked, doing the exact same
+							fucking thing... 🔁 over and 🔁 over and 🔁 over and 🔁 over again
+							thinking 'this time is gonna be different' no, no, no please... This
+							time is gonna be different, I'm sorry 🙏, I don't like... The way... you
+							are looking at me... 🧐
+						</p>
+						<p>
+							Okay, Do you have a fucking problem in your head 🤕, do you think I am
+							bullshitting you, do you think I am lying 🤥? Fuck you! Okay? Fuck you!
+							😡
+						</p>
+						<p>
+							It's okay, man. I'm gonna chill, hermano. I'm gonna chill 🥶... The
+							thing is... Alright, the thing is I killed you once already 🪦... and
+							it's not like I am fucking crazy 🤪. It's okay... It's like water under
+							the bridge 🌉. Did I ever tell you the definition... of insanity?
+						</p>
+					</>
+				))}
+			</section>
+		</>
+	);
+}

--- a/islands/StyledButton.tsx
+++ b/islands/StyledButton.tsx
@@ -1,0 +1,19 @@
+//? This file holds the content to the default button used
+//? throughout the application. It comes with default internal
+//? spacing (padding) and coloring, but has no default margins
+//! Style buttons on-demand by providing a optional style prop!
+export default function StyledButton({
+	text,
+	style,
+	onClickFunction,
+}: {
+	text: string;
+	style?: string;
+	onClickFunction?: () => void;
+}) {
+	return (
+		<button class="styled-button" onClick={onClickFunction} style={style}>
+			{text}
+		</button>
+	);
+}

--- a/routes/[blog]/this.tsx
+++ b/routes/[blog]/this.tsx
@@ -13,75 +13,36 @@ export default function Home() {
 			<Base>
 				<BlogNavigationButtons />
 				<article>
-					<h1>
-						Hi, sorry about this, I'm using this page to check the responsiveness of my
-						layout. :)
-					</h1>
+					<h1>Did I ever tell you what the definition of insanity is?</h1>
+					<button>Dial ⤴️ the Insanity 🤪</button>
 					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
+						Insanity is doing the exact... same fucking thing... 🔁 over and 🔁 over
+						again expecting... shit to change... ⏭️{' '}
+						<em>
+							That. Is. <strong>Crazy.</strong>
+						</em>{' '}
+						🤪
 					</p>
 					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
+						The first time somebody told me that, I dunno, I thought they were
+						bullshitting me, so 💥, I shot him 🔫. The thing is... He was right 🤔. And
+						then I started seeing, everywhere I looked 🔎, everywhere I looked all these
+						fucking pricks, everywhere I looked, doing the exact same fucking thing...
+						🔁 over and 🔁 over and 🔁 over and 🔁 over again thinking 'this time is
+						gonna be different' no, no, no please... This time is gonna be different,
+						I'm sorry 🙏, I don't like... The way... you are looking at me... 🧐
 					</p>
 					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
+						Okay, Do you have a fucking problem in your head 🤕, do you think I am
+						bullshitting you, do you think I am lying 🤥? Fuck you! Okay? Fuck you! 😡
 					</p>
 					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
+						It's okay, man. I'm gonna chill, hermano. I'm gonna chill 🥶... The thing
+						is... Alright, the thing is I killed you once already 🪦... and it's not
+						like I am fucking crazy 🤪. It's okay... It's like water under the bridge
+						🌉. Did I ever tell you the definition... of insanity?
 					</p>
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
-					</p>
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
-					</p>
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
-					</p>
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
-					</p>
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
-					</p>
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
-					</p>
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
-					</p>
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
-					</p>
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos unde
-						sapiente, dolor ducimus distinctio architecto alias, eaque at repellendus
-						modi totam quas sint exercitationem. Culpa ipsam esse eum distinctio odio.
-					</p>
+					
 				</article>
 			</Base>
 		</>

--- a/routes/[blog]/this.tsx
+++ b/routes/[blog]/this.tsx
@@ -42,7 +42,11 @@ export default function Home() {
 						like I am fucking crazy 🤪. It's okay... It's like water under the bridge
 						🌉. Did I ever tell you the definition... of insanity?
 					</p>
-					
+					<div class="spacer"></div>
+					<footer class="blog-footer">
+						This page exists to text the responsiveness of the layout whenever changes
+						happens.
+					</footer>
 				</article>
 			</Base>
 		</>

--- a/routes/[blog]/this.tsx
+++ b/routes/[blog]/this.tsx
@@ -4,6 +4,8 @@ import { Base } from '../../components/Base.tsx';
 import { BlogHead } from '../../heads/BlogHead.tsx';
 //? Navigation Buttons to go back to the previous page or to the next article
 import BlogNavigationButtons from '../../islands/BlogNavigationButtons.tsx';
+//? Infinitely expandable insanity section
+import InsanitySection from '../../islands/InsanitySection.tsx';
 
 export default function Home() {
 	return (
@@ -13,36 +15,13 @@ export default function Home() {
 			<Base>
 				<BlogNavigationButtons />
 				<article>
+					{/* Static Insanity Heading */}
 					<h1>Did I ever tell you what the definition of insanity is?</h1>
-					<button>Dial ⤴️ the Insanity 🤪</button>
-					<p>
-						Insanity is doing the exact... same fucking thing... 🔁 over and 🔁 over
-						again expecting... shit to change... ⏭️{' '}
-						<em>
-							That. Is. <strong>Crazy.</strong>
-						</em>{' '}
-						🤪
-					</p>
-					<p>
-						The first time somebody told me that, I dunno, I thought they were
-						bullshitting me, so 💥, I shot him 🔫. The thing is... He was right 🤔. And
-						then I started seeing, everywhere I looked 🔎, everywhere I looked all these
-						fucking pricks, everywhere I looked, doing the exact same fucking thing...
-						🔁 over and 🔁 over and 🔁 over and 🔁 over again thinking 'this time is
-						gonna be different' no, no, no please... This time is gonna be different,
-						I'm sorry 🙏, I don't like... The way... you are looking at me... 🧐
-					</p>
-					<p>
-						Okay, Do you have a fucking problem in your head 🤕, do you think I am
-						bullshitting you, do you think I am lying 🤥? Fuck you! Okay? Fuck you! 😡
-					</p>
-					<p>
-						It's okay, man. I'm gonna chill, hermano. I'm gonna chill 🥶... The thing
-						is... Alright, the thing is I killed you once already 🪦... and it's not
-						like I am fucking crazy 🤪. It's okay... It's like water under the bridge
-						🌉. Did I ever tell you the definition... of insanity?
-					</p>
+					{/* Infinitely expandable Insanity text section */}
+					<InsanitySection />
+					{/* Spacer to push the post footer text to the bottom */}
 					<div class="spacer"></div>
+					{/* Small notice about this page */}
 					<footer class="blog-footer">
 						This page exists to text the responsiveness of the layout whenever changes
 						happens.

--- a/static/base.css
+++ b/static/base.css
@@ -36,8 +36,8 @@ main {
 	--main-padding: 1rem;
 	--main-margin: 1.5rem;
 	position: absolute;
-	width: calc(100% - 2 * var(--main-margin));
-	min-height: calc(100% - 2 * var(--main-margin));
+	width: calc(100dvw - 2 * var(--main-margin));
+	min-height: calc(100dvh - 2 * var(--main-margin));
 	padding: var(--main-padding);
 	margin: var(--main-margin);
 	border: 2px solid var(--accent-color);

--- a/static/base.css
+++ b/static/base.css
@@ -68,7 +68,7 @@ input[type='checkbox'] {
 }
 
 /* Positions the footer on the bottom right side of the page, below the frame */
-footer {
+.page-footer {
 	position: absolute;
 	display: inline-flex;
 	align-items: center;

--- a/static/base.css
+++ b/static/base.css
@@ -33,11 +33,13 @@ html {
 
 /* Positioning for the main frame, border color, transition for theme switch */
 main {
+	--main-padding: 1rem;
+	--main-margin: 1.5rem;
 	position: absolute;
-	width: calc(100% - 2 * 1.5rem);
-	min-height: calc(100% - 2 * 1.5rem);
-	padding: 1rem;
-	margin: 1.5rem;
+	width: calc(100% - 2 * var(--main-margin));
+	min-height: calc(100% - 2 * var(--main-margin));
+	padding: var(--main-padding);
+	margin: var(--main-margin);
 	border: 2px solid var(--accent-color);
 	border-radius: 1.5rem;
 	transition: border 0.7s ease-in-out 0.3s;

--- a/static/blog.css
+++ b/static/blog.css
@@ -35,7 +35,13 @@ h1 {
 	margin: var(--h1-margin) 0;
 	font-family: 'Alfa Slab One', cursive;
 	font-size: 2.5rem;
+	text-align: center;
 	line-height: 1;
+}
+
+/* Justify blog post body */
+p {
+	text-align: justify;
 }
 
 /* Spacer to push the blog footer to the end of the page,

--- a/static/blog.css
+++ b/static/blog.css
@@ -19,6 +19,12 @@
 
 /* Define article as flexible centered column */
 article {
+	/* Vertical margin to the article's heading */
+	--h1-margin: 1rem;
+	/* Viewport height - (2 * base marginY) - (2 * base paddingY) - (2 * article h1 marginY) - (2 * base borderWidth) */
+	min-height: calc(
+		100vh - 2 * var(--main-margin) - 2 * var(--main-padding) - 2 * var(--h1-margin) - 4px
+	);
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -26,10 +32,23 @@ article {
 
 /* Style article's heading */
 h1 {
-	margin: 1rem 0;
+	margin: var(--h1-margin) 0;
 	font-family: 'Alfa Slab One', cursive;
 	font-size: 2.5rem;
 	line-height: 1;
+}
+
+/* Spacer to push the blog footer to the end of the page,
+    if the page doesn't have enough content to max out
+    the height by itself */
+.spacer {
+	flex-grow: 1;
+}
+
+/* Ending note at the end of a blog post */
+.blog-footer {
+	font-size: 0.75rem;
+	align-self: end;
 }
 
 /* Reduce heading font size on smaller resolutions */

--- a/static/blog.css
+++ b/static/blog.css
@@ -39,6 +39,12 @@ h1 {
 	line-height: 1;
 }
 
+/* Style section as flex colunn */
+section {
+	display: flex;
+	flex-direction: column;
+}
+
 /* Justify blog post body */
 p {
 	text-align: justify;

--- a/static/blog.css
+++ b/static/blog.css
@@ -23,7 +23,7 @@ article {
 	--h1-margin: 1rem;
 	/* Viewport height - (2 * base marginY) - (2 * base paddingY) - (2 * article h1 marginY) - (2 * base borderWidth) */
 	min-height: calc(
-		100vh - 2 * var(--main-margin) - 2 * var(--main-padding) - 2 * var(--h1-margin) - 4px
+		100dvh - 2 * var(--main-margin) - 2 * var(--main-padding) - 2 * var(--h1-margin) - 4px
 	);
 	display: flex;
 	flex-direction: column;

--- a/static/styled-button.css
+++ b/static/styled-button.css
@@ -1,0 +1,22 @@
+/* Style, space and animate default styled button */
+.styled-button {
+	display: flex;
+	align-self: center;
+	color: var(--neutral-color);
+	background-color: var(--base-color);
+	box-shadow: 0.1em 0.2em var(--accent-color);
+	border: 0.15em solid var(--neutral-color);
+	text-shadow: 0.05em 0.05em 0 var(--accent-color);
+	transition: color 0.4s, box-shadow 0.4s, border 0.4s, text-shadow 0.4s;
+	border-radius: 0.5rem;
+	padding: 0.3rem 0.6rem;
+}
+
+/* Inverse colorset when button is hovered */
+.styled-button:hover {
+	color: var(--accent-color);
+	background-color: var(--base-color);
+	box-shadow: 0.1em 0.2em var(--neutral-color);
+	border: 0.15em solid var(--accent-color);
+	text-shadow: 0.05em 0.05em 0 var(--neutral-color);
+}


### PR DESCRIPTION
Additionally, this request also does the following:
- Decouples the styling for `<footer>` tags into using its individual class.
- - That way I can use more footer tags without making the additional footers overlap the original `<footer>`. You can see that in the Insanity page.
- Created a stylized button component so it can be reused throughout the entire application. This button can take additional `style` props if necessary to add additional individual styles. This button also has no margin attached to it, so this needs to be passed individually based on context/requirements.
- Changed `<main>` element to use 100dvh instead of 100%.
- - This change aims to avoid causing mobile accesses to display an unnecessary scrollbar whenever the content fits the screen just fine.