### PR TITLE
fix: recreate Post without dynamic imports

### DIFF
--- a/blog_posts/all-blog-posts.ts
+++ b/blog_posts/all-blog-posts.ts
@@ -2,14 +2,13 @@
 import BlogPostSummaryProperties from "../types/BlogPostSummaryProperties.ts";
 
 //? Mock array of posts
-// todo 1 Read .md files from disk and create this array dynamically
-// todo 2 Implement pagination
+// todo Implement pagination
 const createdPosts: Array<BlogPostSummaryProperties> = [{
-    link: "/how-create-theme-switcher-deno-fresh",
-    title: "How to Create a Theme Switcher with Fresh",
-    shortSummary:
-        "A guide on how to create your own Theme Switcher using Deno and Fresh",
-    date: 1684849328672,
+  link: "/how-create-theme-switcher-deno-fresh",
+  title: "How to Create a Theme Switcher with Fresh",
+  shortSummary:
+    "A guide on how to create your own Theme Switcher using Deno and Fresh",
+  date: 1684849328672,
 }];
 
 export default createdPosts;

--- a/blog_posts/how-create-theme-switcher-deno-fresh.ts
+++ b/blog_posts/how-create-theme-switcher-deno-fresh.ts
@@ -1,162 +1,165 @@
-//? Import CompletePost type
-import { CompletePost, contentPieceType } from "../types/Post.ts";
+// Unused because Deno Deploy doesn't support dynamically
+// importing this file from /services/fetchPosts.ts
 
-export const post: CompletePost = {
-    title: "How to Create a Theme Switcher with Fresh",
-    description:
-        "A guide on how to create your own Theme Switcher using Deno and Fresh",
-    link: "/how-create-theme-switcher-deno-fresh",
-    content: [
-        [
-            contentPieceType.LargeImage,
-            "https://web-dev.imgix.net/image/vS06HQ1YTsbMKSFTIPl2iogUQP73/skKcjSv1gMQRYk1AdEp7.png?auto=format&w=1600",
-        ],
-        [
-            contentPieceType.Text,
-            "Being able to customize your Theme is a huge user experience upgrade to any website. While some websites use a default Dark Theme, the majority of the internet still sticks to creating content in Light Mode as default (and sometimes the only option).",
-        ],
-        [
-            contentPieceType.Text,
-            "However, if you have tried to do this on your own before, you might have ran into a problem... or many. In this blog post, I'll explain how I've managed to create my theme, what pitfalls I've faced and how I've circumvented them.",
-        ], // 'heading', 'What is Fresh?'
-        [
-            contentPieceType.Image,
-            "https://fresh.deno.dev/logo.svg?__frsh_c=3171c5e64510907f14fca32f4e0ba9a86bc5247c",
-        ],
-        [
-            contentPieceType.Text,
-            "Let's start from the top: what is Fresh? Fresh is the official framework to create web apps using the Deno javascript runtime. It features no build-time, zero config, typescript support out-of-the-box, JIT-rendering and uses the Island design architecture (more about this in a minute). The premise here is very simple: Single Page Applications rely really heavily on the Client's devices to build the webpages and that will impact your performance. Fresh, just like Remix (and to some extent Next), aims to move all the rendering back to the server and serves exclusively static HTML pages, hydrating any potential Javascript interactivity only when absolutely necessary. While that's amazing for Lighthouse performance, it comes with its own sets of drawbacks.",
-        ],
-        [
-            contentPieceType.Text,
-            "Fresh uses Preact under the hood to compile the JSX/TSX files into static HTML that gets sent to clients. If you have any experience with React, SolidJS or Remix, you shouldn't have any trouble adapting, specially if you have experience building React+NextJS projects.",
-        ],
-        [contentPieceType.Heading, "Creating your first theme"],
-        [contentPieceType.Text, "Let's create a very simple Theme Switcher:"],
-        [
-            contentPieceType.CodeBlock,
-            `// /islands/ThemeSwitcher.tsx
-import { useState, useEffect } from 'preact/hooks';
-export default function ThemeSwitcher() {
-    const [theme, setTheme] = useState('Dark');
+// //? Import CompletePost type
+// import { CompletePost, contentPieceType } from "../types/Post.ts";
 
-    useEffect(() => {
-		const cssRoot: HTMLElement | null = document.querySelector(':root');
-		if (cssRoot !== null) {
-			if (theme === 'Light') {
-				cssRoot.style.setProperty('--base-color', 'rgb(203 213 225)');
-				cssRoot.style.setProperty('--neutral-color', 'rgb(15 23 42)');
-				cssRoot.style.setProperty('--accent-color', 'rgb(220 38 38)');
-			} else {
-				cssRoot.style.setProperty('--base-color', 'rgb(15 23 42)');
-				cssRoot.style.setProperty('--neutral-color', 'rgb(203 213 225)');
-				cssRoot.style.setProperty('--accent-color', 'rgb(126 34 206)');
-			}
-		}
-	}, [theme]);
+// export const post: CompletePost = {
+//     title: "How to Create a Theme Switcher with Fresh",
+//     description:
+//         "A guide on how to create your own Theme Switcher using Deno and Fresh",
+//     link: "/how-create-theme-switcher-deno-fresh",
+//     content: [
+//         [
+//             contentPieceType.LargeImage,
+//             "https://web-dev.imgix.net/image/vS06HQ1YTsbMKSFTIPl2iogUQP73/skKcjSv1gMQRYk1AdEp7.png?auto=format&w=1600",
+//         ],
+//         [
+//             contentPieceType.Text,
+//             "Being able to customize your Theme is a huge user experience upgrade to any website. While some websites use a default Dark Theme, the majority of the internet still sticks to creating content in Light Mode as default (and sometimes the only option).",
+//         ],
+//         [
+//             contentPieceType.Text,
+//             "However, if you have tried to do this on your own before, you might have ran into a problem... or many. In this blog post, I'll explain how I've managed to create my theme, what pitfalls I've faced and how I've circumvented them.",
+//         ], // 'heading', 'What is Fresh?'
+//         [
+//             contentPieceType.Image,
+//             "https://fresh.deno.dev/logo.svg?__frsh_c=3171c5e64510907f14fca32f4e0ba9a86bc5247c",
+//         ],
+//         [
+//             contentPieceType.Text,
+//             "Let's start from the top: what is Fresh? Fresh is the official framework to create web apps using the Deno javascript runtime. It features no build-time, zero config, typescript support out-of-the-box, JIT-rendering and uses the Island design architecture (more about this in a minute). The premise here is very simple: Single Page Applications rely really heavily on the Client's devices to build the webpages and that will impact your performance. Fresh, just like Remix (and to some extent Next), aims to move all the rendering back to the server and serves exclusively static HTML pages, hydrating any potential Javascript interactivity only when absolutely necessary. While that's amazing for Lighthouse performance, it comes with its own sets of drawbacks.",
+//         ],
+//         [
+//             contentPieceType.Text,
+//             "Fresh uses Preact under the hood to compile the JSX/TSX files into static HTML that gets sent to clients. If you have any experience with React, SolidJS or Remix, you shouldn't have any trouble adapting, specially if you have experience building React+NextJS projects.",
+//         ],
+//         [contentPieceType.Heading, "Creating your first theme"],
+//         [contentPieceType.Text, "Let's create a very simple Theme Switcher:"],
+//         [
+//             contentPieceType.CodeBlock,
+//             `// /islands/ThemeSwitcher.tsx
+// import { useState, useEffect } from 'preact/hooks';
+// export default function ThemeSwitcher() {
+//     const [theme, setTheme] = useState('Dark');
 
-    const themes: string[] = ['Dark', 'Light'];
+//     useEffect(() => {
+// 		const cssRoot: HTMLElement | null = document.querySelector(':root');
+// 		if (cssRoot !== null) {
+// 			if (theme === 'Light') {
+// 				cssRoot.style.setProperty('--base-color', 'rgb(203 213 225)');
+// 				cssRoot.style.setProperty('--neutral-color', 'rgb(15 23 42)');
+// 				cssRoot.style.setProperty('--accent-color', 'rgb(220 38 38)');
+// 			} else {
+// 				cssRoot.style.setProperty('--base-color', 'rgb(15 23 42)');
+// 				cssRoot.style.setProperty('--neutral-color', 'rgb(203 213 225)');
+// 				cssRoot.style.setProperty('--accent-color', 'rgb(126 34 206)');
+// 			}
+// 		}
+// 	}, [theme]);
 
-    return (
-		<>
-			{themes.map((themeOption) => (
-				<label for={themeOption}>
-					<input
-						class="mr-1"
-						type="radio"
-						id={themeOption}
-						name="theme"
-						checked={theme == themeOption}
-						onClick={() => {
-							setTheme(themeOption);
-						}}
-					></input>
-					{themeOption}
-				</label>
-			))}
-		</>
-	);
-}`,
-        ],
-        [contentPieceType.InlineBlock, [
-            "This creates a radio input that has ",
-            "`Dark`",
-            " selected by default and allows you to toggle between modes. Switching themes will toggle between the Light and the Dark versions of the theme for this blog, now let's make sure we can save the changes when the user clicks either input. Feel free to replace the values of ",
-            "`--base-color`",
-            ", ",
-            "`--neutral-color`",
-            ", and ",
-            "`--accent-color`",
-            " with the values for your own theme.",
-        ]],
-        [
-            contentPieceType.CodeBlock,
-            `import { useEffect, useRef, useState } from "preact/hooks";
-...
-const isInitialMount = useRef(true);
+//     const themes: string[] = ['Dark', 'Light'];
 
-useEffect(() => {
-    const savedTheme = localStorage.getItem("theme")
+//     return (
+// 		<>
+// 			{themes.map((themeOption) => (
+// 				<label for={themeOption}>
+// 					<input
+// 						class="mr-1"
+// 						type="radio"
+// 						id={themeOption}
+// 						name="theme"
+// 						checked={theme == themeOption}
+// 						onClick={() => {
+// 							setTheme(themeOption);
+// 						}}
+// 					></input>
+// 					{themeOption}
+// 				</label>
+// 			))}
+// 		</>
+// 	);
+// }`,
+//         ],
+//         [contentPieceType.InlineBlock, [
+//             "This creates a radio input that has ",
+//             "`Dark`",
+//             " selected by default and allows you to toggle between modes. Switching themes will toggle between the Light and the Dark versions of the theme for this blog, now let's make sure we can save the changes when the user clicks either input. Feel free to replace the values of ",
+//             "`--base-color`",
+//             ", ",
+//             "`--neutral-color`",
+//             ", and ",
+//             "`--accent-color`",
+//             " with the values for your own theme.",
+//         ]],
+//         [
+//             contentPieceType.CodeBlock,
+//             `import { useEffect, useRef, useState } from "preact/hooks";
+// ...
+// const isInitialMount = useRef(true);
 
-    if (isInitialMount.current === true) {
-        if (savedTheme !== null && savedTheme !== theme){
-            setTheme(() => savedTheme)
-            return
-        }
+// useEffect(() => {
+//     const savedTheme = localStorage.getItem("theme")
 
-      isInitialMount.current = false;
-      return;
-    }
-    localStorage.setItem("theme", theme);
-...`,
-        ],
-        [contentPieceType.InlineBlock, [
-            "What the ",
-            "`useEffect()`",
-            " does, in order:",
-        ]],
-        [contentPieceType.InlineBlock, [
-            "1- Runs on start, checks if there is a theme saved (if not, ",
-            "`savedTheme`",
-            " will be ",
-            "`null`",
-            ") and sets the current theme as the ",
-            "`savedTheme`",
-            ", if they are different, then stops (remember that ",
-            "`useEffect()`",
-            " is using the ",
-            "`theme`",
-            " as dependency so not returning here would cause an infinite loop!).",
-        ]],
-        [contentPieceType.InlineBlock, [
-            "2- After setting the ",
-            "`theme`",
-            " equal to localStorage's ",
-            "`savedTheme`",
-            ", ",
-            "`useEffect()`",
-            " is triggered again. Because the ",
-            "`savedTheme`",
-            " is the same as ",
-            "`theme`",
-            ", it will skip the first ",
-            "`if`",
-            " check and negate the ",
-            "`isInitialMount`",
-            " value and stop.",
-        ]],
-        [contentPieceType.InlineBlock, [
-            "3- (Optional) If the theme is switched, it will skip both ",
-            "`if`",
-            " checks, save the theme to ",
-            "`localStorage`",
-            " and apply the theme.",
-        ]],
-        [
-            contentPieceType.Text,
-            "So there you have it, a theme switcher build with Preact and Fresh. But can we make this better?",
-        ],
-    ],
-    date: 1684849328672,
-    author: "Written with 💞 by TheYuriG",
-};
+//     if (isInitialMount.current === true) {
+//         if (savedTheme !== null && savedTheme !== theme){
+//             setTheme(() => savedTheme)
+//             return
+//         }
+
+//       isInitialMount.current = false;
+//       return;
+//     }
+//     localStorage.setItem("theme", theme);
+// ...`,
+//         ],
+//         [contentPieceType.InlineBlock, [
+//             "What the ",
+//             "`useEffect()`",
+//             " does, in order:",
+//         ]],
+//         [contentPieceType.InlineBlock, [
+//             "1- Runs on start, checks if there is a theme saved (if not, ",
+//             "`savedTheme`",
+//             " will be ",
+//             "`null`",
+//             ") and sets the current theme as the ",
+//             "`savedTheme`",
+//             ", if they are different, then stops (remember that ",
+//             "`useEffect()`",
+//             " is using the ",
+//             "`theme`",
+//             " as dependency so not returning here would cause an infinite loop!).",
+//         ]],
+//         [contentPieceType.InlineBlock, [
+//             "2- After setting the ",
+//             "`theme`",
+//             " equal to localStorage's ",
+//             "`savedTheme`",
+//             ", ",
+//             "`useEffect()`",
+//             " is triggered again. Because the ",
+//             "`savedTheme`",
+//             " is the same as ",
+//             "`theme`",
+//             ", it will skip the first ",
+//             "`if`",
+//             " check and negate the ",
+//             "`isInitialMount`",
+//             " value and stop.",
+//         ]],
+//         [contentPieceType.InlineBlock, [
+//             "3- (Optional) If the theme is switched, it will skip both ",
+//             "`if`",
+//             " checks, save the theme to ",
+//             "`localStorage`",
+//             " and apply the theme.",
+//         ]],
+//         [
+//             contentPieceType.Text,
+//             "So there you have it, a theme switcher build with Preact and Fresh. But can we make this better?",
+//         ],
+//     ],
+//     date: 1684849328672,
+//     author: "Written with 💞 by TheYuriG",
+// };

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -4,14 +4,15 @@
 
 import config from "./deno.json" assert { type: "json" };
 import * as $0 from "./routes/[blog]/[post].tsx";
-import * as $1 from "./routes/[toys]/insanity.tsx";
-import * as $2 from "./routes/[toys]/spinners.tsx";
-import * as $3 from "./routes/_404.tsx";
-import * as $4 from "./routes/api/joke.ts";
-import * as $5 from "./routes/blog.tsx";
-import * as $6 from "./routes/index.tsx";
-import * as $7 from "./routes/toys.tsx";
-import * as $8 from "./routes/what-is-this.tsx";
+import * as $1 from "./routes/[blog]/how-create-theme-switcher-deno-fresh.tsx";
+import * as $2 from "./routes/[toys]/insanity.tsx";
+import * as $3 from "./routes/[toys]/spinners.tsx";
+import * as $4 from "./routes/_404.tsx";
+import * as $5 from "./routes/api/joke.ts";
+import * as $6 from "./routes/blog.tsx";
+import * as $7 from "./routes/index.tsx";
+import * as $8 from "./routes/toys.tsx";
+import * as $9 from "./routes/what-is-this.tsx";
 import * as $$0 from "./islands/BlogNavigationButtons.tsx";
 import * as $$1 from "./islands/InsanitySection.tsx";
 import * as $$2 from "./islands/StyledButton.tsx";
@@ -20,14 +21,15 @@ import * as $$3 from "./islands/ThemeSwitcher.tsx";
 const manifest = {
   routes: {
     "./routes/[blog]/[post].tsx": $0,
-    "./routes/[toys]/insanity.tsx": $1,
-    "./routes/[toys]/spinners.tsx": $2,
-    "./routes/_404.tsx": $3,
-    "./routes/api/joke.ts": $4,
-    "./routes/blog.tsx": $5,
-    "./routes/index.tsx": $6,
-    "./routes/toys.tsx": $7,
-    "./routes/what-is-this.tsx": $8,
+    "./routes/[blog]/how-create-theme-switcher-deno-fresh.tsx": $1,
+    "./routes/[toys]/insanity.tsx": $2,
+    "./routes/[toys]/spinners.tsx": $3,
+    "./routes/_404.tsx": $4,
+    "./routes/api/joke.ts": $5,
+    "./routes/blog.tsx": $6,
+    "./routes/index.tsx": $7,
+    "./routes/toys.tsx": $8,
+    "./routes/what-is-this.tsx": $9,
   },
   islands: {
     "./islands/BlogNavigationButtons.tsx": $$0,

--- a/routes/[blog]/[post].tsx
+++ b/routes/[blog]/[post].tsx
@@ -1,90 +1,93 @@
-//? Head component with all Meta tags pre-set
-import { CustomHead } from "../../components/CustomHead.tsx";
-//? Lateral text with theme switcher
-import { Base } from "../../components/Base.tsx";
-//? Navigation Buttons to go back to the previous page or to the next page (optional)
-import BlogNavigationButtons from "../../islands/BlogNavigationButtons.tsx";
-//? To know what is the current route
-import { Handlers } from "$fresh/server.ts";
-//? Parse content from a file into JSX
-import contentParser from "../../services/contentParser.tsx";
-//? Fetch a post from source and return it as a CompletePost type
-import fetchPost from "../../services/fetchPost.ts";
-//? Import CompletePost type
-import type {
-  CompletePost, // Post interface
-} from "../../types/Post.ts";
-import FetchPostError from "../../types/FetchPostError.ts";
+// Unused because Deno Deploy doesn't support dynamically
+// importing this file from /services/fetchPosts.ts
 
-//? Runs before the render function to fetch the post from the files, then
-//? pushes
-export const handler: Handlers = {
-  async GET(req, ctx) {
-    const blogpost = await fetchPost(ctx.params.post);
-    if (blogpost instanceof FetchPostError) {
-      return ctx.renderNotFound();
-    }
-    return ctx.render(blogpost);
-  },
-};
+// //? Head component with all Meta tags pre-set
+// import { CustomHead } from "../../components/CustomHead.tsx";
+// //? Lateral text with theme switcher
+// import { Base } from "../../components/Base.tsx";
+// //? Navigation Buttons to go back to the previous page or to the next page (optional)
+// import BlogNavigationButtons from "../../islands/BlogNavigationButtons.tsx";
+// //? To know what is the current route
+// import { Handlers } from "$fresh/server.ts";
+// //? Parse content from a file into JSX
+// import contentParser from "../../services/contentParser.tsx";
+// //? Fetch a post from source and return it as a CompletePost type
+// import fetchPost from "../../services/fetchPost.ts";
+// //? Import CompletePost type
+// import type {
+//   CompletePost, // Post interface
+// } from "../../types/Post.ts";
+// import FetchPostError from "../../types/FetchPostError.ts";
 
-//? Exports a single Blog Post Summary
-export default function CompleteBlogPost(
-  { data: savedPost }: { data: CompletePost },
-) {
-  return (
-    <>
-      <CustomHead
-        title={savedPost.title}
-        description={savedPost.description}
-        link={"https://www.theyurig.com/blog" + savedPost.link}
-      >
-        <link rel="stylesheet" href="/home.css" />
-        <link rel="stylesheet" href="/navigation-buttons.css" />
-        <link rel="stylesheet" href="/content.css" />
-        <link rel="stylesheet" href="/blog.css" />
-        <link rel="stylesheet" href="/syntax-highlighting.css" />
-        {
-          /* Syntax highlight for code. How can we do this better
-            so we don't cause Cumulative Layout Shift?
-            There must be a better way... */
+// //? Runs before the render function to fetch the post from the files, then
+// //? pushes
+// export const handler: Handlers = {
+//   async GET(req, ctx) {
+//     const blogpost = await fetchPost(ctx.params.post);
+//     if (blogpost instanceof FetchPostError) {
+//       return ctx.renderNotFound();
+//     }
+//     return ctx.render(blogpost);
+//   },
+// };
 
-          // Checked March 23rd, 2023 and there is currently no better
-          // option for Deno. As for NPM packages, options to consider are
-          // rc-highlight: https://www.npmjs.com/package/rc-highlight
-          // and lowlight: https://github.com/wooorm/lowlight
-        }
-        <script
-          type="module"
-          dangerouslySetInnerHTML={{
-            __html:
-              `import { highlightAll } from 'https://unpkg.com/@speed-highlight/core/dist/index.js';
-            highlightAll();`,
-          }}
-        />
-      </CustomHead>
-      {/* Base page layout with theme switching and footer outside of accent box */}
-      <Base>
-        {/* Back button */}
-        <BlogNavigationButtons />
-        {/* Complete Post */}
-        <article class="center">
-          {/* Centered heading */}
-          <h2 class="navigation-link blog-title">{savedPost.title}</h2>
-          {/* Post creation date */}
-          <p class="post-date">
-            {new Date(savedPost.date).toLocaleString()}
-          </p>
-          {/* Post content, parsed and spread */}
-          <div class="justified">
-            {...contentParser(savedPost.content)}
-          </div>
-          {/* Post author */}
-          <footer class="blog-footer" style="margin-top: auto;">
-            {savedPost.author}
-          </footer>
-        </article>
-      </Base>
-    </>
-  );
-}
+// //? Exports a single Blog Post Summary
+// export default function CompleteBlogPost(
+//   { data: savedPost }: { data: CompletePost },
+// ) {
+//   return (
+//     <>
+//       <CustomHead
+//         title={savedPost.title}
+//         description={savedPost.description}
+//         link={"https://www.theyurig.com/blog" + savedPost.link}
+//       >
+//         <link rel="stylesheet" href="/home.css" />
+//         <link rel="stylesheet" href="/navigation-buttons.css" />
+//         <link rel="stylesheet" href="/content.css" />
+//         <link rel="stylesheet" href="/blog.css" />
+//         <link rel="stylesheet" href="/syntax-highlighting.css" />
+//         {
+//           /* Syntax highlight for code. How can we do this better
+//             so we don't cause Cumulative Layout Shift?
+//             There must be a better way... */
+
+//           // Checked March 23rd, 2023 and there is currently no better
+//           // option for Deno. As for NPM packages, options to consider are
+//           // rc-highlight: https://www.npmjs.com/package/rc-highlight
+//           // and lowlight: https://github.com/wooorm/lowlight
+//         }
+//         <script
+//           type="module"
+//           dangerouslySetInnerHTML={{
+//             __html:
+//               `import { highlightAll } from 'https://unpkg.com/@speed-highlight/core/dist/index.js';
+//             highlightAll();`,
+//           }}
+//         />
+//       </CustomHead>
+//       {/* Base page layout with theme switching and footer outside of accent box */}
+//       <Base>
+//         {/* Back button */}
+//         <BlogNavigationButtons />
+//         {/* Complete Post */}
+//         <article class="center">
+//           {/* Centered heading */}
+//           <h2 class="navigation-link blog-title">{savedPost.title}</h2>
+//           {/* Post creation date */}
+//           <p class="post-date">
+//             {new Date(savedPost.date).toLocaleString()}
+//           </p>
+//           {/* Post content, parsed and spread */}
+//           <div class="justified">
+//             {...contentParser(savedPost.content)}
+//           </div>
+//           {/* Post author */}
+//           <footer class="blog-footer" style="margin-top: auto;">
+//             {savedPost.author}
+//           </footer>
+//         </article>
+//       </Base>
+//     </>
+//   );
+// }

--- a/routes/[blog]/how-create-theme-switcher-deno-fresh.tsx
+++ b/routes/[blog]/how-create-theme-switcher-deno-fresh.tsx
@@ -1,0 +1,274 @@
+//? Head component with all Meta tags pre-set
+import { CustomHead } from "../../components/CustomHead.tsx";
+//? Lateral text with theme switcher
+import { Base } from "../../components/Base.tsx";
+//? Navigation Buttons to go back to the previous page or to the next page (optional)
+import BlogNavigationButtons from "../../islands/BlogNavigationButtons.tsx";
+
+export default function Home() {
+  return (
+    <>
+      <CustomHead
+        title="How to Create a Theme Switcher with Fresh"
+        description="A guide on how to create your own Theme Switcher using Deno and Fresh"
+        link="https://www.theyurig.com/blog/how-create-theme-switcher-deno-fresh"
+      >
+        <link rel="stylesheet" href="/home.css" />
+        <link rel="stylesheet" href="/navigation-buttons.css" />
+        <link rel="stylesheet" href="/content.css" />
+        <link rel="stylesheet" href="/blog.css" />
+        <link rel="stylesheet" href="/syntax-highlighting.css" />
+        {
+          /* Syntax highlight for code. How can we do this better
+            so we don't cause Cumulative Layout Shift?
+            There must be a better way... */
+
+          // Checked March 23rd, 2023 and there is currently no better
+          // option for Deno. As for NPM packages, options to consider are
+          // rc-highlight: https://www.npmjs.com/package/rc-highlight
+          // and lowlight: https://github.com/wooorm/lowlight
+        }
+        <script
+          type="module"
+          dangerouslySetInnerHTML={{
+            __html:
+              `import { highlightAll } from 'https://unpkg.com/@speed-highlight/core/dist/index.js';
+            highlightAll();`,
+          }}
+        />
+      </CustomHead>
+      {/* Base page layout with theme switching and footer outside of accent box */}
+      <Base>
+        {/* Back button */}
+        <BlogNavigationButtons />
+        <article class="center">
+          {/* Centered heading */}
+          <h2 class="navigation-link blog-title">
+            How to Create a Theme Switcher with Fresh
+          </h2>
+          {/* Post creation date */}
+          <p class="post-date">
+            {new Date(1684849328672).toLocaleString()}
+          </p>
+          {/* Blog post opening image */}
+          <img
+            src={"https://web-dev.imgix.net/image/vS06HQ1YTsbMKSFTIPl2iogUQP73/skKcjSv1gMQRYk1AdEp7.png?auto=format&w=1600"}
+            class="large-image"
+          />
+          {/* Introduction */}
+          <p class="space">
+            Being able to customize your Theme is a huge user experience upgrade
+            to any website. While some websites use a default Dark Theme, the
+            majority of the internet still sticks to creating content in Light
+            Mode as default (and sometimes the only option).
+          </p>
+          {/* Presenting the problem */}
+          <p class="space">
+            However, if you have tried to do this on your own before, you might
+            have ran into a problem... or many. In this blog post, I'll explain
+            how I've managed to create my theme, what pitfalls I've faced and
+            how I've circumvented them.
+          </p>
+          {/* Image introducing to next topic: Fresh */}
+          <img
+            src={"https://fresh.deno.dev/logo.svg?__frsh_c=3171c5e64510907f14fca32f4e0ba9a86bc5247c"}
+            class="small-image"
+          />
+          {/* Explaining what is Fresh */}
+          <p class="space">
+            Let's start from the top: what is Fresh? Fresh is the official
+            framework to create web apps using the Deno javascript runtime. It
+            features no build-time, zero config, typescript support
+            out-of-the-box, JIT-rendering and uses the Island design
+            architecture (more about this in a minute). The premise here is very
+            simple: Single Page Applications rely really heavily on the Client's
+            devices to build the webpages and that will impact your performance.
+            Fresh, just like Remix (and to some extent Next), aims to move all
+            the rendering back to the server and serves exclusively static HTML
+            pages, hydrating any potential Javascript interactivity only when
+            absolutely necessary. While that's amazing for Lighthouse
+            performance, it comes with its own sets of drawbacks.
+          </p>
+          {/* Further explanation about Fresh */}
+          <p class="space">
+            Fresh uses Preact under the hood to compile the JSX/TSX files into
+            static HTML that gets sent to clients. If you have any experience
+            with React, SolidJS or Remix, you shouldn't have any trouble
+            adapting, specially if you have experience building React+NextJS
+            projects.
+          </p>
+          {/* Main content start */}
+          <h2 class="subtopic">Creating your first theme</h2>
+          <p class="space">Let's create a very simple Theme Switcher:</p>
+          {/* Code block with initial implementation */}
+          <div class="shj-lang-js">
+            {`// /islands/ThemeSwitcher.tsx
+import { useState, useEffect } from 'preact/hooks';
+export default function ThemeSwitcher() {
+    const [theme, setTheme] = useState('Dark');
+
+    useEffect(() => {
+		const cssRoot: HTMLElement | null = document.querySelector(':root');
+		if (cssRoot !== null) {
+			if (theme === 'Light') {
+				cssRoot.style.setProperty('--base-color', 'rgb(203 213 225)');
+				cssRoot.style.setProperty('--neutral-color', 'rgb(15 23 42)');
+				cssRoot.style.setProperty('--accent-color', 'rgb(220 38 38)');
+			} else {
+				cssRoot.style.setProperty('--base-color', 'rgb(15 23 42)');
+				cssRoot.style.setProperty('--neutral-color', 'rgb(203 213 225)');
+				cssRoot.style.setProperty('--accent-color', 'rgb(126 34 206)');
+			}
+		}
+	}, [theme]);
+
+    const themes: string[] = ['Dark', 'Light'];
+
+    return (
+		<>
+			{themes.map((themeOption) => (
+				<label for={themeOption}>
+					<input
+						class="mr-1"
+						type="radio"
+						id={themeOption}
+						name="theme"
+						checked={theme == themeOption}
+						onClick={() => {
+							setTheme(themeOption);
+						}}
+					></input>
+					{themeOption}
+				</label>
+			))}
+		</>
+	);
+}`}
+          </div>
+          {/* Initial implementation explanation */}
+          <p>
+            This creates a radio input that has{" "}
+            <code class="shj-lang-js">
+              Dark
+            </code>{" "}
+            selected by default and allows you to toggle between modes.
+            Switching themes will toggle between the Light and the Dark versions
+            of the theme for this blog, now let's make sure we can save the
+            changes when the user clicks either input. Feel free to replace the
+            values of{" "}
+            <code class="shj-lang-js">
+              --base-color
+            </code>
+            ,{" "}
+            <code class="shj-lang-js">
+              --neutral-color
+            </code>
+            , and{" "}
+            <code class="shj-lang-js">
+              --accent-color
+            </code>{" "}
+            with the values for your own theme.
+          </p>
+          {/* Improved implementation with localStorage */}
+          <div class="shj-lang-js">
+            {`import { useEffect, useRef, useState } from "preact/hooks";
+...
+const isInitialMount = useRef(true);
+
+useEffect(() => {
+    const savedTheme = localStorage.getItem("theme")
+
+    if (isInitialMount.current === true) {
+        if (savedTheme !== null && savedTheme !== theme){
+            setTheme(() => savedTheme)
+            return
+        }
+
+      isInitialMount.current = false;
+      return;
+    }
+    localStorage.setItem("theme", theme);
+...`}
+          </div>
+          {/* Second code block explanation */}
+          <p>
+            What the{"  "}
+            <code class="shj-lang-js">
+              useEffect()
+            </code>{" "}
+            does, in order:
+          </p>
+          {/* Explanation part 1 */}
+          <p>
+            1- Runs on start, checks if there is a theme saved (if not,{" "}
+            <code class="shj-lang-js">
+              savedTheme
+            </code>{" "}
+            will be{" "}
+            <code class="shj-lang-js">
+              null
+            </code>
+            ) and sets the current theme as the{" "}
+            <code class="shj-lang-js">
+              savedTheme
+            </code>
+            , if they are different, then stops (remember that{" "}
+            <code class="shj-lang-js">
+              useEffect()
+            </code>{" "}
+            is using the{" "}
+            <code class="shj-lang-js">
+              theme
+            </code>{" "}
+            as dependency so not returning here would cause an infinite loop!).
+          </p>
+          {/* Explanation part 2 */}
+          <p>
+            2- After setting the{" "}
+            <code class="shj-lang-js">
+              theme
+            </code>{" "}
+            equal to localStorage's{" "}
+            <code class="shj-lang-js">
+              savedTheme
+            </code>{" "}
+            is the same as{" "}
+            <code class="shj-lang-js">
+              theme
+            </code>
+            , it will skip the first{" "}
+            <code class="shj-lang-js">
+              if
+            </code>{" "}
+            check and negate the{" "}
+            <code class="shj-lang-js">
+              isInitialMount
+            </code>{" "}
+            value and stop
+          </p>
+          {/* Explanation part 3 */}
+          <p>
+            3- (Optional) If the theme is switched, it will skip both{"  "}
+            <code class="shj-lang-js">
+              if
+            </code>{" "}
+            checks, save the theme to
+            <code class="shj-lang-js">
+              localStorage
+            </code>{" "}
+            and applies it.
+          </p>
+          {/* Conclusion */}
+          <p class="space">
+            So there you have it, a theme switcher build with Preact and Fresh.
+            But can we make this better?
+          </p>
+          {/* Post author */}
+          <footer class="blog-footer" style="margin-top: auto;">
+            Written with 💞 by TheYuriG
+          </footer>
+        </article>
+      </Base>
+    </>
+  );
+}

--- a/routes/blog.tsx
+++ b/routes/blog.tsx
@@ -30,10 +30,6 @@ export default function Home() {
           {...createdPosts.map((post) => (
             <BlogPostSummary {...post}></BlogPostSummary>
           ))}
-          <footer class="blog-footer">
-            Disclaimer: I haven't created any of these posts myself, just using
-            them as mock data to test the layout.
-          </footer>
         </section>
       </Base>
     </>

--- a/services/fetchPost.ts
+++ b/services/fetchPost.ts
@@ -1,24 +1,26 @@
-//? Import CompletePost type
-import {
-  type CompletePost, // Post interface
-} from "../types/Post.ts";
-//? Import fetch error
-import FetchPostError from "../types/FetchPostError.ts";
+// Unused because Deno Deploy doesn't support dynamic imports
 
-//? Fetches post by filename, from /blog_posts
-//! Route needs to match filename!
-export default async function fetchPost(
-  postLink: string,
-): Promise<FetchPostError | CompletePost> {
-  try {
-    const { post }: { post: CompletePost } = await import(
-      `../blog_posts/${postLink}.ts`
-    );
-    return post;
-  } catch (error) {
-    return new FetchPostError(
-      "Unable to find the specified Post!",
-      error.trace,
-    );
-  }
-}
+// //? Import CompletePost type
+// import {
+//   type CompletePost, // Post interface
+// } from "../types/Post.ts";
+// //? Import fetch error
+// import FetchPostError from "../types/FetchPostError.ts";
+
+// //? Fetches post by filename, from /blog_posts
+// //! Route needs to match filename!
+// export default async function fetchPost(
+//   postLink: string,
+// ): Promise<FetchPostError | CompletePost> {
+//   try {
+//     const { post }: { post: CompletePost } = await import(
+//       `../blog_posts/${postLink}.ts`
+//     );
+//     return post;
+//   } catch (error) {
+//     return new FetchPostError(
+//       "Unable to find the specified Post!",
+//       error.trace,
+//     );
+//   }
+// }

--- a/types/FetchPostError.ts
+++ b/types/FetchPostError.ts
@@ -1,11 +1,14 @@
-//? Creates an instance of Error to be returned when fetchPosts() fails
-export default class FetchPostError extends Error {
-  constructor(public message: string, public trace: Error["stack"]) {
-    //? Pass the Error message
-    super(message);
-    //? Names this error
-    this.name = "FetchPostError";
-    //? Attaches original stack trace
-    this.stack = trace;
-  }
-}
+// Unused because Deno Deploy doesn't support dynamically
+// importing this file from /services/fetchPosts.ts
+
+// //? Creates an instance of Error to be returned when fetchPosts() fails
+// export default class FetchPostError extends Error {
+//   constructor(public message: string, public trace: Error["stack"]) {
+//     //? Pass the Error message
+//     super(message);
+//     //? Names this error
+//     this.name = "FetchPostError";
+//     //? Attaches original stack trace
+//     this.stack = trace;
+//   }
+// }

--- a/types/Post.ts
+++ b/types/Post.ts
@@ -1,42 +1,45 @@
-//? Possible options of content
-export enum contentPieceType {
-  Heading = "heading",
-  Text = "text",
-  Image = "image",
-  LargeImage = "largeImage",
-  CodeBlock = "codeBlock",
-  InlineBlock = "inlineCode",
-}
+// Unused because Deno Deploy doesn't support dynamically
+// importing this file from /services/fetchPosts.ts
 
-//? How content pieces are created
-export type ContentPiece =
-  // Simple string types: Text (<p>), CodeBlock <div>, Image and LargeImage (both <img>)
-  | [
-    (
-      | contentPieceType.Heading // Secondary heading
-      | contentPieceType.Text // Pure text paragraph
-      | contentPieceType.Image // URL string
-      | contentPieceType.LargeImage // URL string
-      | contentPieceType.CodeBlock // Self contained code block
-    ),
-    //todo Image and LargeImage should also be an array of strings
-    //todo so the first parameter is the link, while the second and
-    //todo third are the alt attribute and the title attribute
-    string, // All of the types above are simple strings
-  ]
-  // Array of strings type: InlineBlock (<p><span?></p>)
-  | [
-    contentPieceType.InlineBlock, // Paragraph with nested code spans
-    string[], // Array of strings. A string surrounded by trailing and
-    // leading ` will be converted to an inline code block
-  ];
+// //? Possible options of content
+// export enum contentPieceType {
+//   Heading = "heading",
+//   Text = "text",
+//   Image = "image",
+//   LargeImage = "largeImage",
+//   CodeBlock = "codeBlock",
+//   InlineBlock = "inlineCode",
+// }
 
-//? All the data a post is required to have
-export interface CompletePost {
-  title: string;
-  description: string;
-  link: string;
-  content: ContentPiece[];
-  date: number;
-  author: string;
-}
+// //? How content pieces are created
+// export type ContentPiece =
+//   // Simple string types: Text (<p>), CodeBlock <div>, Image and LargeImage (both <img>)
+//   | [
+//     (
+//       | contentPieceType.Heading // Secondary heading
+//       | contentPieceType.Text // Pure text paragraph
+//       | contentPieceType.Image // URL string
+//       | contentPieceType.LargeImage // URL string
+//       | contentPieceType.CodeBlock // Self contained code block
+//     ),
+//     //todo Image and LargeImage should also be an array of strings
+//     //todo so the first parameter is the link, while the second and
+//     //todo third are the alt attribute and the title attribute
+//     string, // All of the types above are simple strings
+//   ]
+//   // Array of strings type: InlineBlock (<p><span?></p>)
+//   | [
+//     contentPieceType.InlineBlock, // Paragraph with nested code spans
+//     string[], // Array of strings. A string surrounded by trailing and
+//     // leading ` will be converted to an inline code block
+//   ];
+
+// //? All the data a post is required to have
+// export interface CompletePost {
+//   title: string;
+//   description: string;
+//   link: string;
+//   content: ContentPiece[];
+//   date: number;
+//   author: string;
+// }


### PR DESCRIPTION
Fixes the broken deployment from #28 because of the inability of Deno Deploy to dynamically import files.
Reference: [Dynamic imports #1](https://github.com/denoland/deploy_feedback/issues/1).

Additionally, the dead code files were commented out but left in for future reference whenever I need to deploy dynamic routes.