### PR TITLE
feat: animate home text with fade-ins

### DIFF
--- a/components/HomeContent.tsx
+++ b/components/HomeContent.tsx
@@ -2,9 +2,11 @@ export function HomeContent() {
   return (
     <>
       {/* Greeting */}
-      <h1 class="inline-block text-4xl">Hello!</h1>
+      <h1 class="inline-block text-4xl animate-to-left" style="--dur: 0">
+        Hello!
+      </h1>
       {/* Name */}
-      <p class="block text-2xl ml-4">
+      <p class="block text-2xl ml-4 animate-to-left" style="--dur: 1">
         I am{" "}
         <strong>
           <span class="gradient-underline">TheYuriG</span>
@@ -12,13 +14,16 @@ export function HomeContent() {
         </strong>
       </p>
       {/* Skillset */}
-      <p class="block text-2xl ml-8">a Node/Deno Full Stack developer.</p>
+      <p class="block text-2xl ml-8 animate-to-left" style="--dur: 2">
+        Sky afficionado, gym rat, full stack developer
+      </p>
       {/* Role */}
-      <p class="block ml-8">
-        Currently working as Backend developer at{" "}
+      <p class="block ml-12 animate-to-left" style="--dur: 3">
+        Currently building greatness at{" "}
         <a href="https://trophy.place" target="_blank" class="pretty-link">
           Trophy Place
-        </a>
+        </a>{" "}
+        and blogging
         {/* Blinking caret */}
         <svg
           viewBox="0 0 4 8"

--- a/components/NavigationMenu.tsx
+++ b/components/NavigationMenu.tsx
@@ -4,26 +4,42 @@ export function NavigationMenu() {
       class="flex flex-col p-4 items-end absolute bottom-0 right-0"
       style="font-family: 'Alfa Slab One', cursive;"
     >
-      <a href="/work" class="navigation-link" title="Relevant work experience">
+      <a
+        href="/work"
+        class="navigation-link animate-to-right"
+        style="--dur: 3.8;"
+        title="Things I've done for money"
+      >
         Work
       </a>
-      <a href="/toys" class="navigation-link" title="Curiosity projects">
+      <a
+        href="/toys"
+        class="navigation-link animate-to-right"
+        style="--dur: 5;"
+        title="Curiosity projects"
+      >
         Toys
       </a>
       <a
         href="/blog"
-        class="navigation-link"
+        class="navigation-link animate-to-right"
+        style="--dur: 6;"
         title="Development findings shared over the years"
       >
         Blog
       </a>
-      <a href="/me" class="navigation-link" title="Who is Yuri?">
+      <a
+        href="/me"
+        class="navigation-link animate-to-right"
+        style="--dur: 7;"
+        title="Who is Yuri?"
+      >
         Me
       </a>
       <a
         href="/what-is-this"
-        class="text-sm"
-        style="color: yellow; margin-top: 2em;"
+        class="text-sm animate-to-right"
+        style="color: yellow; margin-top: 2em; --dur: 8;"
         title="information about how this website is built"
       >
         this

--- a/routes/[blog]/how-create-theme-switcher-deno-fresh.tsx
+++ b/routes/[blog]/how-create-theme-switcher-deno-fresh.tsx
@@ -13,10 +13,10 @@ export default function Home() {
         description="A guide on how to create your own Theme Switcher using Deno and Fresh"
         link="https://www.theyurig.com/blog/how-create-theme-switcher-deno-fresh"
       >
-        <link rel="stylesheet" href="/home.css" />
         <link rel="stylesheet" href="/navigation-buttons.css" />
         <link rel="stylesheet" href="/content.css" />
         <link rel="stylesheet" href="/blog.css" />
+        <link rel="stylesheet" href="/gradient-underline.css" />
         <link rel="stylesheet" href="/syntax-highlighting.css" />
         {
           /* Syntax highlight for code. How can we do this better
@@ -53,6 +53,8 @@ export default function Home() {
           {/* Blog post opening image */}
           <img
             src={"https://web-dev.imgix.net/image/vS06HQ1YTsbMKSFTIPl2iogUQP73/skKcjSv1gMQRYk1AdEp7.png?auto=format&w=1600"}
+            alt="Sun and Moon montage with the words Light and Dark accompanying them"
+            title="To many people, themes are an important part of the User Experience"
             class="large-image"
           />
           {/* Introduction */}
@@ -69,26 +71,36 @@ export default function Home() {
             how I've managed to create my theme, what pitfalls I've faced, and
             how I've circumvented them.
           </p>
-          {/* Image introducing to next topic: Fresh */}
+          {/* Heading and image introducing to next topic: Fresh */}
+          <h2 class="subtopic">What is Fresh?</h2>
           <img
             src={"https://fresh.deno.dev/logo.svg?__frsh_c=3171c5e64510907f14fca32f4e0ba9a86bc5247c"}
+            alt="Fresh's logo"
+            title="Fresh, the official framework to build Web apps on Deno"
             class="small-image"
           />
-          <h2 class="subtopic">What is Fresh?</h2>
           {/* Explaining what is Fresh */}
           <p class="space">
-            Let's start from the top: what is Fresh? Fresh is the official
-            framework to create web apps using the Deno javascript runtime. It
-            features no build-time, zero-config, typescript support
-            out-of-the-box, JIT-rendering, and uses the Island design
-            architecture (more about this in a minute). The premise here is very
-            simple: Single Page Applications rely heavily on the Client's
-            devices to build the webpages and that will impact your performance.
-            Fresh, just like Remix (and to some extent Next), aims to move all
-            the rendering back to the server and serves exclusively static HTML
-            pages, hydrating any potential Javascript interactivity only when
-            necessary. While that's amazing for Lighthouse performance, it comes
-            with its own sets of drawbacks (more on that in the next post).
+            <a
+              class="gradient-underline pretty-link"
+              href="https://fresh.deno.dev/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Fresh
+            </a>{" "}
+            is the official framework to create web apps using the Deno
+            javascript runtime. It features no build-time, zero-config,
+            typescript support out-of-the-box, JIT-rendering, and uses the
+            Island design architecture (more about this in a minute). The
+            premise here is very simple: Single Page Applications rely heavily
+            on the Client's devices to build the webpages and that will impact
+            your performance. Fresh, just like Remix (and to some extent Next),
+            aims to move all the rendering back to the server and serves
+            exclusively static HTML pages, hydrating any potential Javascript
+            interactivity only when necessary. While that's amazing for
+            Lighthouse performance, it comes with its own sets of drawbacks
+            (more on that in the next post).
           </p>
           {/* Further explanation about Fresh */}
           <p class="space">
@@ -263,7 +275,15 @@ useEffect(() => {
           {/* Conclusion */}
           <p class="space">
             So there you have it, a theme switcher built with Preact and Fresh.
-            But can we make this better?
+            If you have been following along, you might have noticed a few
+            issues with it, like flickering on first load. Let's work on those
+            on the{" "}
+            <a
+              class="gradient-underline pretty-link"
+              href="/how-remove-theme-flickering-deno-fresh"
+            >
+              next blog post
+            </a>.
           </p>
           {/* Post author */}
           <footer class="blog-footer" style="margin-top: auto;">

--- a/routes/[blog]/how-create-theme-switcher-deno-fresh.tsx
+++ b/routes/[blog]/how-create-theme-switcher-deno-fresh.tsx
@@ -111,7 +111,7 @@ export default function Home() {
             projects.
           </p>
           {/* Main content start */}
-          <h2 class="subtopic">Creating your first theme</h2>
+          <h2 class="subtopic">Creating A Theme Switcher</h2>
           <p class="space">Let's create a very simple Theme Switcher:</p>
           {/* Code block with initial implementation */}
           <div class="shj-lang-js">
@@ -184,7 +184,8 @@ export default function ThemeSwitcher() {
           </p>
           {/* Improved implementation with localStorage */}
           <div class="shj-lang-js">
-            {`import { useEffect, useRef, useState } from "preact/hooks";
+            {`// /islands/ThemeSwitcher.tsx (updated)
+import { useEffect, useRef, useState } from "preact/hooks";
 ...
 const isInitialMount = useRef(true);
 
@@ -204,8 +205,23 @@ useEffect(() => {
 ...`}
           </div>
           {/* Second code block explanation */}
+          <p class="space">
+            We have added a reference to the{" "}
+            <code class="shj-lang-js">
+              useEffect
+            </code>{" "}
+            to avoid having it saving the current{" "}
+            <code class="shj-lang-js">
+              theme
+            </code>{" "}
+            to{" "}
+            <code class="shj-lang-js">
+              localStorage
+            </code>{" "}
+            on the first render.
+          </p>
           <p>
-            What the{"  "}
+            What the{" "}
             <code class="shj-lang-js">
               useEffect()
             </code>{" "}
@@ -242,7 +258,10 @@ useEffect(() => {
             <code class="shj-lang-js">
               theme
             </code>{" "}
-            equal to localStorage's{" "}
+            equal to{" "}
+            <code class="shj-lang-js">
+              localStorage
+            </code>'s{" "}
             <code class="shj-lang-js">
               savedTheme
             </code>{" "}
@@ -262,7 +281,11 @@ useEffect(() => {
           </p>
           {/* Explanation part 3 */}
           <p>
-            3- (Optional) If the theme is switched, it will skip both{"  "}
+            3- (Optional) If the{" "}
+            <code class="shj-lang-js">
+              theme
+            </code>{" "}
+            is updated, it will skip both{" "}
             <code class="shj-lang-js">
               if
             </code>{" "}
@@ -272,9 +295,22 @@ useEffect(() => {
             </code>
             , and applies it.
           </p>
-          {/* Conclusion */}
+          {/* Linking to repository version */}
           <p class="space">
-            So there you have it, a theme switcher built with Preact and Fresh.
+            This website uses an improved version of this Theme Switcher, which
+            you can check the source code for{" "}
+            <a
+              class="gradient-underline pretty-link"
+              href="https://github.com/TheYuriG/deno-portfolio/blob/0051fc7369f714a7562d303f760e148efc753ea4/islands/ThemeSwitcher.tsx"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              right here
+            </a>.
+          </p>
+          {/* Conclusion and link to next post */}
+          <p class="space">
+            So there you have it, a Theme Switcher built with Preact and Fresh.
             If you have been following along, you might have noticed a few
             issues with it, like flickering on first load. Let's work on those
             on the{" "}

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -19,6 +19,7 @@ export default function Home() {
       >
         <link rel="stylesheet" href="/home.css" />
         <link rel="stylesheet" href="/starry-night.css" />
+        <link rel="stylesheet" href="/animate.css" />
         <link rel="stylesheet" href="/gradient-underline.css" />
       </CustomHead>
       {/* Starry Night background <3 */}

--- a/routes/what-is-this.tsx
+++ b/routes/what-is-this.tsx
@@ -13,8 +13,8 @@ export default function Home() {
         description="Tech stack used to create this website."
         link="https://www.theyurig.com/this"
       >
-        <link rel="stylesheet" href="/content.css" />
         <link rel="stylesheet" href="/navigation-buttons.css" />
+        <link rel="stylesheet" href="/content.css" />
         <link rel="stylesheet" href="/this.css" />
         <link rel="stylesheet" href="/gradient-underline.css" />
       </CustomHead>
@@ -45,7 +45,6 @@ export default function Home() {
               class="gradient-underline"
               href="/blog"
               target="_blank"
-              rel="noopener noreferrer"
             >
               thoughts
             </a>{" "}
@@ -54,7 +53,6 @@ export default function Home() {
               class="gradient-underline"
               href="/toys"
               target="_blank"
-              rel="noopener noreferrer"
             >
               creative expression
             </a>

--- a/static/animate.css
+++ b/static/animate.css
@@ -1,0 +1,37 @@
+/* Animate header items in sequence */
+.animate-to-left {
+    animation: 0.7s linear calc(var(--dur)*0.6s) to-left;
+    animation-fill-mode: both;
+}
+
+/* Start invisible right, fade in left */
+@keyframes to-left {
+    0% {
+        opacity: 0;
+        transform: translateX(3em);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+/* Animate menu items in sequence, after header items */
+.animate-to-right {
+    animation: 0.7s linear calc(var(--dur)*0.6s) to-right;
+    animation-fill-mode: both;
+}
+
+/* Start invisible left, fade in right */
+@keyframes to-right {
+    0% {
+        opacity: 0;
+        transform: translateX(-3em);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}

--- a/static/gradient-underline.css
+++ b/static/gradient-underline.css
@@ -1,18 +1,25 @@
 /* Creates the gradient underline */
 .gradient-underline {
-	/* The gradient won't display if the text spans several lines.
+    /* The gradient won't display if the text spans several lines.
         inline block ensures it's always in one line */
-	display: inline-block;
-	position: relative;
-	text-decoration: none;
+    display: inline-block;
+    position: relative;
+    text-decoration: none;
+    /* Animate smoothly to accent color on hover */
+    transition: color ease-in-out 0.5s;
+}
+
+/* Change text color to accent on hover */
+.gradient-underline:hover {
+    color: var(--accent-color);
 }
 
 /* Colors the gradient underline */
 .gradient-underline:before {
-	content: '';
-	position: absolute;
-	bottom: -0.05em;
-	width: 100%;
-	height: 3px;
-	background: linear-gradient(111.3deg, #9c27b0 9.6%, #00bcd4 93.6%);
+    content: '';
+    position: absolute;
+    bottom: -0.05em;
+    width: 100%;
+    height: 3px;
+    background: linear-gradient(111.3deg, #9c27b0 9.6%, #00bcd4 93.6%);
 }

--- a/static/home.css
+++ b/static/home.css
@@ -1,77 +1,81 @@
 /* Animates the emoji that displays when hovering over my Persona name,
     as if it was greeting the user */
 .wave-emoji {
-	display: none;
-	animation: wave 0.3s linear infinite alternate;
+    display: none;
+    animation: wave 0.3s linear infinite alternate;
 }
 
 /* Makes the wave emoji visible when hovering my Persona name */
-.gradient-underline:hover + .wave-emoji {
-	display: inline-block;
+.gradient-underline:hover+.wave-emoji {
+    display: inline-block;
 }
 
 /* Animates the wave emoji to wave */
 /* 15 -15 0 -5 */
 @keyframes wave {
-	0% {
-		transform: translate(10%, 0%) rotate(60deg);
-	}
-	100% {
-		transform: translate(-10%, 10%) rotate(0deg);
-	}
+    0% {
+        transform: translate(10%, 0%) rotate(60deg);
+    }
+
+    100% {
+        transform: translate(-10%, 10%) rotate(0deg);
+    }
 }
 
 /* Creates an initial dotted underline below the link to Trophy Place */
 .pretty-link {
-	text-underline-offset: 0.2em;
-	text-decoration: underline dotted var(--neutral-color) 0.1em;
-	transition: text-underline-offset 600ms, text-decoration 600ms, color 600ms;
+    text-underline-offset: 0.2em;
+    text-decoration: underline dotted var(--neutral-color) 0.1em;
+    transition: text-underline-offset 600ms, text-decoration 600ms, color 600ms;
 }
 
 /* Animates the link to Trophy Place on hover to change color,
     underline style and underline offset */
 .pretty-link:hover {
-	text-decoration: underline solid var(--accent-color) 0.1em;
-	color: var(--accent-color);
-	text-underline-offset: 0.3em;
+    text-decoration: underline solid var(--accent-color) 0.1em;
+    color: var(--accent-color);
+    text-underline-offset: 0.3em;
 }
 
 /* Creates a blinking caret after the website name */
 .blinking-caret {
-	color: var(--neutral-color);
-	fill: currentColor;
-	position: relative;
-	height: 1.2em;
-	left: 0.1em;
-	top: -0.1em;
-	animation: 1.5s blink step-end infinite;
+    color: var(--neutral-color);
+    fill: currentColor;
+    position: relative;
+    height: 1.2em;
+    left: 0.1em;
+    top: -0.1em;
+    animation: 1.5s blink step-end infinite;
 }
 
 /* Animates the blinking caret */
 @keyframes blink {
-	from,
-	to {
-		opacity: 0;
-	}
-	50% {
-		opacity: 1;
-	}
+
+    from,
+    to {
+        opacity: 0;
+    }
+
+    50% {
+        opacity: 1;
+    }
 }
 
 /* Set transitions for Navigation Menu links, space them out */
 .navigation-link {
-	transition: color 0.5s ease-in-out;
-	text-decoration-color: var(--neutral-color);
-	margin-bottom: 0.2em;
-	font-size: 3rem; /* 48px */
-	line-height: 1;
+    transition: color 0.5s ease-in-out;
+    text-decoration-color: var(--neutral-color);
+    margin-bottom: 0.2em;
+    font-size: 3rem;
+    /* 48px */
+    line-height: 1;
 }
 
 /* Assign color change and underline decoration on hover */
 .navigation-link:hover {
-	color: var(--accent-color);
-	text-decoration-line: underline;
-	text-decoration-skip-ink: none;
-	text-underline-offset: -0.2em;
-	text-decoration-thickness: 0.3em;
+    color: var(--accent-color);
+    text-decoration-line: underline;
+    text-decoration-skip-ink: none;
+    text-underline-offset: -0.2em;
+    text-decoration-thickness: 0.3em;
 }

--- a/static/starry-night.css
+++ b/static/starry-night.css
@@ -7,8 +7,8 @@
 .stars-wrapper {
     position: absolute;
     pointer-events: none;
-    width: 100vw;
-    height: 100vh;
+    width: 100dvw;
+    height: 100dvh;
     background: var(--base-color);
     overflow: hidden;
 }


### PR DESCRIPTION
Additionally, these changes are also bundled in this PR:
- Removed `rel` attribute for internal links.
- All links with the `gradient-underline` will now also have their text colored to `--accent-color` on `hover`.
- The first blog post had better links added to it and had their images added `title` and `alt` attributes.
- The home screen's Starry Night had a subtle change to dimensions to avoid allowing mobile users to useless scroll down.
- As mentioned in the PR title, text on the home will now animate on load. Text on the left will come from the right, and text on the right will come from the left. The Theme Switcher already had an animation for a few commits now and there is no plan to add an animation to the base footer.