### PR TITLE
feat: add /blog and /blog/:id

### DIFF
--- a/blog_posts/all-blog-posts.ts
+++ b/blog_posts/all-blog-posts.ts
@@ -1,0 +1,45 @@
+//? Import the types so that it doesn't need to be interfaced twice
+import BlogPostSummaryProperties from "../types/BlogPostSummaryProperties.ts";
+
+//? Mock array of posts
+// todo 1 Read .md files from disk and create this array dynamically
+// todo 2 Implement pagination
+const createdPosts: Array<BlogPostSummaryProperties> = [{
+    link: "/post-1",
+    title: "No Code/Low Code Vs. Traditional Development",
+    shortSummary:
+        "Do you want to know which is better - No Code/Low Code or Traditional Development? Are you looking for the advantages and disadvantages of each? Do you need to know how...",
+    date: 1684897287564,
+}, {
+    link: "/post-2",
+    title: "How to delete all your local branches but keep master",
+    shortSummary:
+        "I find myself searching for this git one-liner a lot, so I figured I'd drop it here to help future searchers...",
+    date: 1684983612487,
+}, {
+    link: "/post-3",
+    title: "How to convert an array into an object in javascript",
+    shortSummary:
+        "To convert an array into an object we will create a function and give it 2 properties, an array and a key...",
+    date: 1698375696587,
+}, {
+    link: "/post-4",
+    title: "Ridiculously easy row and column layouts with Flexbox",
+    shortSummary:
+        "Grid layouts are the bread and butter of web development design and chances are you've reached for something like Bootstrap or Foundation to make your layouts a reality...",
+    date: 17016588085775,
+}, {
+    link: "/post-5",
+    title: "Flutter and Firebase Integration",
+    shortSummary:
+        "Flutter and Firebase, both Google Products make it seamless and powerful if used together. The best part about Firebase is you can use it for all mobile platforms, Android, iOS, and even Fuchsia. You can also use it for Web Development written in any language...",
+    date: 1701918068547,
+}, {
+    link: "/post-6",
+    title: "Top 50 CSS Buttons (+ animations)",
+    shortSummary:
+        "Buttons are not only good for usability, but also an extremely important design element for your website. For this reason, here is a collection of the best CSS...",
+    date: 1703127645875,
+}];
+
+export default createdPosts

--- a/components/BlogPostSummary.tsx
+++ b/components/BlogPostSummary.tsx
@@ -1,0 +1,20 @@
+//? Require the interface to ensure we receive the proper data
+import BlogPostSummaryProperties from "../types/BlogPostSummaryProperties.ts";
+
+//? Exports a single Blog Post Summary
+export function BlogPostSummary(summary: BlogPostSummaryProperties) {
+  return (
+    // What a Post Summary looks like
+    <article class="blog-post" style="margin: 1em 0">
+      {/* Post link */}
+      <a href={"/blog" + summary.link}>
+        {/* Centered heading */}
+        <h2 class="navigation-link blog-title">{summary.title}</h2>
+      </a>
+      {/* Post creation date */}
+      <p class="post-date">{new Date(summary.date).toLocaleString()}</p>
+      {/* Post summary */}
+      <p class="justified">{summary.shortSummary}</p>
+    </article>
+  );
+}

--- a/components/CustomHead.tsx
+++ b/components/CustomHead.tsx
@@ -32,7 +32,7 @@ export function CustomHead(options: HeadOptions) {
           property="og:url"
           content={options.link ?? "https://www.theyurig.com/blog"}
         />
-        <script src="themeSwitcherMinified.js"></script>
+        <script src="/themeSwitcherMinified.js"></script>
         <link
           href="https://fonts.googleapis.com/css2?family=Fragment+Mono&family=Kanit:wght@400;700&display=swap"
           rel="stylesheet"

--- a/deno.lock
+++ b/deno.lock
@@ -145,6 +145,9 @@
     "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/8031f71afa1bbcd3237a94b11f53a2e5c5c0e7bf/src/deno.ts": "71bee6b14e72ca193c0686d8b4f1f47d639a64745b6f5c7576f7a3616f436f57",
     "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/8031f71afa1bbcd3237a94b11f53a2e5c5c0e7bf/src/native_loader.ts": "2a0f5a7b68a57c4651ad48161b32532356b434597a6cf282683427482b38f6fa",
     "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/8031f71afa1bbcd3237a94b11f53a2e5c5c0e7bf/src/portable_loader.ts": "47adb6d9a00f13a87d0a15f2af79118eb93503234008c31392d71270bc0a42fa",
-    "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/8031f71afa1bbcd3237a94b11f53a2e5c5c0e7bf/src/shared.ts": "007e8d575cb6ebcac4110f1f72188a8bec3aa29287b4ad26e98403c00bebf036"
+    "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/8031f71afa1bbcd3237a94b11f53a2e5c5c0e7bf/src/shared.ts": "007e8d575cb6ebcac4110f1f72188a8bec3aa29287b4ad26e98403c00bebf036",
+    "https://unpkg.com/@speed-highlight/core@1.1.11/dist/index.js": "3f06bcb851f0ad78de4ab1886611d1253a57d875c287a93ae92efa80c5e7593b",
+    "https://unpkg.com/@speed-highlight/core@1.1.11/dist/languages/js.js": "7876640e51ac364ccc44ed578a7ad0c7d8e430524a27307d91c960a0adf7836e",
+    "https://unpkg.com/@speed-highlight/core@1.1.11/dist/terminal.js": "7077ecb9f3f0e6f8d0b341dd106dee521c82a9d0bdabacf86cd4fb3b25388b98"
   }
 }

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -3,36 +3,38 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import config from "./deno.json" assert { type: "json" };
-import * as $0 from "./routes/[toys]/insanity.tsx";
-import * as $1 from "./routes/[toys]/spinners.tsx";
-import * as $2 from "./routes/api/joke.ts";
-import * as $3 from "./routes/blog.tsx";
-import * as $4 from "./routes/index.tsx";
-import * as $5 from "./routes/toys.tsx";
-import * as $6 from "./routes/what-is-this.tsx";
+import * as $0 from "./routes/[blog]/[post].tsx";
+import * as $1 from "./routes/[toys]/insanity.tsx";
+import * as $2 from "./routes/[toys]/spinners.tsx";
+import * as $3 from "./routes/api/joke.ts";
+import * as $4 from "./routes/blog.tsx";
+import * as $5 from "./routes/index.tsx";
+import * as $6 from "./routes/toys.tsx";
+import * as $7 from "./routes/what-is-this.tsx";
 import * as $$0 from "./islands/BlogNavigationButtons.tsx";
 import * as $$1 from "./islands/InsanitySection.tsx";
 import * as $$2 from "./islands/StyledButton.tsx";
 import * as $$3 from "./islands/ThemeSwitcher.tsx";
 
 const manifest = {
-    routes: {
-        "./routes/[toys]/insanity.tsx": $0,
-        "./routes/[toys]/spinners.tsx": $1,
-        "./routes/api/joke.ts": $2,
-        "./routes/blog.tsx": $3,
-        "./routes/index.tsx": $4,
-        "./routes/toys.tsx": $5,
-        "./routes/what-is-this.tsx": $6,
-    },
-    islands: {
-        "./islands/BlogNavigationButtons.tsx": $$0,
-        "./islands/InsanitySection.tsx": $$1,
-        "./islands/StyledButton.tsx": $$2,
-        "./islands/ThemeSwitcher.tsx": $$3,
-    },
-    baseUrl: import.meta.url,
-    config,
+  routes: {
+    "./routes/[blog]/[post].tsx": $0,
+    "./routes/[toys]/insanity.tsx": $1,
+    "./routes/[toys]/spinners.tsx": $2,
+    "./routes/api/joke.ts": $3,
+    "./routes/blog.tsx": $4,
+    "./routes/index.tsx": $5,
+    "./routes/toys.tsx": $6,
+    "./routes/what-is-this.tsx": $7,
+  },
+  islands: {
+    "./islands/BlogNavigationButtons.tsx": $$0,
+    "./islands/InsanitySection.tsx": $$1,
+    "./islands/StyledButton.tsx": $$2,
+    "./islands/ThemeSwitcher.tsx": $$3,
+  },
+  baseUrl: import.meta.url,
+  config,
 };
 
 export default manifest;

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -3,34 +3,36 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import config from "./deno.json" assert { type: "json" };
-import * as $0 from "./routes/[toys]/index.tsx";
-import * as $1 from "./routes/[toys]/insanity.tsx";
-import * as $2 from "./routes/[toys]/spinners.tsx";
-import * as $3 from "./routes/api/joke.ts";
+import * as $0 from "./routes/[toys]/insanity.tsx";
+import * as $1 from "./routes/[toys]/spinners.tsx";
+import * as $2 from "./routes/api/joke.ts";
+import * as $3 from "./routes/blog.tsx";
 import * as $4 from "./routes/index.tsx";
-import * as $5 from "./routes/what-is-this.tsx";
+import * as $5 from "./routes/toys.tsx";
+import * as $6 from "./routes/what-is-this.tsx";
 import * as $$0 from "./islands/BlogNavigationButtons.tsx";
 import * as $$1 from "./islands/InsanitySection.tsx";
 import * as $$2 from "./islands/StyledButton.tsx";
 import * as $$3 from "./islands/ThemeSwitcher.tsx";
 
 const manifest = {
-  routes: {
-    "./routes/[toys]/index.tsx": $0,
-    "./routes/[toys]/insanity.tsx": $1,
-    "./routes/[toys]/spinners.tsx": $2,
-    "./routes/api/joke.ts": $3,
-    "./routes/index.tsx": $4,
-    "./routes/what-is-this.tsx": $5,
-  },
-  islands: {
-    "./islands/BlogNavigationButtons.tsx": $$0,
-    "./islands/InsanitySection.tsx": $$1,
-    "./islands/StyledButton.tsx": $$2,
-    "./islands/ThemeSwitcher.tsx": $$3,
-  },
-  baseUrl: import.meta.url,
-  config,
+    routes: {
+        "./routes/[toys]/insanity.tsx": $0,
+        "./routes/[toys]/spinners.tsx": $1,
+        "./routes/api/joke.ts": $2,
+        "./routes/blog.tsx": $3,
+        "./routes/index.tsx": $4,
+        "./routes/toys.tsx": $5,
+        "./routes/what-is-this.tsx": $6,
+    },
+    islands: {
+        "./islands/BlogNavigationButtons.tsx": $$0,
+        "./islands/InsanitySection.tsx": $$1,
+        "./islands/StyledButton.tsx": $$2,
+        "./islands/ThemeSwitcher.tsx": $$3,
+    },
+    baseUrl: import.meta.url,
+    config,
 };
 
 export default manifest;

--- a/routes/[blog]/[post].tsx
+++ b/routes/[blog]/[post].tsx
@@ -1,0 +1,167 @@
+//? Head component with all Meta tags pre-set
+import { CustomHead } from "../../components/CustomHead.tsx";
+//? Lateral text with theme switcher
+import { Base } from "../../components/Base.tsx";
+//? Navigation Buttons to go back to the previous page or to the next page (optional)
+import BlogNavigationButtons from "../../islands/BlogNavigationButtons.tsx";
+
+import { PageProps } from "$fresh/server.ts";
+import { JSX } from "preact";
+
+//? Possible options of content
+enum contentPieceType {
+  Text = "text",
+  //todo add Mixed type for Text+InlineCode
+  Image = "image",
+  LargeImage = "largeImage",
+  CodeBlock = "codeBlock",
+  InlineBlock = "inlineCode",
+}
+//? How content pieces are created
+type ContentPìece = [contentPieceType, string];
+//! First one could be an Enum, since it's always going
+//! to be one of very few specific select types
+
+//? All the data a post is required to have
+interface CompletePost {
+  title: string;
+  content: ContentPìece[];
+  date: number;
+  author: string;
+}
+
+//? Exports a single Blog Post Summary
+export default function CompleteBlogPost(props: PageProps) {
+  const { post } = props.params;
+
+  //! Fetch post
+
+  //? Mock post data
+  const currentPost: CompletePost = {
+    title: post,
+    content: [[
+      contentPieceType.Text,
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsum, beatae autem consequatur fugiat enim nam, deserunt voluptate eaque, rerum magni at tenetur dolorem? Porro nihil sapiente aut fugiat omnis quia?",
+    ], [
+      contentPieceType.LargeImage,
+      "https://res.cloudinary.com/practicaldev/image/fetch/s--8eb2ZxJZ--/c_imagga_scale,f_auto,fl_progressive,h_420,q_auto,w_1000/https://dev-to-uploads.s3.amazonaws.com/uploads/articles/am7bndcbz2iel9sjw7oc.png",
+    ], [
+      contentPieceType.Image,
+      "https://fresh.deno.dev/logo.svg?__frsh_c=414f858427046bd41a702d524fadc4215ab7180f",
+    ], [
+      contentPieceType.Text,
+      "Inline code:",
+    ], [
+      contentPieceType.InlineBlock,
+      "const num = 20",
+    ], [
+      contentPieceType.Text,
+      "Block code:",
+    ], [
+      contentPieceType.CodeBlock,
+      "const aaa = null\nconst bbb = undefined",
+    ]],
+    date: Date.now(),
+    author: "TheYuriG",
+  };
+
+  return (
+    <>
+      <CustomHead
+        title="Blog"
+        description="Blog posts and articles about my experience with certain tech stacks or situations I had to untangle myself out of."
+        link="https://www.theyurig.com/blog"
+      >
+        <link rel="stylesheet" href="/home.css" />
+        <link rel="stylesheet" href="/navigation-buttons.css" />
+        <link rel="stylesheet" href="/content.css" />
+        <link rel="stylesheet" href="/blog.css" />
+        <link rel="stylesheet" href="/syntax-highlighting.css" />
+        {
+          /* Syntax highlight for code. How can we do this better
+            so we don't cause Cumulative Layout Shift?
+            There must be a better way... */
+        }
+        <script
+          type="module"
+          dangerouslySetInnerHTML={{
+            __html:
+              `import { highlightAll } from 'https://unpkg.com/@speed-highlight/core/dist/index.js';
+            highlightAll();`,
+          }}
+        />
+      </CustomHead>
+      {/* Base page layout with theme switching and footer outside of accent box */}
+      <Base>
+        {/* Back button */}
+        <BlogNavigationButtons />
+        {/* Complete Post */}
+        <article class="center">
+          {/* Centered heading */}
+          <h2 class="navigation-link blog-title">{currentPost.title}</h2>
+          {/* Post creation date */}
+          <p class="post-date">{new Date(currentPost.date).toLocaleString()}</p>
+          {/* Post content, parsed and spread */}
+          <div class="justified">{...contentParser(currentPost.content)}</div>
+          {/* Post author */}
+          <footer class="blog-footer" style="margin-top: auto;">
+            {currentPost.author}
+          </footer>
+        </article>
+      </Base>
+    </>
+  );
+}
+
+//? Parses content to be used as Post Content
+function contentParser(content: ContentPìece[]): JSX.Element[] {
+  //? Initializes the Array that will hold all the JSX elements to be rendered
+  const parsedContent: JSX.Element[] = [];
+
+  //? Loop through all the content, push appropriate elements to parsedContent[]
+  for (let pieceIndex = 0; pieceIndex < content.length; pieceIndex++) {
+    //? Destructure the content for legibility
+    const [contentType, contentValue] = content[pieceIndex];
+
+    //? Use a switch-case to process the blog content for better performance
+    switch (contentType) {
+      case contentPieceType.Text:
+        parsedContent.push(<p>{contentValue}</p>);
+        break;
+      case contentPieceType.Image:
+        parsedContent.push(
+          <img
+            src={contentValue}
+            class="small-image"
+          />,
+        );
+        break;
+      case contentPieceType.LargeImage:
+        parsedContent.push(
+          <img src={contentValue} class="large-image" />,
+        );
+        break;
+      case contentPieceType.InlineBlock:
+        parsedContent.push(
+          <code class="shj-lang-js">
+            {contentValue}
+          </code>,
+        );
+        break;
+      case contentPieceType.CodeBlock:
+        parsedContent.push(
+          <div class="shj-lang-js">
+            {contentValue}
+          </div>,
+        );
+        break;
+      default: {
+        const thisShouldNeverRun: never = contentType;
+        throw new Error(thisShouldNeverRun);
+      }
+    }
+  }
+
+  //? Return the array of JSX elements to be rendered
+  return parsedContent;
+}

--- a/routes/blog.tsx
+++ b/routes/blog.tsx
@@ -1,11 +1,11 @@
-//? Lateral text with theme switcher
-import { Base } from "../components/Base.tsx";
-//? Import the template for Blog Post summaries
-import { BlogPostSummary } from "../components/BlogPostSummary.tsx";
 //? Head component with all Meta tags pre-set
 import { CustomHead } from "../components/CustomHead.tsx";
+//? Lateral text with theme switcher
+import { Base } from "../components/Base.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import BlogNavigationButtons from "../islands/BlogNavigationButtons.tsx";
+//? Import the template for Blog Post summaries
+import { BlogPostSummary } from "../components/BlogPostSummary.tsx";
 //? All posts so far
 import createdPosts from "../blog_posts/all-blog-posts.ts";
 

--- a/routes/blog.tsx
+++ b/routes/blog.tsx
@@ -1,0 +1,23 @@
+//? Lateral text with theme switcher
+import { Base } from "../components/Base.tsx";
+//? Head component with all Meta tags pre-set
+import { CustomHead } from "../components/CustomHead.tsx";
+
+export default function Home() {
+  return (
+    <>
+      <CustomHead
+        title="Blog"
+        description="Blog posts and articles about my experience with certain tech stacks or situations I had to untangle myself out of."
+        link="https://www.theyurig.com/blog"
+      >
+        <link rel="stylesheet" href="home.css" />
+        <link rel="stylesheet" href="/starry-night.css" />
+        <link rel="stylesheet" href="/gradient-underline.css" />
+      </CustomHead>
+      {/* Base page layout with theme switching and footer outside of accent box */}
+      <Base>
+      </Base>
+    </>
+  );
+}

--- a/routes/blog.tsx
+++ b/routes/blog.tsx
@@ -1,7 +1,13 @@
 //? Lateral text with theme switcher
 import { Base } from "../components/Base.tsx";
+//? Import the template for Blog Post summaries
+import { BlogPostSummary } from "../components/BlogPostSummary.tsx";
 //? Head component with all Meta tags pre-set
 import { CustomHead } from "../components/CustomHead.tsx";
+//? Navigation Buttons to go back to the previous page or to the next page (optional)
+import BlogNavigationButtons from "../islands/BlogNavigationButtons.tsx";
+//? All posts so far
+import createdPosts from "../blog_posts/all-blog-posts.ts";
 
 export default function Home() {
   return (
@@ -12,11 +18,23 @@ export default function Home() {
         link="https://www.theyurig.com/blog"
       >
         <link rel="stylesheet" href="home.css" />
-        <link rel="stylesheet" href="/starry-night.css" />
-        <link rel="stylesheet" href="/gradient-underline.css" />
+        <link rel="stylesheet" href="navigation-buttons.css" />
+        <link rel="stylesheet" href="content.css" />
+        <link rel="stylesheet" href="blog.css" />
       </CustomHead>
       {/* Base page layout with theme switching and footer outside of accent box */}
       <Base>
+        {/* Back button */}
+        <BlogNavigationButtons />
+        <section class="center">
+          {...createdPosts.map((post) => (
+            <BlogPostSummary {...post}></BlogPostSummary>
+          ))}
+          <footer class="blog-footer">
+            Disclaimer: I haven't created any of these posts myself, just using
+            them as mock data to test the layout.
+          </footer>
+        </section>
       </Base>
     </>
   );

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -13,8 +13,8 @@ export default function Home() {
   return (
     <>
       <CustomHead
-        title="TheYuriG - Node/Deno Developer"
-        description="Showcasing Yuri's experience, thoughts and projects created."
+        title="Full Stack Development"
+        description="Get to know more about Yuri's experience, thoughts and past projects."
         link="https://www.theyurig.com/"
       >
         <link rel="stylesheet" href="home.css" />

--- a/routes/toys.tsx
+++ b/routes/toys.tsx
@@ -1,12 +1,12 @@
 //? Create blog content inside Base component
-import { Base } from "../../components/Base.tsx";
+import { Base } from "../components/Base.tsx";
 //? Import a Card component that automatically creates
 //? redirection link, card title and centers card child
-import { CarouselCard } from "../../components/CarouselCard.tsx";
+import { CarouselCard } from "../components/CarouselCard.tsx";
 //? Import CustomHead with appropriate metadata
-import { CustomHead } from "../../components/CustomHead.tsx";
+import { CustomHead } from "../components/CustomHead.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
-import BlogNavigationButtons from "../../islands/BlogNavigationButtons.tsx";
+import BlogNavigationButtons from "../islands/BlogNavigationButtons.tsx";
 
 export default function Home() {
   return (

--- a/routes/toys.tsx
+++ b/routes/toys.tsx
@@ -16,15 +16,15 @@ export default function Home() {
         description="Various experimentations over things I've seen online."
         link="https://www.theyurig.com/toys"
       >
-        <link rel="stylesheet" href="/content.css" />
-        <link rel="stylesheet" href="/navigation-buttons.css" />
-        <link rel="stylesheet" href="/toys.css" />
-        <link rel="stylesheet" href="/carousel-card.css" />
+        <link rel="stylesheet" href="content.css" />
+        <link rel="stylesheet" href="navigation-buttons.css" />
+        <link rel="stylesheet" href="toys.css" />
+        <link rel="stylesheet" href="carousel-card.css" />
       </CustomHead>
       {/* Base page layout with theme switching and footer outside of accent box */}
       <Base>
         <BlogNavigationButtons />
-        <article>
+        <article class="center">
           <h1>Toys</h1>
           <details style="width: 100%;">
             <p style="margin-bottom: 1em;">

--- a/routes/what-is-this.tsx
+++ b/routes/what-is-this.tsx
@@ -21,7 +21,7 @@ export default function Home() {
       {/* Base page layout with theme switching and footer outside of accent box */}
       <Base>
         <BlogNavigationButtons />
-        <article>
+        <article class="center">
           <h1>What is this?</h1>
           <p>
             <span class="inline-code">this</span>{" "}

--- a/static/blog.css
+++ b/static/blog.css
@@ -1,0 +1,11 @@
+/* Size the Blog Titles */
+.blog-title {
+    font-size: 2.5rem;
+    font-family: 'Alfa Slab One', cursive;
+}
+
+/* Decrease size for post creation timestamps and add bottom margin */
+.post-date {
+    font-size: 0.8rem;
+    margin-bottom: 0.5em;
+}

--- a/static/blog.css
+++ b/static/blog.css
@@ -9,3 +9,17 @@
     font-size: 0.8rem;
     margin-bottom: 0.5em;
 }
+
+/* Size blog's small images to a square */
+.small-image {
+    margin: 1em auto;
+    height: 10em;
+    width: 10em;
+    object-fit: cover;
+}
+
+/* Size blog's large images to span the entire screen */
+.large-image {
+    margin: 1em auto;
+    object-fit: cover;
+}

--- a/static/content.css
+++ b/static/content.css
@@ -1,60 +1,58 @@
 /* Define article as flexible centered column */
-article {
-	/* Vertical margin to the article's heading */
-	--h1-margin: 1rem;
-	/* Viewport height - (2 * base marginY) - (2 * base paddingY) - (2 * article h1 marginY) - (2 * base borderWidth) */
-	min-height: calc(
-		100dvh - 2 * var(--main-margin) - 2 * var(--main-padding) - 2 * var(--h1-margin) - 4px
-	);
-	display: flex;
-	flex-direction: column;
-	align-items: center;
+.center {
+    /* Vertical margin to the article's heading */
+    --h1-margin: 1rem;
+    /* Viewport height - (2 * base marginY) - (2 * base paddingY) - (2 * article h1 marginY) - (2 * base borderWidth) */
+    min-height: calc(100dvh - 2 * var(--main-margin) - 2 * var(--main-padding) - 2 * var(--h1-margin) - 4px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 /* Style article's heading */
 h1 {
-	margin: var(--h1-margin) 0;
-	font-family: 'Alfa Slab One', cursive;
-	font-size: 2.5rem;
-	text-align: center;
-	line-height: 1;
+    margin: var(--h1-margin) 0;
+    font-family: 'Alfa Slab One', cursive;
+    font-size: 2.5rem;
+    text-align: center;
+    line-height: 1;
 }
 
 /* Style section as flex colunn */
 section {
-	display: flex;
-	flex-direction: column;
+    display: flex;
+    flex-direction: column;
 }
 
 /* Justify blog post body */
 p {
-	text-align: justify;
+    text-align: justify;
 }
 
 /* Spacer to push the blog footer to the end of the page,
     if the page doesn't have enough content to max out
     the height by itself */
 .spacer {
-	flex-grow: 1;
+    flex-grow: 1;
 }
 
 /* Ending note at the end of a blog post */
 .blog-footer {
-	font-size: 0.75rem;
-	align-self: end;
+    font-size: 0.75rem;
+    align-self: end;
 }
 
 /* Reduce heading font size on smaller resolutions */
 @media (max-width: 600px) {
-	h1 {
-		font-size: 1.5rem;
-	}
+    h1 {
+        font-size: 1.5rem;
+    }
 }
 
 /* Article doesn't expand horizontally forever on larger resolutions */
 @media (min-width: 1024px) {
-	article {
-		width: 900px;
-		margin: 0 auto;
-	}
+    article {
+        width: 900px;
+        margin: 0 auto;
+    }
 }

--- a/static/syntax-highlighting.css
+++ b/static/syntax-highlighting.css
@@ -1,0 +1,129 @@
+/* I'm not even going to try to comment the styles in this
+    file since I didn't write any of them. This is imported
+    for code-highlighting from speed-highlight.js
+    Docs are outdated, but it's the least of our concerns:
+    https://deno.land/x/speed_highlight_js@1.1.11 */
+
+[class*=shj-lang-] {
+    white-space: pre;
+    margin: 10px 0;
+    border-radius: 10px;
+    padding: 30px 20px;
+    background: white;
+    color: #112;
+    box-shadow: 0 0 5px #0001;
+    text-shadow: none;
+    font: 18px Consolas, Courier New, Monaco, Andale Mono, Ubuntu Mono, monospace;
+    line-height: 24px;
+    box-sizing: border-box;
+    max-width: min(100%, 100vw)
+}
+
+.shj-inline {
+    margin: 0;
+    padding: 2px 5px;
+    display: inline-block;
+    border-radius: 5px
+}
+
+[class*=shj-lang-]::selection,
+[class*=shj-lang-] ::selection {
+    background: #bdf5
+}
+
+[class*=shj-lang-]>div {
+    display: flex;
+    overflow: auto
+}
+
+[class*=shj-lang-]>div :last-child {
+    flex: 1;
+    outline: none
+}
+
+.shj-numbers {
+    padding-left: 5px;
+    counter-reset: line
+}
+
+.shj-numbers div {
+    padding-right: 5px
+}
+
+.shj-numbers div:before {
+    color: #999;
+    display: block;
+    content: counter(line);
+    opacity: .5;
+    text-align: right;
+    margin-right: 5px;
+    counter-increment: line
+}
+
+.shj-syn-cmnt {
+    font-style: italic
+}
+
+.shj-syn-err,
+.shj-syn-kwd {
+    color: #e16
+}
+
+.shj-syn-num,
+.shj-syn-class {
+    color: #f60
+}
+
+.shj-numbers,
+.shj-syn-cmnt {
+    color: #999
+}
+
+.shj-syn-insert,
+.shj-syn-str {
+    color: #7d8
+}
+
+.shj-syn-bool {
+    color: #3bf
+}
+
+.shj-syn-type,
+.shj-syn-oper {
+    color: #5af
+}
+
+.shj-syn-section,
+.shj-syn-func {
+    color: #84f
+}
+
+.shj-syn-deleted,
+.shj-syn-var {
+    color: #f44
+}
+
+.shj-oneline {
+    padding: 12px 10px
+}
+
+.shj-lang-http.shj-oneline .shj-syn-kwd {
+    background: #25f;
+    color: #fff;
+    padding: 5px 7px;
+    border-radius: 5px
+}
+
+.shj-multiline.shj-mode-header {
+    padding: 20px
+}
+
+.shj-multiline.shj-mode-header:before {
+    content: attr(data-lang);
+    color: #58f;
+    display: block;
+    padding: 10px 20px;
+    background: #58f3;
+    border-radius: 5px;
+    margin-bottom: 20px
+}

--- a/types/BlogPostSummaryProperties.ts
+++ b/types/BlogPostSummaryProperties.ts
@@ -1,0 +1,15 @@
+//? Define what obligatory data a post must have
+interface BlogPostSummaryProperties {
+    //? A post summary must link to the entire post. The link is built from the file name
+    link: string;
+    //? Title of the full post
+    title: string;
+    //? Brief summary of the full post, overflow=ellipsis
+    shortSummary: string;
+    //? Date of when the post was created
+    date: number;
+}
+
+//? Export these summary details so they can be used in 
+//? components/BlogPost.tsx and routes/blog.tsx
+export default BlogPostSummaryProperties


### PR DESCRIPTION
Adds both a page to browse through all blog posts and the individual blog page.
Both of them are populated with placeholder text/mock data for now.

Additionally:
- Redid the routing, it will now give a broken link for pages that don't exist (intended behavior).
- Fixed broken imports for nested routes (previously only `/toys/:id`, also was just breaking `/blog/:id`. both fixed now)

Closes #12.