### PR TITLE
Fix: correct theme flickering issue on page transition

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,29 +23,35 @@
 		"fresh.gen.ts"
 	],
 	"files.exclude": {
-		"**/.git": true,
-		"**/.svn": true,
-		"**/.hg": true,
-		"**/CVS": true,
-		"**/.DS_Store": true,
-		"**/Thumbs.db": true,
-		"static/android-chrome-192x192.png": true,
-		"static/android-chrome-512x512.png": true,
-		"static/apple-touch-icon.png": true,
-		"static/deno-logo.svg": true,
-		"static/favicon-16x16.png": true,
-		"static/favicon-32x32.png": true,
-		"static/favicon.ico": true,
-		"static/ts-logo-128.svg": true,
-		"static/logo.svg": true,
-		"static/fresh-logo.png": true,
-		"deno.json": true,
-		"deno.lock": true,
-		"import_map.json": true,
-		"dev.ts": true,
-		"twind.config.ts": true,
-		".vscode": true,
-		"main.ts": true,
-		"fresh.gen.ts": true
-	}
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/CVS": true,
+        "**/.DS_Store": true,
+        "**/Thumbs.db": true,
+        "static/android-chrome-192x192.png": true,
+        "static/android-chrome-512x512.png": true,
+        "static/apple-touch-icon.png": true,
+        "static/deno-logo.svg": true,
+        "static/favicon-16x16.png": true,
+        "static/favicon-32x32.png": true,
+        "static/favicon.ico": true,
+        "static/ts-logo-128.svg": true,
+        "static/logo.svg": true,
+        "static/fresh-logo.png": true,
+        "deno.json": true,
+        "deno.lock": true,
+        "import_map.json": true,
+        "dev.ts": true,
+        "twind.config.ts": true,
+        ".vscode": true,
+        "main.ts": true,
+        "fresh.gen.ts": true
+    },
+    "[css]": {
+        "editor.defaultFormatter": "vscode.css-language-features"
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "denoland.vscode-deno"
+    }
 }

--- a/components/Base.tsx
+++ b/components/Base.tsx
@@ -1,21 +1,21 @@
 //? Lateral text with theme switcher
-import { Aside } from '../components/Aside.tsx';
+import { Aside } from "../components/Aside.tsx";
 //? Footer with tech stack
-import { Footer } from '../components/Footer.tsx';
+import { Footer } from "../components/Footer.tsx";
 //? Import Preact JSX so we can define the props.children type
-import { JSX, toChildArray } from 'preact';
+import { JSX, toChildArray } from "preact";
 
 export function Base(props: { children: Array<JSX.Element> | JSX.Element }) {
-	return (
-		<body>
-			{/* Main content: name, role, company */}
-			<main>
-				{/* Theme switcher */}
-				<Aside />
-				{...toChildArray(props.children)}
-				{/* Footer with Tech Stack on bottom right corner */}
-				<Footer />
-			</main>
-		</body>
-	);
+  return (
+    <body>
+      {/* Main content: name, role, company */}
+      <main>
+        {/* Theme switcher */}
+        <Aside />
+        {...toChildArray(props.children)}
+        {/* Footer with Tech Stack on bottom right corner */}
+        <Footer />
+      </main>
+    </body>
+  );
 }

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -6,9 +6,10 @@ import config from "./deno.json" assert { type: "json" };
 import * as $0 from "./routes/[blog]/this.tsx";
 import * as $1 from "./routes/[toys]/index.tsx";
 import * as $2 from "./routes/[toys]/spinners.tsx";
-import * as $3 from "./routes/api/joke.ts";
-import * as $4 from "./routes/index.tsx";
-import * as $5 from "./routes/this.tsx";
+import * as $3 from "./routes/_app.tsx";
+import * as $4 from "./routes/api/joke.ts";
+import * as $5 from "./routes/index.tsx";
+import * as $6 from "./routes/this.tsx";
 import * as $$0 from "./islands/BlogNavigationButtons.tsx";
 import * as $$1 from "./islands/InsanitySection.tsx";
 import * as $$2 from "./islands/StyledButton.tsx";
@@ -19,9 +20,10 @@ const manifest = {
     "./routes/[blog]/this.tsx": $0,
     "./routes/[toys]/index.tsx": $1,
     "./routes/[toys]/spinners.tsx": $2,
-    "./routes/api/joke.ts": $3,
-    "./routes/index.tsx": $4,
-    "./routes/this.tsx": $5,
+    "./routes/_app.tsx": $3,
+    "./routes/api/joke.ts": $4,
+    "./routes/index.tsx": $5,
+    "./routes/this.tsx": $6,
   },
   islands: {
     "./islands/BlogNavigationButtons.tsx": $$0,

--- a/islands/ThemeSwitcher.tsx
+++ b/islands/ThemeSwitcher.tsx
@@ -1,70 +1,92 @@
 //? Import hooks so a theme can be loaded on pageLoad and
 //? set on a click to the Radio buttons
-import { useState, useEffect } from 'preact/hooks';
+import { useEffect, useRef, useState } from "preact/hooks";
 
 //? Exports the ThemeSwitcher Island, so users can switch
 //? themes, if so they desire
+//! The theme is applied on page load by the route _app.tsx
+//! Changing things here and not there might break functionality
 export default function ThemeSwitcher() {
-	//? Manages the theme state
-	const [theme, setTheme] = useState('');
+  //? Create a reference that will track if the useEffect()
+  //? should update the theme and save to localStorage. This
+  //? reference is initially true so that the useEffect() skips
+  //? setting a value for the theme on the first pass
+  const isInitialMount = useRef(true);
 
-	//? Loads current theme from localStorage, if one is saved.
-	//! Uses default 'Dark' theme if no theme is set.
-	//? Saves switched theme on change
-	useEffect(() => {
-		//? Check if the user has no current theme state and
-		//? attempts to load from localStorage to find their
-		//? saved option, in case they previously saved one
-		if (theme === '') {
-			setTheme(localStorage.getItem('theme') ?? 'Dark');
-		}
+  //? Manages the theme state
+  const [theme, setTheme] = useState(localStorage.getItem("theme") ?? "Dark");
 
-		//? Saves current theme to local storage
-		localStorage.setItem('theme', theme);
+  //? Saves switched theme on change, but not on first load
+  useEffect(() => {
+    //? Checks for initial mount to avoid changing theme twice
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
 
-		//? Access the root element, where our styles were defined
-		const cssRoot: HTMLElement | null = document.querySelector(':root');
-		if (cssRoot !== null) {
-			if (theme === 'Light') {
-				// TW Slate 300 background color
-				cssRoot.style.setProperty('--base-color', 'rgb(203 213 225)');
-				// TW Slate 900 text color
-				cssRoot.style.setProperty('--neutral-color', 'rgb(15 23 42)');
-				// TW Red 600 accent
-				cssRoot.style.setProperty('--accent-color', 'rgb(220 38 38)');
-			} else {
-				// TW Slate 900 background color
-				cssRoot.style.setProperty('--base-color', 'rgb(15 23 42)');
-				// TW Slate 300 text color
-				cssRoot.style.setProperty('--neutral-color', 'rgb(203 213 225)');
-				// TW Purple 700 accent
-				cssRoot.style.setProperty('--accent-color', 'rgb(126 34 206)');
-			}
-		}
-	}, [theme]);
+    //? Saves current theme to local storage
+    localStorage.setItem("theme", theme);
 
-	//? Array of possible themes. Here just so I can learn how
-	//? render an array of items :)
-	const themes: string[] = ['Dark', 'Light'];
+    //? Access the root element, where our styles were defined
+    const cssRoot: HTMLElement | null = document.querySelector(":root");
+    if (cssRoot !== null) {
+      // Transition effect to make the switch to Light theme on load less jarring
+      cssRoot.style.setProperty("transition", "color 0.9s ease-in-out");
+      cssRoot.style.setProperty(
+        "transition",
+        "background-color 0.8s ease-in-out",
+      );
 
-	return (
-		<>
-			{/* Returns two labels and Radio buttons for Dark and Light themes */}
-			{themes.map((themeOption) => (
-				<label for={themeOption}>
-					<input
-						class="mr-1"
-						type="radio"
-						id={themeOption}
-						name="theme"
-						checked={theme == themeOption}
-						onClick={() => {
-							setTheme(themeOption);
-						}}
-					></input>
-					{themeOption}
-				</label>
-			))}
-		</>
-	);
+      if (theme === "Light") {
+        // TW Slate 300 background color
+        cssRoot.style.setProperty("--base-color", "rgb(203 213 225)");
+        // TW Slate 900 text color
+        cssRoot.style.setProperty("--neutral-color", "rgb(15 23 42)");
+        // TW Red 600 accent
+        cssRoot.style.setProperty("--accent-color", "rgb(220 38 38)");
+      } else {
+        // TW Slate 900 background color
+        cssRoot.style.setProperty("--base-color", "rgb(15 23 42)");
+        // TW Slate 300 text color
+        cssRoot.style.setProperty("--neutral-color", "rgb(203 213 225)");
+        // TW Purple 700 accent
+        cssRoot.style.setProperty("--accent-color", "rgb(126 34 206)");
+      }
+    }
+  }, [theme]);
+
+  if (theme === "Light") {
+    return (
+      <>
+        <button onClick={() => setTheme(() => "Dark")}>
+          <div class="theme-switcher">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 16 16"
+            >
+              <path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z" />
+            </svg>
+            Light
+          </div>
+        </button>
+      </>
+    );
+  } else {
+    return (
+      <>
+        <button onClick={() => setTheme(() => "Light")}>
+          <div class="theme-switcher">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <path
+                fill="currentColor"
+                d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z"
+              />
+            </svg>
+            Dark
+          </div>
+        </button>
+      </>
+    );
+  }
 }

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -1,0 +1,57 @@
+//? HTML Head to setup the script tag that will set the theme colors
+import { Head } from "$fresh/runtime.ts";
+import { AppProps } from "$fresh/src/server/types.ts";
+
+//? This will run before every response, so the theming color always
+//? gets applied before anything else on the page.
+//! WARNING: Anything you do here will inject on EVERY. SINGLE. REQUEST!
+export default function App({ Component }: AppProps) {
+  return (
+    <html>
+      <Head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            // Gets the saved theme, if the user has one
+            const selectedTheme = localStorage.getItem('theme');
+
+            // Save on the window object if we should enable Dark Mode
+            if (selectedTheme === undefined) {
+                window.showDarkMode = window.matchMedia("(prefers-color-scheme: dark)").matches;
+            } else {
+                window.showDarkMode = selectedTheme === 'Dark';
+            }
+
+            // Grab the HTML root element, so the chosen colors can be applied to 
+            const cssRoot = document.querySelector(":root");
+
+            // Sets Dark Mode, if either that's the theme saved on localStorage or
+            // if it's the user's OS mode preference
+            if (window.showDarkMode === true) {
+                // TW Slate 900 background color
+                cssRoot.style.setProperty("--base-color", "rgb(15 23 42)");
+                // TW Slate 300 text color
+                cssRoot.style.setProperty("--neutral-color", "rgb(203 213 225)");
+                // TW Purple 700 accent
+                cssRoot.style.setProperty("--accent-color", "rgb(126 34 206)");
+            }
+            // If the User didn't save Dark Mode as their preferred theme
+            // OR they haven't set their OS preference to Dark Mode, then
+            // display the website in Light Mode (default option)
+            else {
+                // TW Slate 300 background color
+                cssRoot.style.setProperty("--base-color", "rgb(203 213 225)");
+                // TW Slate 900 text color
+                cssRoot.style.setProperty("--neutral-color", "rgb(15 23 42)");
+                // TW Red 600 accent
+                cssRoot.style.setProperty("--accent-color", "rgb(220 38 38)");
+            }
+            `,
+          }}
+        />
+      </Head>
+      {/* Loads everything else related to the route path that will be sent as response */}
+      <Component />
+    </html>
+  );
+}

--- a/static/base.css
+++ b/static/base.css
@@ -1,3 +1,5 @@
+/* Note: Color scheme variables are set on routes/_app.tsx script tag */
+
 /* Scrollbar styling */
 body::-webkit-scrollbar {
     width: 0.8em;
@@ -34,31 +36,29 @@ main {
 
 /* Position the theme switcher on the bottom left corner */
 aside {
-    /* Color for the radio buttons */
-    accent-color: var(--accent-color);
+    height: 1em;
+    width: 5em;
+    height: min-content;
     position: fixed;
-    bottom: 5.5rem;
+    bottom: 3.2em;
     rotate: -90deg;
-    translate: -70%;
-
+    translate: -78%;
     font-size: 1.25rem;
-    /* 20px */
-    line-height: 1.75rem;
-    /* 28px */
+    line-height: 1em;
 }
 
-/* Space-X-2 */
-aside>*+* {
-    margin-left: 0.5rem;
-    /* 8px */
+/* Define theme SVG size, push text away */
+aside svg {
+    height: 1em;
+    width: 1em;
+    margin-right: 0.2em;
 }
 
-/* Radio buttons, colored by accent color on :root */
-input[type='checkbox'] {
-    appearance: none;
-    margin: 0;
-    width: 1rem;
-    height: 1rem;
+/* Organize theme button horizontally and align vertically */
+.theme-switcher {
+    display: flex;
+    flex-direction: row;
+    text-justify: center;
 }
 
 /* Positions the footer on the bottom right side of the page, below the frame */

--- a/static/base.css
+++ b/static/base.css
@@ -1,91 +1,84 @@
-:root {
-	/* TW Slate 900 background color */
-	--base-color: rgb(15 23 42);
-	/* TW Slate 300 text color */
-	--neutral-color: rgb(203 213 225);
-	/* TW Purple 700 accent */
-	--accent-color: rgb(120 50 200);
-	/* Color for the radio buttons */
-	accent-color: var(--accent-color);
-	/* Transition effect to make the switch to
-        Light theme on load less jarring */
-	transition: color 0.9s ease-in-out 0.1s, background-color 0.8s ease-in-out 0.2s;
-}
-
 /* Scrollbar styling */
 body::-webkit-scrollbar {
-	width: 0.8em;
+    width: 0.8em;
 }
+
 body::-webkit-scrollbar-thumb {
-	background-color: transparent;
-	outline: 2px solid var(--accent-color);
-	outline-offset: -0.1rem;
-	border-radius: 0.3rem;
+    background-color: transparent;
+    outline: 2px solid var(--accent-color);
+    outline-offset: -0.1rem;
+    border-radius: 0.3rem;
 }
 
 /* Expand page to use full screen and set page default font and color scheme */
 html {
-	max-height: fit-content;
-	font-family: 'Fragment Mono', monospace;
-	background-color: var(--base-color);
-	color: var(--neutral-color);
+    max-height: fit-content;
+    font-family: 'Fragment Mono', monospace;
+    background-color: var(--base-color);
+    color: var(--neutral-color);
 }
 
 /* Positioning for the main frame, border color, transition for theme switch */
 main {
-	--main-padding: 1rem;
-	--main-margin: 1.5rem;
-	position: absolute;
-	width: calc(100dvw - 2 * var(--main-margin));
-	min-height: calc(100dvh - 2 * var(--main-margin));
-	padding: var(--main-padding);
-	margin: var(--main-margin);
-	border: 2px solid var(--accent-color);
-	border-radius: 1.5rem;
-	transition: border 0.7s ease-in-out 0.3s;
+    --main-padding: 1rem;
+    --main-margin: 1.5rem;
+    position: absolute;
+    width: calc(100dvw - 2 * var(--main-margin));
+    min-height: calc(100dvh - 2 * var(--main-margin));
+    padding: var(--main-padding);
+    margin: var(--main-margin);
+    border: 2px solid var(--accent-color);
+    border-radius: 1.5rem;
+    transition: border 0.7s ease-in-out 0.3s;
 }
 
 /* Position the theme switcher on the bottom left corner */
 aside {
-	position: fixed;
-	bottom: 5.5rem;
-	rotate: -90deg;
-	translate: -70%;
+    /* Color for the radio buttons */
+    accent-color: var(--accent-color);
+    position: fixed;
+    bottom: 5.5rem;
+    rotate: -90deg;
+    translate: -70%;
 
-	font-size: 1.25rem; /* 20px */
-	line-height: 1.75rem; /* 28px */
+    font-size: 1.25rem;
+    /* 20px */
+    line-height: 1.75rem;
+    /* 28px */
 }
 
 /* Space-X-2 */
-aside > * + * {
-	margin-left: 0.5rem; /* 8px */
+aside>*+* {
+    margin-left: 0.5rem;
+    /* 8px */
 }
 
 /* Radio buttons, colored by accent color on :root */
 input[type='checkbox'] {
-	appearance: none;
-	margin: 0;
-	width: 1rem;
-	height: 1rem;
+    appearance: none;
+    margin: 0;
+    width: 1rem;
+    height: 1rem;
 }
 
 /* Positions the footer on the bottom right side of the page, below the frame */
 .page-footer {
-	position: absolute;
-	display: inline-flex;
-	align-items: center;
-	width: max-content;
-	bottom: -1.5rem;
-	right: 0;
-	font-size: 0.875rem; /* 14px */
-	line-height: 1.25rem;
-	white-space: nowrap;
+    position: absolute;
+    display: inline-flex;
+    align-items: center;
+    width: max-content;
+    bottom: -1.5rem;
+    right: 0;
+    font-size: 0.875rem;
+    /* 14px */
+    line-height: 1.25rem;
+    white-space: nowrap;
 }
 
 /* Style the images on the footer */
 footer img {
-	margin-left: 0.4rem;
-	margin-right: 0.4rem;
-	height: 18px;
-	width: 18px;
+    margin-left: 0.4rem;
+    margin-right: 0.4rem;
+    height: 18px;
+    width: 18px;
 }


### PR DESCRIPTION
Fixed the problem that caused the page to flicker for a moment when changing pages.

Because of the Islands architecture of Fresh, the javascript is only loaded after the rest of the application finished loading, which was causing the initial theme to load and then flicker to the new theme once the javascript file executes.

In [fix: stop theme flickering on page switch](https://github.com/TheYuriG/deno-portfolio/commit/43cddc9239b03a2ab70afb89e9a4869284ce2218), a script tag is injected on the head of every response, causing the appropriate color variables to be set before the body finishes loading, removing the flickering effect entirely.

This is probably worth blogging about, so I'll get around to creating a post about it in the future and credit the user on [this comment](https://github.com/denoland/fresh/issues/907#issuecomment-1330745592) about his method to fix this (which I've adapted here).

Closes #15.