### PR TITLE
feat: add /work and one page for related work completed

### DIFF
--- a/components/GradientLink.tsx
+++ b/components/GradientLink.tsx
@@ -1,0 +1,26 @@
+//? Define the required and optional properties of a Gradient Link
+interface GradientLinkProperties {
+  link: string;
+  title?: string;
+  newTab?: boolean;
+  customRel?: string;
+  content: string;
+}
+
+//? Exports an anchor tag with default styling for gradient-underline, while
+//? using the other attributes provided
+export function GradientLink(
+  { link, title, newTab = true, customRel, content }: GradientLinkProperties,
+) {
+  return (
+    <a
+      class="gradient-underline pretty-link"
+      href={link}
+      title={title}
+      target={newTab ? "_blank" : "_self"}
+      rel={customRel}
+    >
+      {content}
+    </a>
+  );
+}

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -8,17 +8,21 @@ import * as $1 from "./routes/[blog]/how-create-theme-switcher-deno-fresh.tsx";
 import * as $2 from "./routes/[blog]/stopping-theme-flickering-deno-fresh.tsx";
 import * as $3 from "./routes/[toys]/insanity.tsx";
 import * as $4 from "./routes/[toys]/spinners.tsx";
-import * as $5 from "./routes/_404.tsx";
-import * as $6 from "./routes/api/joke.ts";
-import * as $7 from "./routes/blog.tsx";
-import * as $8 from "./routes/index.tsx";
-import * as $9 from "./routes/me.tsx";
-import * as $10 from "./routes/toys.tsx";
-import * as $11 from "./routes/what-is-this.tsx";
+import * as $5 from "./routes/[work]/form.tsx";
+import * as $6 from "./routes/_404.tsx";
+import * as $7 from "./routes/api/joke.ts";
+import * as $8 from "./routes/blog.tsx";
+import * as $9 from "./routes/index.tsx";
+import * as $10 from "./routes/me.tsx";
+import * as $11 from "./routes/toys.tsx";
+import * as $12 from "./routes/what-is-this.tsx";
+import * as $13 from "./routes/work.tsx";
 import * as $$0 from "./islands/BlogNavigationButtons.tsx";
-import * as $$1 from "./islands/InsanitySection.tsx";
-import * as $$2 from "./islands/StyledButton.tsx";
-import * as $$3 from "./islands/ThemeSwitcher.tsx";
+import * as $$1 from "./islands/FormWithValidation.tsx";
+import * as $$2 from "./islands/InsanitySection.tsx";
+import * as $$3 from "./islands/StyledButton.tsx";
+import * as $$4 from "./islands/StyledInput.tsx";
+import * as $$5 from "./islands/ThemeSwitcher.tsx";
 
 const manifest = {
   routes: {
@@ -27,19 +31,23 @@ const manifest = {
     "./routes/[blog]/stopping-theme-flickering-deno-fresh.tsx": $2,
     "./routes/[toys]/insanity.tsx": $3,
     "./routes/[toys]/spinners.tsx": $4,
-    "./routes/_404.tsx": $5,
-    "./routes/api/joke.ts": $6,
-    "./routes/blog.tsx": $7,
-    "./routes/index.tsx": $8,
-    "./routes/me.tsx": $9,
-    "./routes/toys.tsx": $10,
-    "./routes/what-is-this.tsx": $11,
+    "./routes/[work]/form.tsx": $5,
+    "./routes/_404.tsx": $6,
+    "./routes/api/joke.ts": $7,
+    "./routes/blog.tsx": $8,
+    "./routes/index.tsx": $9,
+    "./routes/me.tsx": $10,
+    "./routes/toys.tsx": $11,
+    "./routes/what-is-this.tsx": $12,
+    "./routes/work.tsx": $13,
   },
   islands: {
     "./islands/BlogNavigationButtons.tsx": $$0,
-    "./islands/InsanitySection.tsx": $$1,
-    "./islands/StyledButton.tsx": $$2,
-    "./islands/ThemeSwitcher.tsx": $$3,
+    "./islands/FormWithValidation.tsx": $$1,
+    "./islands/InsanitySection.tsx": $$2,
+    "./islands/StyledButton.tsx": $$3,
+    "./islands/StyledInput.tsx": $$4,
+    "./islands/ThemeSwitcher.tsx": $$5,
   },
   baseUrl: import.meta.url,
   config,

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -39,7 +39,6 @@ export default function FormWithValidation() {
         <StyledInput
           key={"age"}
           inputType="number"
-          autoFocus={true}
           label="Age"
           name="age"
           value={formValues.age.toString()}
@@ -57,7 +56,6 @@ export default function FormWithValidation() {
         <StyledInput
           key={"profession"}
           inputType="text"
-          autoFocus={true}
           label="Profession"
           name="profession"
           value={formValues.profession}

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -35,6 +35,7 @@ export default function FormWithValidation() {
               name: inputName,
             }));
           }}
+          helpInformation="Validation: 3 to 40 alphabet characters (a-zA-Z)"
         />
         {/* Age number */}
         <StyledInput
@@ -52,6 +53,7 @@ export default function FormWithValidation() {
           }}
           min={18}
           max={100}
+          helpInformation="Validation: Number between 18 and 100 (18 < value < 100)"
         />
         {/* Profession input */}
         <StyledInput
@@ -67,6 +69,7 @@ export default function FormWithValidation() {
               profession: inputProfession,
             }));
           }}
+          helpInformation="Validation: 6 to 20 alphabet characters (a-zA-Z)"
         />
         {/* Confirm button (prints to text area) */}
         <StyledButton

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -28,7 +28,6 @@ export default function FormWithValidation() {
           label="Name"
           name="name"
           value={formValues.name}
-          placeholder=""
           inputFunction={(inputName) => {
             setValues((currentForm) => ({
               ...currentForm,
@@ -44,7 +43,6 @@ export default function FormWithValidation() {
           label="Age"
           name="age"
           value={formValues.age.toString()}
-          placeholder=""
           inputFunction={(inputAge) => {
             setValues((currentForm) => ({
               ...currentForm,
@@ -62,7 +60,6 @@ export default function FormWithValidation() {
           label="Profession"
           name="profession"
           value={formValues.profession}
-          placeholder=""
           inputFunction={(inputProfession) => {
             setValues((currentForm) => ({
               ...currentForm,

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -16,13 +16,25 @@ export default function FormWithValidation() {
   //? Handles textarea's content being populated when "Send" is clicked
   const [sumOfAllInputs, extendSum] = useState([] as Array<string>);
 
+  //? Placeholder text to be used on the textArea before any data got sent
+  const textAreaPlaceholder =
+    'Data will be displayed here as you click "Send".' +
+    "\n\nSome key insights for when building this:" +
+    "\n- When using other websites, it's very annoying when you tap into a " +
+    "field and tap out (without typing anything) and the field gives you a " +
+    "validation error. This form doesn't have that problem, it only " +
+    "attempts to validate the value if a value was actually provided." +
+    "\n- Regexes are very powerful. I use them to validate login/signup" +
+    " on Trophy Place, the form above and probably too many places that" +
+    " could probably just use a simple deep equality check";
+
   return (
     <>
       {/* The whole form */}
       <form class="styled-form">
         {/* Name input */}
         <StyledInput
-          key={"name"}
+          key={"first_input"}
           inputType="text"
           autoFocus={true}
           label="Name"
@@ -35,10 +47,11 @@ export default function FormWithValidation() {
             }));
           }}
           helpInformation="Validation: 3 to 40 alphabet characters (a-zA-Z)"
+          validationPattern="^[a-zA-Z]{3,40}$"
         />
         {/* Age number */}
         <StyledInput
-          key={"age"}
+          key={"second_input"}
           inputType="number"
           label="Age"
           name="age"
@@ -55,7 +68,7 @@ export default function FormWithValidation() {
         />
         {/* Profession input */}
         <StyledInput
-          key={"profession"}
+          key={"third_input"}
           inputType="text"
           label="Profession"
           name="profession"
@@ -66,6 +79,7 @@ export default function FormWithValidation() {
               profession: inputProfession,
             }));
           }}
+          validationPattern="^[a-zA-Z]{6,20}$"
           helpInformation="Validation: 6 to 20 alphabet characters (a-zA-Z)"
         />
         {/* Confirm button (prints to text area) */}
@@ -96,7 +110,7 @@ export default function FormWithValidation() {
         id="form"
         placeholder={sumOfAllInputs.length > 0
           ? sumOfAllInputs.join("\n")
-          : 'Data will be displayed here as you click "Send"'}
+          : textAreaPlaceholder}
         disabled
       >
       </textarea>

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -97,7 +97,9 @@ export default function FormWithValidation() {
         class="base-form-style styled-text-area"
         name="formInput"
         id="form"
-        placeholder={sumOfAllInputs.join("\n")}
+        placeholder={sumOfAllInputs.length > 0
+          ? sumOfAllInputs.join("\n")
+          : 'Data will be displayed here as you click "Send"'}
         disabled
       >
       </textarea>

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -2,17 +2,18 @@
 import { useState } from "preact/hooks";
 //? Responsive and styled Label + Input
 import StyledInput from "./StyledInput.tsx";
-//? Styled Button
+//? Styled Button to confirm sending the form
 import StyledButton from "./StyledButton.tsx";
 
 //? Creates a form that uses RegExp validation
 export default function FormWithValidation() {
+  //? Manages current state for form data
   const [formValues, setValues] = useState({
     name: "",
     age: 18,
     profession: "",
   });
-  //? Handles textarea's content
+  //? Handles textarea's content being populated when "Send" is clicked
   const [sumOfAllInputs, extendSum] = useState([] as Array<string>);
 
   return (
@@ -88,6 +89,7 @@ export default function FormWithValidation() {
           }}
         />
       </form>
+      {/* Text Area that will hold all sent information */}
       <textarea
         class="base-form-style styled-text-area"
         name="formInput"

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -1,0 +1,103 @@
+//? Import from Preact to be able to change state
+import { useState } from "preact/hooks";
+//? Responsive and styled Label + Input
+import StyledInput from "./StyledInput.tsx";
+//? Styled Button
+import StyledButton from "./StyledButton.tsx";
+
+//? Creates a form that uses RegExp validation
+export default function FormWithValidation() {
+  const [formValues, setValues] = useState({
+    name: "",
+    age: 18,
+    profession: "",
+  });
+  //? Handles textarea's content
+  const [sumOfAllInputs, extendSum] = useState([] as Array<string>);
+
+  return (
+    <>
+      {/* The whole form */}
+      <form class="styled-form">
+        {/* Name input */}
+        <StyledInput
+          key={"name"}
+          inputType="text"
+          autoFocus={true}
+          label="Name"
+          name="name"
+          value={formValues.name}
+          placeholder=""
+          inputFunction={(inputName) => {
+            setValues((currentForm) => ({
+              ...currentForm,
+              name: inputName,
+            }));
+          }}
+        />
+        {/* Age number */}
+        <StyledInput
+          key={"age"}
+          inputType="number"
+          autoFocus={true}
+          label="Age"
+          name="age"
+          value={formValues.age.toString()}
+          placeholder=""
+          inputFunction={(inputAge) => {
+            setValues((currentForm) => ({
+              ...currentForm,
+              age: Number(inputAge),
+            }));
+          }}
+          min={18}
+          max={100}
+        />
+        {/* Profession input */}
+        <StyledInput
+          key={"profession"}
+          inputType="text"
+          autoFocus={true}
+          label="Profession"
+          name="profession"
+          value={formValues.profession}
+          placeholder=""
+          inputFunction={(inputProfession) => {
+            setValues((currentForm) => ({
+              ...currentForm,
+              profession: inputProfession,
+            }));
+          }}
+        />
+        {/* Confirm button (prints to text area) */}
+        <StyledButton
+          text="Send"
+          style="margin-top: 0.5em;"
+          onClickFunction={() => {
+            setValues(() => ({
+              name: "",
+              age: 18,
+              profession: "",
+            }));
+            extendSum((
+              currentSum,
+            ) => [
+              ...currentSum,
+              `${
+                currentSum.length + 1
+              } - name: ${formValues.name}, age: ${formValues.age}, profession: ${formValues.profession}`,
+            ]);
+          }}
+        />
+      </form>
+      <textarea
+        class="base-form-style styled-text-area"
+        name="formInput"
+        id="form"
+        placeholder={sumOfAllInputs.join("\n")}
+        disabled
+      >
+      </textarea>
+    </>
+  );
+}

--- a/islands/StyledButton.tsx
+++ b/islands/StyledButton.tsx
@@ -1,3 +1,10 @@
+//? Define button properties
+interface ButtonProperties {
+  text: string;
+  style?: string;
+  onClickFunction?: () => void;
+}
+
 //? This file holds the content to the default button used
 //? throughout the application. It comes with default internal
 //? spacing (padding) and coloring, but has no default margins
@@ -6,13 +13,18 @@ export default function StyledButton({
   text,
   style,
   onClickFunction,
-}: {
-  text: string;
-  style?: string;
-  onClickFunction?: () => void;
-}) {
+}: ButtonProperties) {
   return (
-    <button class="styled-button" onClick={onClickFunction} style={style}>
+    <button
+      class="styled-button"
+      onClick={(event) => {
+        event.preventDefault();
+        if (onClickFunction) {
+          onClickFunction();
+        }
+      }}
+      style={style}
+    >
       {text}
     </button>
   );

--- a/islands/StyledInput.tsx
+++ b/islands/StyledInput.tsx
@@ -7,7 +7,7 @@ interface StyledInputProperties {
   placeholder: string;
   validationPattern?: string;
   value: string;
-  autoFocus: boolean;
+  autoFocus?: boolean;
   inputFunction: (input: string) => void;
   min?: number;
   max?: number;
@@ -25,7 +25,7 @@ export default function StyledInput(
     placeholder,
     validationPattern,
     value,
-    autoFocus = false,
+    autoFocus,
     inputFunction,
     min,
     max,

--- a/islands/StyledInput.tsx
+++ b/islands/StyledInput.tsx
@@ -11,6 +11,7 @@ interface StyledInputProperties {
   inputFunction: (input: string) => void;
   min?: number;
   max?: number;
+  helpInformation?: string;
 }
 
 //? Exports a styled combo of label + input
@@ -29,6 +30,7 @@ export default function StyledInput(
     inputFunction,
     min,
     max,
+    helpInformation,
   }: StyledInputProperties,
 ) {
   return (
@@ -37,25 +39,42 @@ export default function StyledInput(
         <label class="styled-label" htmlFor={name}>
           {label + " "}
         </label>
-        <input
-          key={key}
-          type={inputType}
-          class="base-form-style styled-input"
-          name={name}
-          placeholder={placeholder}
-          pattern={validationPattern}
-          value={value}
-          autofocus={autoFocus}
-          onInput={(e) => {
-            const { target } = e;
-            if (target) {
-              const changedValue = (target as HTMLInputElement).value;
-              inputFunction(changedValue);
-            }
-          }}
-          min={min}
-          max={max}
-        />
+        <div class="helper">
+          <input
+            key={key}
+            type={inputType}
+            class="base-form-style styled-input"
+            name={name}
+            placeholder={placeholder}
+            pattern={validationPattern}
+            value={value}
+            autofocus={autoFocus}
+            onInput={(e) => {
+              const { target } = e;
+              if (target) {
+                const changedValue = (target as HTMLInputElement).value;
+                inputFunction(changedValue);
+              }
+            }}
+            min={min}
+            max={max}
+          />
+          <div class="tooltip">
+            <svg
+              height="1.5em"
+              width="1.5em"
+              fill="currentColor"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 416.979 416.979"
+            >
+              <path d="M356.004,61.156c-81.37-81.47-213.377-81.551-294.848-0.182c-81.47,81.371-81.552,213.379-0.181,294.85 c81.369,81.47,213.378,81.551,294.849,0.181C437.293,274.636,437.375,142.626,356.004,61.156z M237.6,340.786 c0,3.217-2.607,5.822-5.822,5.822h-46.576c-3.215,0-5.822-2.605-5.822-5.822V167.885c0-3.217,2.607-5.822,5.822-5.822h46.576 c3.215,0,5.822,2.604,5.822,5.822V340.786z M208.49,137.901c-18.618,0-33.766-15.146-33.766-33.765 c0-18.617,15.147-33.766,33.766-33.766c18.619,0,33.766,15.148,33.766,33.766C242.256,122.755,227.107,137.901,208.49,137.901z">
+              </path>
+            </svg>
+            {helpInformation && (
+              <span class="tooltiptext">{helpInformation}</span>
+            )}
+          </div>
+        </div>
       </div>
     </>
   );

--- a/islands/StyledInput.tsx
+++ b/islands/StyledInput.tsx
@@ -4,7 +4,7 @@ interface StyledInputProperties {
   key: string;
   inputType: string;
   name: string;
-  placeholder: string;
+  placeholder?: string;
   validationPattern?: string;
   value: string;
   autoFocus?: boolean;

--- a/islands/StyledInput.tsx
+++ b/islands/StyledInput.tsx
@@ -1,0 +1,62 @@
+//? Define optional and required properties for inputs
+interface StyledInputProperties {
+  label: string;
+  key: string;
+  inputType: string;
+  name: string;
+  placeholder: string;
+  validationPattern?: string;
+  value: string;
+  autoFocus: boolean;
+  inputFunction: (input: string) => void;
+  min?: number;
+  max?: number;
+}
+
+//? Exports a styled combo of label + input
+//! Styling sheet form.css will organize in column on smaller
+//! resolutions and as row on larger resolutions
+export default function StyledInput(
+  {
+    label,
+    key,
+    inputType,
+    name,
+    placeholder,
+    validationPattern,
+    value,
+    autoFocus = false,
+    inputFunction,
+    min,
+    max,
+  }: StyledInputProperties,
+) {
+  return (
+    <>
+      <div class="label-wrapper">
+        <label class="styled-label" htmlFor={name}>
+          {label + " "}
+        </label>
+        <input
+          key={key}
+          type={inputType}
+          class="base-form-style styled-input"
+          name={name}
+          placeholder={placeholder}
+          pattern={validationPattern}
+          value={value}
+          autofocus={autoFocus}
+          onInput={(e) => {
+            const { target } = e;
+            if (target) {
+              const changedValue = (target as HTMLInputElement).value;
+              inputFunction(changedValue);
+            }
+          }}
+          min={min}
+          max={max}
+        />
+      </div>
+    </>
+  );
+}

--- a/routes/[blog]/how-create-theme-switcher-deno-fresh.tsx
+++ b/routes/[blog]/how-create-theme-switcher-deno-fresh.tsx
@@ -4,6 +4,8 @@ import { CustomHead } from "../../components/CustomHead.tsx";
 import { Base } from "../../components/Base.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import BlogNavigationButtons from "../../islands/BlogNavigationButtons.tsx";
+//? A HTML Link component to pre-format links and reduce boiletplate
+import { GradientLink } from "../../components/GradientLink.tsx";
 
 export default function Home() {
   return (
@@ -81,14 +83,12 @@ export default function Home() {
           />
           {/* Explaining what is Fresh */}
           <p class="space">
-            <a
-              class="gradient-underline pretty-link"
-              href="https://fresh.deno.dev/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Fresh
-            </a>{" "}
+            <GradientLink
+              link="https://fresh.deno.dev/"
+              title="It's dripping!"
+              content="Fresh"
+              customRel="noopener noreferrer"
+            />{" "}
             is the official framework to create web apps using Deno's Javascript
             runtime. It features no build step, zero-config, Typescript support
             out-of-the-box, JIT-rendering, and uses the Island design
@@ -96,23 +96,20 @@ export default function Home() {
             simple: Single Page Applications rely heavily on the client's
             devices to build the content of webpages and that creates overhead
             that impacts performance. Fresh, just like{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://remix.run/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Remix
-            </a>{" "}
+            <GradientLink
+              link="https://remix.run/"
+              title="The same, but different"
+              content="Remix"
+              customRel="noopener noreferrer"
+            />{" "}
             (and to some extent{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://nextjs.org/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Next.JS
-            </a>), aims to move all the rendering back to the server, serving
+            <GradientLink
+              link="https://nextjs.org/"
+              title="Probably the staple of building modern React apps by now"
+              content="NextJS"
+              customRel="noopener noreferrer"
+            />
+            ), aims to move all the rendering back to the server, serving
             exclusively static HTML pages, hydrating any interactivity only
             when/if necessary. While that's amazing for Lighthouse performance,
             it comes with its own sets of drawbacks (more on that in the next
@@ -123,24 +120,21 @@ export default function Home() {
             Fresh uses Preact under the hood to compile the JSX/TSX files into
             static HTML that is then sent to the client. If you have experience
             with{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://react.dev/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              React
-            </a>{" "}
+            <GradientLink
+              link="https://react.dev/"
+              title="React, the open sourced UI library by Meta"
+              content="React"
+              customRel="noopener noreferrer"
+            />{" "}
             or{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://www.solidjs.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Solid
-            </a>, you shouldn't have any trouble adapting, especially if you
-            have experience building Full Stack projects.
+            <GradientLink
+              link="https://www.solidjs.com/"
+              title="It's like React, but fun and doesn't offer nearly as many options to blow your feet out!"
+              content="Solid"
+              customRel="noopener noreferrer"
+            />
+            , you shouldn't have any trouble adapting, especially if you have
+            experience building Full Stack projects.
           </p>
           {/* Main content start */}
           <h2 class="subtopic">Creating A Theme Switcher</h2>
@@ -331,14 +325,12 @@ useEffect(() => {
           <p class="space">
             This website uses an improved version of the same Theme Switcher
             created in this post, which you can check the source code for{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://github.com/TheYuriG/deno-portfolio/blob/0051fc7369f714a7562d303f760e148efc753ea4/islands/ThemeSwitcher.tsx"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              right here
-            </a>.
+            <GradientLink
+              link="https://github.com/TheYuriG/deno-portfolio/blob/0051fc7369f714a7562d303f760e148efc753ea4/islands/ThemeSwitcher.tsx"
+              title="It's a trip down memory lane"
+              content="right here"
+              customRel="noopener noreferrer"
+            />.
           </p>
           {/* Conclusion and link to next post */}
           <h2 class="subtopic">What's next?</h2>
@@ -347,12 +339,13 @@ useEffect(() => {
             issues with it, like flickering on first load or the inability to
             check for user preferences. Let's address those problems on those on
             the{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="/blog/stopping-theme-flickering-deno-fresh"
-            >
-              next blog post
-            </a>.
+            <GradientLink
+              link="/blog/stopping-theme-flickering-deno-fresh"
+              title="Part 2 of this blog post. Please click, it has really good information!"
+              content="next blog post"
+              newTab={false}
+              customRel="next"
+            />.
           </p>
           {/* Post author */}
           <footer class="blog-footer" style="margin-top: auto;">

--- a/routes/[blog]/how-create-theme-switcher-deno-fresh.tsx
+++ b/routes/[blog]/how-create-theme-switcher-deno-fresh.tsx
@@ -253,74 +253,79 @@ useEffect(() => {
             </code>{" "}
             does, in order:
           </p>
-          {/* Explanation part 1 */}
-          <p>
-            1- Runs on start, checks if there is a theme saved (if not,{" "}
-            <code class="shj-lang-js">
-              savedTheme
-            </code>{" "}
-            will be{" "}
-            <code class="shj-lang-js">
-              null
-            </code>
-            ), and sets the current theme as the{" "}
-            <code class="shj-lang-js">
-              savedTheme
-            </code>
-            , if they are different, then stops (remember that{" "}
-            <code class="shj-lang-js">
-              useEffect()
-            </code>{" "}
-            is using the{" "}
-            <code class="shj-lang-js">
-              theme
-            </code>{" "}
-            as a dependency so not returning here would cause an infinite
-            loop!).
-          </p>
-          {/* Explanation part 2 */}
-          <p>
-            2- After setting the{" "}
-            <code class="shj-lang-js">
-              theme
-            </code>{" "}
-            equal to{" "}
-            <code class="shj-lang-js">
-              localStorage
-            </code>'s{" "}
-            <code class="shj-lang-js">
-              savedTheme
-            </code>{" "}
-            is the same as the{" "}
-            <code class="shj-lang-js">
-              theme
-            </code>
-            , it will skip the first{" "}
-            <code class="shj-lang-js">
-              if
-            </code>{" "}
-            check and negate the{" "}
-            <code class="shj-lang-js">
-              isInitialMount
-            </code>{" "}
-            value and stop.
-          </p>
-          {/* Explanation part 3 */}
-          <p>
-            3- (Optional) If the{" "}
-            <code class="shj-lang-js">
-              theme
-            </code>{" "}
-            is updated, it will skip both{" "}
-            <code class="shj-lang-js">
-              if
-            </code>{" "}
-            checks, save the theme to{" "}
-            <code class="shj-lang-js">
-              localStorage
-            </code>
-            , and applies it.
-          </p>
+          <ol
+            start={1}
+            style="align-self: start; list-style-type: lower-greek; margin: 1em 0;"
+          >
+            {/* Explanation part 1 */}
+            <li>
+              Runs on start, checks if there is a theme saved (if not,{" "}
+              <code class="shj-lang-js">
+                savedTheme
+              </code>{" "}
+              will be{" "}
+              <code class="shj-lang-js">
+                null
+              </code>
+              ), and sets the current theme as the{" "}
+              <code class="shj-lang-js">
+                savedTheme
+              </code>
+              , if they are different, then stops (remember that{" "}
+              <code class="shj-lang-js">
+                useEffect()
+              </code>{" "}
+              is using the{" "}
+              <code class="shj-lang-js">
+                theme
+              </code>{" "}
+              as a dependency so not returning here would cause an infinite
+              loop!).
+            </li>
+            {/* Explanation part 2 */}
+            <li>
+              After setting the{" "}
+              <code class="shj-lang-js">
+                theme
+              </code>{" "}
+              equal to{" "}
+              <code class="shj-lang-js">
+                localStorage
+              </code>'s{" "}
+              <code class="shj-lang-js">
+                savedTheme
+              </code>{" "}
+              is the same as the{" "}
+              <code class="shj-lang-js">
+                theme
+              </code>
+              , it will skip the first{" "}
+              <code class="shj-lang-js">
+                if
+              </code>{" "}
+              check and negate the{" "}
+              <code class="shj-lang-js">
+                isInitialMount
+              </code>{" "}
+              value and stop.
+            </li>
+            {/* Explanation part 3 */}
+            <li>
+              (Optional) If the{" "}
+              <code class="shj-lang-js">
+                theme
+              </code>{" "}
+              is updated, it will skip both{" "}
+              <code class="shj-lang-js">
+                if
+              </code>{" "}
+              checks, save the theme to{" "}
+              <code class="shj-lang-js">
+                localStorage
+              </code>
+              , and applies it.
+            </li>
+          </ol>
           {/* Linking to repository version */}
           <p class="space">
             This website uses an improved version of the same Theme Switcher

--- a/routes/[blog]/stopping-theme-flickering-deno-fresh.tsx
+++ b/routes/[blog]/stopping-theme-flickering-deno-fresh.tsx
@@ -4,6 +4,8 @@ import { CustomHead } from "../../components/CustomHead.tsx";
 import { Base } from "../../components/Base.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import BlogNavigationButtons from "../../islands/BlogNavigationButtons.tsx";
+//? A HTML Link component to pre-format links and reduce boiletplate
+import { GradientLink } from "../../components/GradientLink.tsx";
 
 export default function Home() {
   return (
@@ -60,13 +62,12 @@ export default function Home() {
           {/* Introduction */}
           <p class="space">
             In the{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="/blog/how-create-theme-switcher-deno-fresh"
-              target="_blank"
-            >
-              previous post
-            </a>
+            <GradientLink
+              link="/blog/how-create-theme-switcher-deno-fresh"
+              title="Part 1 of this blog post. You read that before, right...?"
+              content="previous post"
+              customRel="prev"
+            />
             , we built a simple Theme Switcher using Preact and Fresh on top of
             Deno. Two things were missing in that implementation we are going to
             fix both of them now:
@@ -88,14 +89,12 @@ export default function Home() {
           {/* Explaining topic */}
           <p class="space">
             The{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://www.patterns.dev/posts/islands-architecture"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Islands Architecture
-            </a>{" "}
+            <GradientLink
+              link="https://www.patterns.dev/posts/islands-architecture"
+              title="It's called like that because it's a lot of one thing with sprinkles of something else"
+              content="Islands Architecture"
+              customRel="noopener noreferrer"
+            />{" "}
             is a very interesting design pattern. You serve static HTML content
             (the "ocean") to the client's browser and only hydrate a little of
             Javascript (the "island") in specific portions of the User
@@ -111,33 +110,27 @@ export default function Home() {
           />
           <p class="space">
             Fresh wasn't the first to come up with this idea, mind you.{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://remix.run/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Remix
-            </a>{" "}
+            <GradientLink
+              link="https://remix.run/"
+              title="You should watch the 'Everything is a Remix' documentary on YouTube, it was a cornerstone of my Marketing graduation"
+              content="Remix"
+              customRel="noopener noreferrer"
+            />{" "}
             (from the same creators of{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://reactrouter.com/en/main/start/overview"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              React Router
-            </a>{" "}
+            <GradientLink
+              link="https://reactrouter.com/en/main/start/overview"
+              title="What if you could load a bunch of pages without leaving the first page? With React Router, you can!"
+              content="React Router"
+              customRel="noopener noreferrer"
+            />{" "}
             (!))had already started working on this in early 2022, they even
             tried to sell a license to use the framework, which{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://twitter.com/remix_run/status/1460652199269179393"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              didn't work well
-            </a>{" "}
+            <GradientLink
+              link="https://twitter.com/remix_run/status/1460652199269179393"
+              title="That was a certified 'ouchie!' moment"
+              content="didn't work well"
+              customRel="noopener noreferrer"
+            />{" "}
             for them.
           </p>
           {/* Further insight into the problem */}
@@ -184,14 +177,12 @@ export default function Home() {
             {" "}
             tags that you import on your project. Not knowing what you are doing
             can leave you (and your users) vulnerable to{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://en.wikipedia.org/wiki/Cross-site_scripting"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Cross Site Scripting
-            </a>{" "}
+            <GradientLink
+              link="https://en.wikipedia.org/wiki/Cross-site_scripting"
+              title="XSS is really, really bad"
+              content="Cross Site Scripting"
+              customRel="noopener noreferrer"
+            />{" "}
             attacks (XSS, for short). Make sure that you properly review any
             code that suggests using these and, if in doubt, don't use them in
             your project!
@@ -348,14 +339,12 @@ useEffect(() => {
             </code>{" "}
             and also never redirect, essentially turning your application into a
             SPA, making your users navigate through pages using{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://reactrouter.com/en/main/start/overview"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              React Router
-            </a>{" "}
+            <GradientLink
+              link="https://reactrouter.com/en/main/start/overview"
+              title="You are here, but then suddenly you are there"
+              content="React Router"
+              customRel="noopener noreferrer"
+            />{" "}
             instead. The drawback to this approach would be to have the theme
             reset on every visit, which would be annoying if people had to come
             back to your website regularly. If you are just creating a portfolio
@@ -364,14 +353,12 @@ useEffect(() => {
             pretty much unacceptable. This option also isn't really what Fresh
             is going for either, so at this point you might as well just use
             another framework entirely instead, maybe even going full{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://vercel.com/templates/next.js/nextjs-boilerplate"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              NextJS + React
-            </a>{" "}
+            <GradientLink
+              link="https://vercel.com/templates/next.js/nextjs-boilerplate"
+              title="Quickly start a new NextJS project in seconds"
+              content="NextJS + React"
+              customRel="noopener noreferrer"
+            />{" "}
             instead.
           </p>
           {/* Post author */}

--- a/routes/[blog]/stopping-theme-flickering-deno-fresh.tsx
+++ b/routes/[blog]/stopping-theme-flickering-deno-fresh.tsx
@@ -148,18 +148,20 @@ export default function Home() {
             It's possible that we can ship the required Javascript on every
             page, but in doing so, you need to understand the tradeoffs:
           </p>
-          <ol style="align-self: start;">
+          <ol
+            start={1}
+            style="align-self: start; list-style-type: lower-greek;"
+          >
             <li>
-              1 &#183; You introduce consistent overhead to every page load,
-              which will progressively worsen your Lighthouse page performance
-              score, the more you do it.
+              You introduce consistent overhead to every page load, which will
+              progressively worsen your Lighthouse page performance score, the
+              more you do it.
             </li>
             <li>
-              2 &#183; You are deviating from the main design choice for the
-              framework, which means that you will not find a lot of resources
-              to do things this way from this point onwards. If you have
-              questions, you will have to mostly figure something out by
-              yourself.
+              You are deviating from the main design choice for the framework,
+              which means that you will not find a lot of resources to do things
+              this way from this point onwards. If you have questions, you will
+              have to mostly figure something out by yourself.
             </li>
           </ol>
           <p class="space">
@@ -233,9 +235,12 @@ if (window.showDarkMode === true) {
 }`}
           </div>
           <p class="space">In order:</p>
-          <ol style="align-self: start;">
+          <ol
+            start={1}
+            style="align-self: start; list-style-type: lower-greek;"
+          >
             <li>
-              1 &#183; Check if there is a theme already saved on{" "}
+              Check if there is a theme already saved on{" "}
               <code class="shj-lang-js">localStorage</code>. If there isn't one,
               check what's the user preferred color scheme, save it, and set
               {" "}
@@ -247,8 +252,7 @@ if (window.showDarkMode === true) {
               on/off based on the saved theme.
             </li>
             <li>
-              2 &#183; Check window.showDarkMode and apply the colors to the
-              {" "}
+              Check window.showDarkMode and apply the colors to the{" "}
               <code class="shj-lang-js">root</code>{"  "}
               element for either mode based on that being{" "}
               <code class="shj-lang-js">

--- a/routes/[toys]/spinners.tsx
+++ b/routes/[toys]/spinners.tsx
@@ -2,6 +2,8 @@
 import { Base } from "../../components/Base.tsx";
 //? Import CustomHead with appropriate metadata
 import { CustomHead } from "../../components/CustomHead.tsx";
+//? A HTML Link component to pre-format links and reduce boiletplate
+import { GradientLink } from "../../components/GradientLink.tsx";
 //? Navigation Buttons to go back to the previous page or to the next article
 import BlogNavigationButtons from "../../islands/BlogNavigationButtons.tsx";
 
@@ -14,15 +16,17 @@ export default function Home() {
         link="https://www.theyurig.com/toys/spinners"
       >
         <link rel="stylesheet" href="/content.css" />
+        <link rel="stylesheet" href="/blog.css" />
         <link rel="stylesheet" href="/navigation-buttons.css" />
         <link rel="stylesheet" href="/spinners.css" />
+        <link rel="stylesheet" href="/gradient-underline.css" />
       </CustomHead>
       {/* Base page layout with theme switching and footer outside of accent box */}
       <Base>
         <BlogNavigationButtons />
-        <article>
+        <article class="center">
           <h1>Spinners</h1>
-          <p style="margin-bottom: 2em;">
+          <p class="space" style="margin: 0 auto;">
             Experimenting with translate3d (hover for information!)
           </p>
           <section style="flex: 1;">
@@ -129,21 +133,19 @@ export default function Home() {
           </section>
           <footer class="blog-footer" style="margin-top: 1em;">
             this experimentation helped me learn{" "}
-            <a
-              href="https://codepen.io/TheYuriG/pen/yLRQqmr?editors=1100"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <strong>this</strong>
-            </a>
+            <GradientLink
+              link="https://codepen.io/TheYuriG/pen/yLRQqmr?editors=1100"
+              title="The order of your transforms are important!"
+              content="this"
+              customRel="noopener noreferrer"
+            />
             . inspiration{" "}
-            <a
-              href="https://x.st/spinning-diagrams-with-css/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <strong>here</strong>.
-            </a>
+            <GradientLink
+              link="https://x.st/spinning-diagrams-with-css/"
+              title="Thank you, Harold Cooper, for your very detailed blog post about 'translate3d'!"
+              content="here"
+              customRel="noopener noreferrer"
+            />.
           </footer>
         </article>
       </Base>

--- a/routes/[work]/form.tsx
+++ b/routes/[work]/form.tsx
@@ -1,0 +1,35 @@
+//? Create blog content inside Base component
+import { Base } from "../../components/Base.tsx";
+//? Head component with all Meta tags pre-set
+import { CustomHead } from "../../components/CustomHead.tsx";
+//? Navigation Buttons to go back to the previous page or to the next article
+import BlogNavigationButtons from "../../islands/BlogNavigationButtons.tsx";
+//? Stylized and functional Form Island
+import FormWithValidation from "../../islands/FormWithValidation.tsx";
+
+export default function Home() {
+  return (
+    <>
+      <CustomHead
+        title="Form"
+        description="A form built with Preact. Alerts the window on submit."
+        link="https://www.theyurig.com/work/form"
+      >
+        <link rel="stylesheet" href="/navigation-buttons.css" />
+        <link rel="stylesheet" href="/content.css" />
+        <link rel="stylesheet" href="/blog.css" />
+        <link rel="stylesheet" href="/form.css" />
+        <link rel="stylesheet" href="/gradient-underline.css" />
+        <link rel="stylesheet" href="/styled-button.css" />
+      </CustomHead>
+      {/* Base page layout with theme switching and footer outside of accent box */}
+      <Base>
+        <BlogNavigationButtons />
+        <article class="center">
+          <h1 class="blog-title">Form (with validation)</h1>
+          <FormWithValidation />
+        </article>
+      </Base>
+    </>
+  );
+}

--- a/routes/me.tsx
+++ b/routes/me.tsx
@@ -2,6 +2,8 @@
 import { Base } from "../components/Base.tsx";
 //? Head component with all Meta tags pre-set
 import { CustomHead } from "../components/CustomHead.tsx";
+//? A HTML Link component to pre-format links and reduce boiletplate
+import { GradientLink } from "../components/GradientLink.tsx";
 //? Navigation Buttons to go back to the previous page or to the next article
 import BlogNavigationButtons from "../islands/BlogNavigationButtons.tsx";
 
@@ -26,27 +28,26 @@ export default function Home() {
           <img
             src="https://media.discordapp.net/attachments/576538316296421399/1111343977736712232/23112022-IMG_0537.jpg?width=884&height=554"
             alt="A picture of Yuri, in a very sandy vacation."
+            title="Inked them ankles"
             class="large-image"
           />
 
           <p class="space">
             I'm Yuri Gabriel, also known online as{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://github.com/TheYuriG"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              TheYuriG
-            </a>. I used to be a{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://trophy.place/user/TheYuriG"
-              target="_blank"
-            >
-              hardcore gamer
-            </a>, but now obsessed with writing code and creating pretty things
-            to look at and fun to use.
+            <GradientLink
+              link="https://github.com/TheYuriG"
+              content="TheYuriG"
+              title="Hi, this is me!"
+              customRel="noopener noreferrer"
+            />. I used to be a{" "}
+            <GradientLink
+              link="https://trophy.place/user/TheYuriG"
+              content="hardcore gamer"
+              title="My 'retired' gaming profile"
+              customRel="external"
+            />
+            , but now obsessed with writing code and creating pretty things to
+            look at and fun to use.
           </p>
           <p class="space">
             For some good portion of the most last decade, I was using the
@@ -65,24 +66,19 @@ export default function Home() {
           <p class="space">
             I'm an absolute gym rat. It's part of my routine to write code and
             {" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://youtu.be/4UlgXIL0-3g?t=10"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              lift heavy ass circles
-            </a>
+            <GradientLink
+              link="https://youtu.be/4UlgXIL0-3g?t=10"
+              content="lift heavy ass circles"
+              title="Ronnie Coleman, the Greatest Of All Time"
+              customRel="noopener noreferrer"
+            />
             , almost every single day. Rest days are really important... for
             people settling to{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://youtu.be/PNO2yxuzm04?t=76"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              be smaller
-            </a>{" "}
+            <GradientLink
+              link="https://youtu.be/PNO2yxuzm04?t=76"
+              content="be smaller"
+              customRel="noopener noreferrer"
+            />{" "}
             than they could be.
           </p>
           <p class="space">
@@ -101,14 +97,11 @@ export default function Home() {
             assume you are going through extreme survival scenarios and more
             muscle is needed for increased odds at your survival. It's just that
             simple. When in doubt, simply{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://www.youtube.com/watch?v=bGhBbpObA7s"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              go jim now
-            </a>!
+            <GradientLink
+              link="https://www.youtube.com/watch?v=bGhBbpObA7s"
+              content="we go jim"
+              customRel="noopener noreferrer"
+            />!
           </p>
 
           <h2 class="subtopic">Programming</h2>
@@ -121,14 +114,12 @@ export default function Home() {
             After not really getting anywhere with it, in March 2018 I decided
             that if no one was willing to create a Discord bot for trophy
             hunting, then I was going to need to{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://www.youtube.com/watch?v=EzWNBmjyv7Y"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              do it myself
-            </a>. And so I did, I learned how to write Javascript and started
+            <GradientLink
+              link="https://www.youtube.com/watch?v=EzWNBmjyv7Y"
+              content="do it myself"
+              title="Just like Thanos"
+              customRel="noopener noreferrer"
+            />. And so I did, I learned how to write Javascript and started
             Yura.
           </p>
           <img
@@ -151,14 +142,12 @@ export default function Home() {
           <h2 class="subtopic">Trophy Place</h2>
           <p class="space">
             Myself and{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://github.com/Makowo"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Makowo
-            </a>{" "}
+            <GradientLink
+              link="https://github.com/Makowo"
+              content="Makowo"
+              title="Professional Payday 2 modder and ModWorkshop moderator"
+              customRel="noopener noreferrer"
+            />{" "}
             decided to start our own trophy hunting website that would end up
             addressing the majority of the community requests and complaints.
             After all, who knows better what the trophy hunting community wants,
@@ -167,53 +156,43 @@ export default function Home() {
           <p class="space">
             Since I've already had some experience building the backend, I chose
             to manage all of the infrastructure for{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://trophy.place/"
-              target="_blank"
-            >
-              Trophy Place
-            </a>{" "}
+            <GradientLink
+              link="https://trophy.place/"
+              content="Trophy Place"
+              title="Where we build greatness 😊"
+              customRel="external"
+            />{" "}
             while Makowo was responsible for the frontend.
           </p>
           <p class="space">
             Our chosen tech stack is{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://vuejs.org/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Vue 3
-            </a>{" "}
+            <GradientLink
+              link="https://vuejs.org/"
+              content="Vue 3"
+              title="It means 'View' in french and 'Delight' in software development"
+              customRel="noopener noreferrer"
+            />{" "}
             +{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://nuxt.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Nuxt 3
-            </a>{" "}
+            <GradientLink
+              link="https://nuxt.com/"
+              content="Nuxt 3"
+              customRel="noopener noreferrer"
+            />{" "}
             for the frontend, with{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://expressjs.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Express
-            </a>{" "}
+            <GradientLink
+              link="https://expressjs.com/"
+              content="Express"
+              title="Express is basically the backbone of NodeJS development."
+              customRel="noopener noreferrer"
+            />{" "}
             for the backend for our MVP. Once we go into actual production, I'll
             rewrite the backend using{" "}
-            <a
-              class="gradient-underline pretty-link"
-              href="https://github.com/oakserver/oak"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Oak
-            </a>{" "}
+            <GradientLink
+              link="https://github.com/oakserver/oak"
+              content="Oak"
+              title="It's like Koa, but for Deno"
+              customRel="noopener noreferrer"
+            />{" "}
             so that I can write exclusively Typescript code.
           </p>
         </article>

--- a/routes/work.tsx
+++ b/routes/work.tsx
@@ -1,0 +1,51 @@
+//? Create blog content inside Base component
+import { Base } from "../components/Base.tsx";
+//? Head component with all Meta tags pre-set
+import { CustomHead } from "../components/CustomHead.tsx";
+//? Navigation Buttons to go back to the previous page or to the next article
+import BlogNavigationButtons from "../islands/BlogNavigationButtons.tsx";
+//? A HTML Link component to pre-format links and reduce boiletplate
+import { GradientLink } from "../components/GradientLink.tsx";
+
+export default function Home() {
+  return (
+    <>
+      <CustomHead
+        title="Previous work"
+        description="Work that I've done for people in the past."
+        link="https://www.theyurig.com/work"
+      >
+        <link rel="stylesheet" href="/navigation-buttons.css" />
+        <link rel="stylesheet" href="/content.css" />
+        <link rel="stylesheet" href="/blog.css" />
+        <link rel="stylesheet" href="/gradient-underline.css" />
+      </CustomHead>
+      {/* Base page layout with theme switching and footer outside of accent box */}
+      <Base>
+        <BlogNavigationButtons />
+        <article class="center">
+          <h1 class="blog-title">Past and Current work</h1>
+          <p class="space">
+            There is nothing to display here yet. I'm still deciding if I'll
+            rewrite my projects in Deno or if I'll just host them somewhere and
+            link here. Maybe come back at a later point? 🤔
+          </p>
+          <p class="space">Meanwhile, here are some smaller snippets:</p>
+          <ol
+            start={1}
+            style="align-self: start; list-style-type: lower-greek;"
+          >
+            <li>
+              <GradientLink
+                content="Form"
+                title="A simple form that uses Alert() once you submit it."
+                link="/work/form"
+                newTab={false}
+              />
+            </li>
+          </ol>
+        </article>
+      </Base>
+    </>
+  );
+}

--- a/static/form.css
+++ b/static/form.css
@@ -29,6 +29,14 @@ div.label-wrapper {
     width: max-content;
 }
 
+/*  */
+div.helper {
+    display: flex;
+    align-items: center;
+    /* flex-grow: 1; */
+    width: 100%;
+}
+
 /* Style the input to take the remainder space */
 .styled-input {
     caret-color: var(--accent-color);
@@ -42,6 +50,38 @@ div.label-wrapper {
     color: var(--neutral-color);
 }
 
+/* Tooltip container */
+div.tooltip {
+    position: relative;
+    display: inline-block;
+}
+
+/* Tooltip text */
+div.tooltip span.tooltiptext {
+    visibility: hidden;
+    opacity: 0;
+    width: max-content;
+    background-color: var(--accent-color);
+    color: var(--neutral-color);
+    text-align: center;
+    font-weight: 600;
+    padding: 0.5em;
+    border-radius: 0.3em;
+    position: absolute;
+    /* positions the tooltip at bottom left of icon */
+    right: 0;
+    top: 2em;
+    z-index: 1;
+    transition: opacity 0.4s ease-in-out, color 0.9s ease-in-out;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+div.tooltip:hover span.tooltiptext {
+    visibility: visible;
+    opacity: 1;
+}
+
+/* Style the disabled text-area that holds the submitted dummy data */
 .styled-text-area {
     min-height: 10em;
     flex-grow: 1;

--- a/static/form.css
+++ b/static/form.css
@@ -1,3 +1,4 @@
+/* Base styling applied to most form components */
 .base-form-style {
     width: 100%;
     padding: 0.5em;
@@ -6,6 +7,7 @@
     border-radius: 1em;
 }
 
+/* Styles applied to the form that holds the inputs and the button */
 .styled-form {
     width: 100%;
     margin-bottom: 1em;
@@ -13,23 +15,29 @@
     flex-direction: column;
 }
 
+/* Style the div that holds the label+input combo */
 div.label-wrapper {
     display: flex;
+    flex-grow: 1;
     align-items: center;
-    width: 100%;
+    justify-items: center;
     flex-direction: column;
 }
 
+/* Style the label to never shrink */
 .styled-label {
     width: max-content;
 }
 
+/* Style the input to take the remainder space */
 .styled-input {
     caret-color: var(--accent-color);
-    margin: 0.25em 0em;
+    margin: 0.25em 0.5em;
     flex-grow: 1;
+    transition: background-color 0.8s ease-in-out, color 0.9s ease-in-out;
 }
 
+/* Change the color of the placeholder text */
 .styled-input::placeholder {
     color: var(--neutral-color);
 }
@@ -40,14 +48,13 @@ div.label-wrapper {
     width: 100%;
     border: 2px solid var(--accent-color);
     border-radius: 1em;
+    transition: background-color 0.8s ease-in-out, color 0.9s ease-in-out;
 }
 
+/* Use a media query to move the label to the side of the input on larger resolutions */
 @media (min-width: 600px) {
     div.label-wrapper {
         flex-direction: row;
-    }
-
-    .styled-label {
-        margin-right: 0.5em;
+        margin-left: 0em;
     }
 }

--- a/static/form.css
+++ b/static/form.css
@@ -1,0 +1,53 @@
+.base-form-style {
+    width: 100%;
+    padding: 0.5em;
+    background-color: var(--base-color);
+    border: 2px solid var(--accent-color);
+    border-radius: 1em;
+}
+
+.styled-form {
+    width: 100%;
+    margin-bottom: 1em;
+    display: flex;
+    flex-direction: column;
+}
+
+div.label-wrapper {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    flex-direction: column;
+}
+
+.styled-label {
+    width: max-content;
+}
+
+.styled-input {
+    caret-color: var(--accent-color);
+    margin: 0.25em 0em;
+    flex-grow: 1;
+}
+
+.styled-input::placeholder {
+    color: var(--neutral-color);
+}
+
+.styled-text-area {
+    min-height: 10em;
+    flex-grow: 1;
+    width: 100%;
+    border: 2px solid var(--accent-color);
+    border-radius: 1em;
+}
+
+@media (min-width: 600px) {
+    div.label-wrapper {
+        flex-direction: row;
+    }
+
+    .styled-label {
+        margin-right: 0.5em;
+    }
+}

--- a/static/form.css
+++ b/static/form.css
@@ -45,10 +45,6 @@ div.helper {
     transition: background-color 0.8s ease-in-out, color 0.9s ease-in-out;
 }
 
-/* Change the color of the placeholder text */
-.styled-input::placeholder {
-    color: var(--neutral-color);
-}
 
 /* Tooltip container */
 div.tooltip {
@@ -89,6 +85,12 @@ div.tooltip:hover span.tooltiptext {
     border: 2px solid var(--accent-color);
     border-radius: 1em;
     transition: background-color 0.8s ease-in-out, color 0.9s ease-in-out;
+}
+
+/* Change the color of the placeholder texts */
+.styled-text-area::placeholder,
+.styled-input::placeholder {
+    color: var(--neutral-color);
 }
 
 /* Use a media query to move the label to the side of the input on larger resolutions */

--- a/static/form.css
+++ b/static/form.css
@@ -45,6 +45,15 @@ div.helper {
     transition: background-color 0.8s ease-in-out, color 0.9s ease-in-out;
 }
 
+/* Change border color on invalid input value */
+.invalid-input {
+    border-color: red;
+}
+
+/* Change border color on valid input value */
+.valid-input {
+    border-color: green;
+}
 
 /* Tooltip container */
 div.tooltip {

--- a/static/styled-button.css
+++ b/static/styled-button.css
@@ -1,22 +1,22 @@
 /* Style, space and animate default styled button */
 .styled-button {
-	display: flex;
-	align-self: center;
-	color: var(--neutral-color);
-	background-color: var(--base-color);
-	box-shadow: 0.1em 0.2em var(--accent-color);
-	border: 0.15em solid var(--neutral-color);
-	text-shadow: 0.05em 0.05em 0 var(--accent-color);
-	transition: color 0.4s, box-shadow 0.4s, border 0.4s, text-shadow 0.4s;
-	border-radius: 0.5rem;
-	padding: 0.3rem 0.6rem;
+    display: flex;
+    align-self: center;
+    color: var(--neutral-color);
+    background-color: var(--base-color);
+    box-shadow: 0.1em 0.2em var(--accent-color);
+    border: 0.15em solid var(--neutral-color);
+    text-shadow: 0.05em 0.05em 0 var(--accent-color);
+    transition: background-color 0.8s ease-in-out, color 0.9s, box-shadow 0.4s, border 0.8s, text-shadow 0.4s;
+    border-radius: 0.5rem;
+    padding: 0.3rem 0.6rem;
 }
 
 /* Inverse colorset when button is hovered */
 .styled-button:hover {
-	color: var(--accent-color);
-	background-color: var(--base-color);
-	box-shadow: 0.1em 0.2em var(--neutral-color);
-	border: 0.15em solid var(--accent-color);
-	text-shadow: 0.05em 0.05em 0 var(--neutral-color);
+    color: var(--accent-color);
+    background-color: var(--base-color);
+    box-shadow: 0.1em 0.2em var(--neutral-color);
+    border: 0.15em solid var(--accent-color);
+    text-shadow: 0.05em 0.05em 0 var(--neutral-color);
 }


### PR DESCRIPTION
Creates an index page for `/work` and another for `/work/form` for a small practice of how forms should look like.
The form page currently has responsiveness but lacks a few features that I intend to tackle in the next PR.

Additionally, this PR also delivers these updates:
- Gradient links are now an individual component. The 2 blog posts have been moved to use them as well.
- Lists now use Greek ordering. (related issue: it overflows the border on smaller resolutions. Add left margin to fix).
- `StyledButton` will now preventDefault() and has a defined property.

Closes #25.