### PR TITLE
feat: add radio and checkboxes to /work/form

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -22,8 +22,9 @@ import * as $$1 from "./islands/FormWithValidation.tsx";
 import * as $$2 from "./islands/InsanitySection.tsx";
 import * as $$3 from "./islands/StyledButton.tsx";
 import * as $$4 from "./islands/StyledInput.tsx";
-import * as $$5 from "./islands/StyledSelect.tsx";
-import * as $$6 from "./islands/ThemeSwitcher.tsx";
+import * as $$5 from "./islands/StyledRadio.tsx";
+import * as $$6 from "./islands/StyledSelect.tsx";
+import * as $$7 from "./islands/ThemeSwitcher.tsx";
 
 const manifest = {
   routes: {
@@ -48,8 +49,9 @@ const manifest = {
     "./islands/InsanitySection.tsx": $$2,
     "./islands/StyledButton.tsx": $$3,
     "./islands/StyledInput.tsx": $$4,
-    "./islands/StyledSelect.tsx": $$5,
-    "./islands/ThemeSwitcher.tsx": $$6,
+    "./islands/StyledRadio.tsx": $$5,
+    "./islands/StyledSelect.tsx": $$6,
+    "./islands/ThemeSwitcher.tsx": $$7,
   },
   baseUrl: import.meta.url,
   config,

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -21,10 +21,11 @@ import * as $$0 from "./islands/BlogNavigationButtons.tsx";
 import * as $$1 from "./islands/FormWithValidation.tsx";
 import * as $$2 from "./islands/InsanitySection.tsx";
 import * as $$3 from "./islands/StyledButton.tsx";
-import * as $$4 from "./islands/StyledInput.tsx";
-import * as $$5 from "./islands/StyledRadio.tsx";
-import * as $$6 from "./islands/StyledSelect.tsx";
-import * as $$7 from "./islands/ThemeSwitcher.tsx";
+import * as $$4 from "./islands/StyledCheckbox.tsx";
+import * as $$5 from "./islands/StyledInput.tsx";
+import * as $$6 from "./islands/StyledRadio.tsx";
+import * as $$7 from "./islands/StyledSelect.tsx";
+import * as $$8 from "./islands/ThemeSwitcher.tsx";
 
 const manifest = {
   routes: {
@@ -48,10 +49,11 @@ const manifest = {
     "./islands/FormWithValidation.tsx": $$1,
     "./islands/InsanitySection.tsx": $$2,
     "./islands/StyledButton.tsx": $$3,
-    "./islands/StyledInput.tsx": $$4,
-    "./islands/StyledRadio.tsx": $$5,
-    "./islands/StyledSelect.tsx": $$6,
-    "./islands/ThemeSwitcher.tsx": $$7,
+    "./islands/StyledCheckbox.tsx": $$4,
+    "./islands/StyledInput.tsx": $$5,
+    "./islands/StyledRadio.tsx": $$6,
+    "./islands/StyledSelect.tsx": $$7,
+    "./islands/ThemeSwitcher.tsx": $$8,
   },
   baseUrl: import.meta.url,
   config,

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -11,8 +11,9 @@ import StyledRadio from "./StyledRadio.tsx";
 //? Styled checkbox for Stimulus Check option
 import StyledCheckbox from "./StyledCheckbox.tsx";
 
-//? Validation values for typecasting
+//? Types for typecasting
 import { validationStatus } from "../types/validationStatus.ts";
+import type { stimulusCheckboxOptions } from "../types/stimulusCheckboxOptions.ts";
 
 //? Validates the form's name input field
 const validateName = (
@@ -103,23 +104,28 @@ const selectDropdownOptions = [
   "Retired",
 ];
 const radioOptions = ["None", "Once", "Twice or More"];
-const checkboxOptions = [
-  "Individual ($1000)",
-  "Family ($2000)",
-  "Business ($10000)",
-];
+const checkboxOptions: Array<{ value: stimulusCheckboxOptions; name: string }> =
+  [
+    { value: "individual", name: "Individual ($1000)" },
+    { value: "family", name: "Family ($2000)" },
+    { value: "business", name: "Business ($10000)" },
+  ];
 const defaultFormValues = {
   name: "",
   age: 18,
   profession: "",
   employment: selectDropdownOptions[0],
   welfare: radioOptions[0],
+  //? Check properties must match stimulusCheckboxOptions' values property
+  //! Record<stimulusCheckboxOptions, boolean>
+  check: { individual: false, family: false, business: false },
 };
 const defaultFormValidation = {
   name: validationStatus.Unchanged,
   age: validationStatus.Unchanged,
   profession: validationStatus.Unchanged,
   employment: validationStatus.Unchanged,
+  check: validationStatus.Unchanged,
 };
 
 //? Creates a form that uses RegExp validation
@@ -228,7 +234,15 @@ export default function FormWithValidation() {
         //? Adds "number - name: name, age: age, profession: profession, employment: employment, welfare: welfare"
         `${
           currentSum.length + 1
-        } - name: ${formValues.name}, age: ${formValues.age}, profession: ${formValues.profession}, employment status: ${formValues.employment}, times on welfare: ${formValues.welfare}`,
+        } - name: ${formValues.name}, age: ${formValues.age}, profession: ${formValues.profession}, employment status: ${formValues.employment}, times on welfare: ${formValues.welfare}, checks desired: ${
+          //? Gets all properties, filters to only the ones selected as true
+          // {1: true, 2: false, 3: true}
+          Object.entries(formValues.check).filter((check) => check[1] === true) // [[1,true],[3,true]]
+            //? Return property names
+            .map((check) => check[0]) // [1,3]
+            //? Join property names with forward slash
+            .join("/") // 1/3
+        }`,
       ]);
     }
   }
@@ -361,14 +375,21 @@ export default function FormWithValidation() {
         />
         {/* Styled checkbox */}
         <StyledCheckbox
-          label="Stimulus Check pack"
-          onChangeFunction={(newWelfareValue) => {
-            setValues((currentFormValues) => ({
-              ...currentFormValues,
-              welfare: newWelfareValue,
-            }));
-          }}
+          label="Stimulus Check desired"
           optionsArray={checkboxOptions}
+          onChangeFunction={(
+            checkName: stimulusCheckboxOptions,
+          ) => {
+            setValues((currentFormValues) => {
+              const editedValues = {
+                ...currentFormValues,
+                check: { ...currentFormValues.check },
+              };
+              editedValues.check[checkName] = !editedValues.check[checkName];
+              console.log("editedValues:", editedValues);
+              return editedValues;
+            });
+          }}
         />
         {/* Confirm button (prints to text area) */}
         <StyledButton

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -9,6 +9,7 @@ import StyledSelect from "./StyledSelect.tsx";
 
 //? Validation values for typecasting
 import { validationStatus } from "../types/validationStatus.ts";
+import StyledRadio from "./StyledRadio.tsx";
 
 //? Validates the form's name input field
 const validateName = (
@@ -132,7 +133,7 @@ export default function FormWithValidation() {
 
     updateValidation((currentValidationStatus) => ({
       ...currentValidationStatus,
-      age: 1,
+      age: validationStatus.Valid,
     }));
 
     //? If the name is empty or invalid, increase errors counter
@@ -334,6 +335,13 @@ export default function FormWithValidation() {
               }));
             }
           }}
+        />
+        {/* Styled radio */}
+        <StyledRadio
+          label="Times on Welfare"
+          name="aa"
+          onChangeFunction={() => {}}
+          optionsArray={["None", "Once", "Twice or More"]}
         />
         {/* Confirm button (prints to text area) */}
         <StyledButton

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -99,11 +99,13 @@ const selectDropdownOptions = [
   "Employed",
   "Retired",
 ];
+const radioOptions = ["None", "Once", "Twice or More"];
 const defaultFormValues = {
   name: "",
   age: 18,
   profession: "",
   employment: selectDropdownOptions[0],
+  welfare: radioOptions[0],
 };
 const defaultFormValidation = {
   name: validationStatus.Unchanged,
@@ -215,10 +217,10 @@ export default function FormWithValidation() {
         currentSum,
       ) => [
         ...currentSum,
-        //? Adds "number - name: name, age: age, profession: profession"
+        //? Adds "number - name: name, age: age, profession: profession, employment: employment, welfare: welfare"
         `${
           currentSum.length + 1
-        } - name: ${formValues.name}, age: ${formValues.age}, profession: ${formValues.profession}, employment status: ${formValues.employment}`,
+        } - name: ${formValues.name}, age: ${formValues.age}, profession: ${formValues.profession}, employment status: ${formValues.employment}, times on welfare: ${formValues.welfare}`,
       ]);
     }
   }
@@ -339,9 +341,15 @@ export default function FormWithValidation() {
         {/* Styled radio */}
         <StyledRadio
           label="Times on Welfare"
-          name="aa"
-          onChangeFunction={() => {}}
-          optionsArray={["None", "Once", "Twice or More"]}
+          name="welfare"
+          starterValue={formValues.welfare}
+          onChangeFunction={(newWelfareValue) => {
+            setValues((currentFormValues) => ({
+              ...currentFormValues,
+              welfare: newWelfareValue,
+            }));
+          }}
+          optionsArray={radioOptions}
         />
         {/* Confirm button (prints to text area) */}
         <StyledButton

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -6,10 +6,13 @@ import StyledInput from "./StyledInput.tsx";
 import StyledButton from "./StyledButton.tsx";
 //? Styled Select for Employment Status dropdown
 import StyledSelect from "./StyledSelect.tsx";
+//? Styled radio for Welfare option
+import StyledRadio from "./StyledRadio.tsx";
+//? Styled checkbox for Stimulus Check option
+import StyledCheckbox from "./StyledCheckbox.tsx";
 
 //? Validation values for typecasting
 import { validationStatus } from "../types/validationStatus.ts";
-import StyledRadio from "./StyledRadio.tsx";
 
 //? Validates the form's name input field
 const validateName = (
@@ -100,6 +103,11 @@ const selectDropdownOptions = [
   "Retired",
 ];
 const radioOptions = ["None", "Once", "Twice or More"];
+const checkboxOptions = [
+  "Individual ($1000)",
+  "Family ($2000)",
+  "Business ($10000)",
+];
 const defaultFormValues = {
   name: "",
   age: 18,
@@ -350,6 +358,17 @@ export default function FormWithValidation() {
             }));
           }}
           optionsArray={radioOptions}
+        />
+        {/* Styled checkbox */}
+        <StyledCheckbox
+          label="Stimulus Check pack"
+          onChangeFunction={(newWelfareValue) => {
+            setValues((currentFormValues) => ({
+              ...currentFormValues,
+              welfare: newWelfareValue,
+            }));
+          }}
+          optionsArray={checkboxOptions}
         />
         {/* Confirm button (prints to text area) */}
         <StyledButton

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -125,6 +125,7 @@ const defaultFormValidation = {
   age: validationStatus.Unchanged,
   profession: validationStatus.Unchanged,
   employment: validationStatus.Unchanged,
+  welfare: validationStatus.Unchanged,
   check: validationStatus.Unchanged,
 };
 
@@ -205,12 +206,23 @@ export default function FormWithValidation() {
         age: validationStatus.Invalid,
       }));
     }
-    //? If the age is invalid, increase errors counter
+    //? If the employment status is invalid, increase errors counter
     if (formValues.employment === defaultFormValues.employment) {
       validationErrors++;
       updateValidation((currentValidationStatus) => ({
         ...currentValidationStatus,
         employment: validationStatus.Invalid,
+      }));
+    }
+    //? If no stimulus checks were chosen, increase errors counter
+    if (
+      Object.values(formValues.check).filter((status) => status !== false)
+        .length === 0
+    ) {
+      validationErrors++;
+      updateValidation((currentValidationStatus) => ({
+        ...currentValidationStatus,
+        check: validationStatus.Invalid,
       }));
     }
 
@@ -377,6 +389,9 @@ export default function FormWithValidation() {
         <StyledCheckbox
           label="Stimulus Check desired"
           optionsArray={checkboxOptions}
+          stateForCheckedReference={formValues.check}
+          validationReference={formValidationStatus
+            .check as validationStatus}
           onChangeFunction={(
             checkName: stimulusCheckboxOptions,
           ) => {

--- a/islands/StyledCheckbox.tsx
+++ b/islands/StyledCheckbox.tsx
@@ -1,5 +1,7 @@
 //? Types for typecasting
 import { stimulusCheckboxOptions } from "../types/stimulusCheckboxOptions.ts";
+//? Validation values for typecasting
+import { validationStatus } from "../types/validationStatus.ts";
 
 //? Every checkbox item needs to have a name and an associated
 //? value to enable changing its state
@@ -11,7 +13,10 @@ type CheckboxItem = {
 //? Properties required to build a Checkbox input
 interface CheckboxProperties {
   label: string;
+  //? Tracks the validation reference state for this input
+  validationReference: validationStatus;
   optionsArray: Array<CheckboxItem>;
+  stateForCheckedReference: Record<string, boolean>;
   onChangeFunction: (name: stimulusCheckboxOptions) => void;
 }
 
@@ -19,6 +24,8 @@ interface CheckboxProperties {
 export default function StyledCheckbox({
   label,
   optionsArray,
+  validationReference,
+  stateForCheckedReference,
   onChangeFunction,
 }: CheckboxProperties) {
   return (
@@ -26,7 +33,14 @@ export default function StyledCheckbox({
       <span class="radio-label">
         {label}
       </span>
-      <div class="base-form-style radio-input-group">
+      <div
+        class={"base-form-style radio-input-group" +
+          (
+            validationReference === validationStatus.Invalid
+              ? " invalid-input"
+              : ""
+          )}
+      >
         {/* Programatically creates radio inputs from array of strings provided */}
         {optionsArray.map(({ value, name }: CheckboxItem) => (
           <>
@@ -35,6 +49,7 @@ export default function StyledCheckbox({
               <input
                 class="styled-checkbox"
                 type="checkbox"
+                checked={stateForCheckedReference[value] === true}
                 //? Updates state when an option is clicked
                 onClick={() => {
                   onChangeFunction(value as stimulusCheckboxOptions);

--- a/islands/StyledCheckbox.tsx
+++ b/islands/StyledCheckbox.tsx
@@ -1,0 +1,48 @@
+//? Properties required to build a Checkbox input
+interface CheckboxProperties {
+  label: string;
+  optionsArray: Array<string>;
+  onChangeFunction: (value: string) => void;
+}
+
+//? Exports a styled select with label and options
+export default function StyledCheckbox({
+  label,
+  optionsArray,
+  onChangeFunction,
+}: CheckboxProperties) {
+  return (
+    <div class="radio-label-inputs-group">
+      <span class="radio-label">
+        {label}
+      </span>
+      <div className="radio-input-group">
+        {/* Programatically creates radio inputs from array of strings provided */}
+        {optionsArray.map((checkbox) => (
+          <>
+            <label class="styled-label">
+              {/* Checkbox */}
+              <input
+                class="styled-checkbox"
+                type="checkbox"
+                //? Tracks current value
+                value={checkbox}
+                //? Updates state when an option is clicked
+                onChange={(e) => {
+                  const { target } = e;
+                  if (target) {
+                    const changedValue = (target as HTMLInputElement).value;
+                    onChangeFunction(changedValue);
+                  }
+                }}
+              >
+              </input>
+              {/* Label for what this is for */}
+              {checkbox}
+            </label>
+          </>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/islands/StyledCheckbox.tsx
+++ b/islands/StyledCheckbox.tsx
@@ -26,7 +26,7 @@ export default function StyledCheckbox({
       <span class="radio-label">
         {label}
       </span>
-      <div className="radio-input-group">
+      <div class="base-form-style radio-input-group">
         {/* Programatically creates radio inputs from array of strings provided */}
         {optionsArray.map(({ value, name }: CheckboxItem) => (
           <>

--- a/islands/StyledCheckbox.tsx
+++ b/islands/StyledCheckbox.tsx
@@ -1,8 +1,18 @@
+//? Types for typecasting
+import { stimulusCheckboxOptions } from "../types/stimulusCheckboxOptions.ts";
+
+//? Every checkbox item needs to have a name and an associated
+//? value to enable changing its state
+type CheckboxItem = {
+  name: string;
+  value: string;
+};
+
 //? Properties required to build a Checkbox input
 interface CheckboxProperties {
   label: string;
-  optionsArray: Array<string>;
-  onChangeFunction: (value: string) => void;
+  optionsArray: Array<CheckboxItem>;
+  onChangeFunction: (name: stimulusCheckboxOptions) => void;
 }
 
 //? Exports a styled select with label and options
@@ -18,27 +28,21 @@ export default function StyledCheckbox({
       </span>
       <div className="radio-input-group">
         {/* Programatically creates radio inputs from array of strings provided */}
-        {optionsArray.map((checkbox) => (
+        {optionsArray.map(({ value, name }: CheckboxItem) => (
           <>
             <label class="styled-label">
               {/* Checkbox */}
               <input
                 class="styled-checkbox"
                 type="checkbox"
-                //? Tracks current value
-                value={checkbox}
                 //? Updates state when an option is clicked
-                onChange={(e) => {
-                  const { target } = e;
-                  if (target) {
-                    const changedValue = (target as HTMLInputElement).value;
-                    onChangeFunction(changedValue);
-                  }
+                onClick={() => {
+                  onChangeFunction(value as stimulusCheckboxOptions);
                 }}
               >
               </input>
               {/* Label for what this is for */}
-              {checkbox}
+              {name}
             </label>
           </>
         ))}

--- a/islands/StyledRadio.tsx
+++ b/islands/StyledRadio.tsx
@@ -1,15 +1,17 @@
 //? Properties required to build a Radio input
 interface RadioProperties {
-  name: string;
   label: string;
+  name: string;
+  starterValue: string;
   optionsArray: Array<string>;
   onChangeFunction: (value: string) => void;
 }
 
 //? Exports a styled select with label and options
 export default function StyledRadio({
-  name,
   label,
+  name,
+  starterValue,
   optionsArray,
   onChangeFunction,
 }: RadioProperties) {
@@ -28,14 +30,14 @@ export default function StyledRadio({
               <input
                 class="styled-radio"
                 type="radio"
-                name={name} //? Links to label
+                name={name} //? Links all radio options together
                 value={radio} //? Tracks current value
-                //? Updates state when an option is inputed
+                checked={radio === starterValue} //? Track if this option should be checked
+                //? Updates state when an option is clicked
                 onChange={(e) => {
                   const { target } = e;
                   if (target) {
                     const changedValue = (target as HTMLInputElement).value;
-                    console.log(changedValue);
                     onChangeFunction(changedValue);
                   }
                 }}

--- a/islands/StyledRadio.tsx
+++ b/islands/StyledRadio.tsx
@@ -1,0 +1,51 @@
+//? Properties required to build a Radio input
+interface RadioProperties {
+  name: string;
+  label: string;
+  optionsArray: Array<string>;
+  onChangeFunction: (value: string) => void;
+}
+
+//? Exports a styled select with label and options
+export default function StyledRadio({
+  name,
+  label,
+  optionsArray,
+  onChangeFunction,
+}: RadioProperties) {
+  return (
+    <div class="radio-label-inputs-group">
+      <span class="radio-label">
+        {label}
+      </span>
+      <div className="radio-input-group">
+        {/* Programatically creates radio inputs from array of strings provided */}
+        {optionsArray.map((radio) => (
+          <>
+            {/* Label for what this is for */}
+            <label class="styled-label">
+              {/* Radio */}
+              <input
+                class="styled-radio"
+                type="radio"
+                name={name} //? Links to label
+                value={radio} //? Tracks current value
+                //? Updates state when an option is inputed
+                onChange={(e) => {
+                  const { target } = e;
+                  if (target) {
+                    const changedValue = (target as HTMLInputElement).value;
+                    console.log(changedValue);
+                    onChangeFunction(changedValue);
+                  }
+                }}
+              >
+              </input>
+              {radio}
+            </label>
+          </>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/islands/StyledRadio.tsx
+++ b/islands/StyledRadio.tsx
@@ -20,7 +20,7 @@ export default function StyledRadio({
       <span class="radio-label">
         {label}
       </span>
-      <div className="radio-input-group">
+      <div class="base-form-style radio-input-group">
         {/* Programatically creates radio inputs from array of strings provided */}
         {optionsArray.map((radio) => (
           <>

--- a/routes/[work]/form.tsx
+++ b/routes/[work]/form.tsx
@@ -12,7 +12,7 @@ export default function Home() {
     <>
       <CustomHead
         title="Form"
-        description="A form built with Preact. Alerts the window on submit."
+        description="A form to pretend to request Stimulus Check built with Preact."
         link="https://www.theyurig.com/work/form"
       >
         <link rel="stylesheet" href="/navigation-buttons.css" />
@@ -26,7 +26,9 @@ export default function Home() {
       <Base>
         <BlogNavigationButtons />
         <article class="center">
-          <h1 class="blog-title">Form (with validation)</h1>
+          <h1 class="blog-title">
+            Stimulus Checks Eligibility Form
+          </h1>
           <FormWithValidation />
         </article>
       </Base>

--- a/routes/work.tsx
+++ b/routes/work.tsx
@@ -37,7 +37,7 @@ export default function Home() {
           >
             <li>
               <GradientLink
-                content="Form"
+                content="Form (with validation)"
                 title="A simple form that uses Alert() once you submit it."
                 link="/work/form"
                 newTab={false}

--- a/static/form.css
+++ b/static/form.css
@@ -111,6 +111,7 @@ div.tooltip:hover span.tooltiptext {
 
 /* Name for group of radio inputs */
 .radio-label-inputs-group {
+    margin: 0.5em 0;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -130,7 +131,8 @@ div.tooltip:hover span.tooltiptext {
 }
 
 /* Styles the radio to use customized balls for toggles */
-input[type="radio"] {
+input[type="radio"],
+input[type="checkbox"] {
     /* Remove default selection circle */
     -webkit-appearance: none;
     appearance: none;
@@ -140,48 +142,67 @@ input[type="radio"] {
     margin: 0;
     font: inherit;
     color: currentColor;
+    /* Sizing */
     width: 0.9em;
     height: 0.9em;
+    /* Outline for checker */
     border: 0.15em solid currentColor;
-    border-radius: 50%;
+    /* Border radius for checkbox, radio gets overriden below */
+    border-radius: 0.2em;
+    /* Push right the label text */
     margin-right: 0.5em;
-    /* Move the circle a little down */
+    /* Push down the checker */
     transform: translateY(0.3em);
-    /* Enable the radio check icon to be centered inside the circle */
+    /* Enable the radio check icon to be centered inside the checker */
     display: grid;
     place-content: center;
 }
 
-/* Create positioning for the 'checked' ball */
-input[type="radio"]::before {
+/* Create positioning for the checker, common to radio and checkbox */
+input[type="radio"]::before,
+input[type="checkbox"]::before {
     content: "";
-    width: 0.4em;
-    height: 0.4em;
-    border-radius: 50%;
+    width: 0.5em;
+    height: 0.5em;
     transform: scale(0);
-    transition: 120ms transform ease-in-out;
+    transition: 0.2s transform ease-in-out;
     /* Inner colored ball for whenever checked */
     box-shadow: inset 1em 1em var(--accent-color);
 }
 
-/* Grow the inner ball when checked */
-input[type="radio"]:checked::before {
+/* Turn the checker into a ball for radio inputs only */
+input[type="radio"],
+input[type="radio"]::before {
+    border-radius: 50%;
+}
+
+/* Turns the checkbox checker into a confirmation */
+input[type="checkbox"]::before {
+    transform-origin: bottom left;
+    clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+}
+
+/* Grow the inner ball/confirmation when checked */
+input[type="radio"]:checked::before,
+input[type="checkbox"]:checked::before {
     transform: scale(1);
 }
 
-/* Puts a circle around the clicked radio input */
-input[type="radio"]:focus {
+/* Puts an outline around the clicked radio/checkbox input */
+input[type="radio"]:focus,
+input[type="checkbox"]:focus {
     outline: max(2px, 0.15em) solid var(--accent-color);
     outline-offset: max(2px, 0.15em);
 }
 
-/* Pushes the radio input label a little to the side */
+/* Pushes the input+label to the right */
 .radio-input-group .styled-label {
     margin-left: 1em;
 }
 
 /* Styles radio inputs */
-.styled-radio {
+.styled-radio,
+.styled-checkbox {
     margin: 0.5em 0.25em;
 }
 
@@ -217,20 +238,25 @@ input[type="radio"]:focus {
 
 /* Use a media query to move the label to the side of the input on larger resolutions */
 @media (min-width: 600px) {
+
+    /* Turns input box labels into rows */
     div.label-wrapper {
         flex-direction: row;
         margin-left: 0em;
     }
 
+    /* Spaces left and right on the input fields */
+    .styled-input {
+        margin: 0.25em 0.5em;
+    }
+
+    /* Spaces left and right on the select dropdown */
     .styled-select {
         margin: 0.25em 0em 0.25em 0.5em;
         width: calc(100% - 0.5em);
     }
 
-    .styled-input {
-        margin: 0.25em 0.5em;
-    }
-
+    /* Turns radio/checkbox and overlaying label into a row */
     .radio-label-inputs-group {
         flex-direction: row;
     }

--- a/static/form.css
+++ b/static/form.css
@@ -26,6 +26,9 @@ div.label-wrapper {
 
 /* Style the label to never shrink */
 .styled-label {
+    /* Needed to make the radio buttons stay in a row */
+    display: flex;
+    flex-direction: row;
     width: max-content;
     white-space: nowrap;
 }
@@ -106,6 +109,82 @@ div.tooltip:hover span.tooltiptext {
     opacity: 1;
 }
 
+/* Name for group of radio inputs */
+.radio-label-inputs-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+}
+
+/* Label for radio input */
+.radio-label {
+    width: max-content;
+}
+
+/* Collection of radio inputs and labels */
+.radio-input-group {
+    display: flex;
+    flex-grow: 1;
+    flex-wrap: wrap;
+}
+
+/* Styles the radio to use customized balls for toggles */
+input[type="radio"] {
+    /* Remove default selection circle */
+    -webkit-appearance: none;
+    appearance: none;
+    /* For iOS < 15 to remove gradient background */
+    background-color: var(--base-color);
+    /* Not removed via appearance */
+    margin: 0;
+    font: inherit;
+    color: currentColor;
+    width: 0.9em;
+    height: 0.9em;
+    border: 0.15em solid currentColor;
+    border-radius: 50%;
+    margin-right: 0.5em;
+    /* Move the circle a little down */
+    transform: translateY(0.3em);
+    /* Enable the radio check icon to be centered inside the circle */
+    display: grid;
+    place-content: center;
+}
+
+/* Create positioning for the 'checked' ball */
+input[type="radio"]::before {
+    content: "";
+    width: 0.4em;
+    height: 0.4em;
+    border-radius: 50%;
+    transform: scale(0);
+    transition: 120ms transform ease-in-out;
+    /* Inner colored ball for whenever checked */
+    box-shadow: inset 1em 1em var(--accent-color);
+}
+
+/* Grow the inner ball when checked */
+input[type="radio"]:checked::before {
+    transform: scale(1);
+}
+
+/* Puts a circle around the clicked radio input */
+input[type="radio"]:focus {
+    outline: max(2px, 0.15em) solid currentColor;
+    outline-offset: max(2px, 0.15em);
+}
+
+/* Pushes the radio input label a little to the side */
+.radio-input-group .styled-label {
+    margin-left: 1em;
+}
+
+/* Styles radio inputs */
+.styled-radio {
+    margin: 0.5em 0.25em;
+}
+
 /* Style the disabled text-area that holds the submitted dummy data */
 .styled-text-area {
     min-height: 10em;
@@ -122,11 +201,12 @@ div.tooltip:hover span.tooltiptext {
     color: var(--neutral-color);
 }
 
-/* TextArea scrollbar styling */
+/* TextArea scrollbar area size */
 .styled-text-area::-webkit-scrollbar {
     width: 0.8em;
 }
 
+/* TextArea scrollbar styling */
 .styled-text-area::-webkit-scrollbar-thumb {
     background-color: var(--base-color);
     overflow: hidden;
@@ -149,5 +229,9 @@ div.tooltip:hover span.tooltiptext {
 
     .styled-input {
         margin: 0.25em 0.5em;
+    }
+
+    .radio-label-inputs-group {
+        flex-direction: row;
     }
 }

--- a/static/form.css
+++ b/static/form.css
@@ -111,23 +111,25 @@ div.tooltip:hover span.tooltiptext {
 
 /* Name for group of radio inputs */
 .radio-label-inputs-group {
-    margin: 0.5em 0;
+    margin: 0.25em 0;
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 100%;
 }
 
 /* Label for radio input */
 .radio-label {
     width: max-content;
+    flex-shrink: 0;
 }
 
 /* Collection of radio inputs and labels */
 .radio-input-group {
     display: flex;
-    flex-grow: 1;
+    flex-direction: column;
+    width: min-content;
     flex-wrap: wrap;
+    place-content: center;
 }
 
 /* Styles the radio to use customized balls for toggles */
@@ -195,11 +197,6 @@ input[type="checkbox"]:focus {
     outline-offset: max(2px, 0.15em);
 }
 
-/* Pushes the input+label to the right */
-.radio-input-group .styled-label {
-    margin-left: 1em;
-}
-
 /* Styles radio inputs */
 .styled-radio,
 .styled-checkbox {
@@ -257,7 +254,20 @@ input[type="checkbox"]:focus {
     }
 
     /* Turns radio/checkbox and overlaying label into a row */
-    .radio-label-inputs-group {
+    .radio-label-inputs-group,
+    .radio-input-group {
         flex-direction: row;
+    }
+
+
+    .radio-input-group {
+        margin-left: 1em;
+        width: fit-content;
+    }
+
+    /* Pushes the input+label to the right */
+    .radio-input-group .styled-label {
+        margin-right: 0.5em;
+        margin-left: 0.5em;
     }
 }

--- a/static/form.css
+++ b/static/form.css
@@ -171,7 +171,7 @@ input[type="radio"]:checked::before {
 
 /* Puts a circle around the clicked radio input */
 input[type="radio"]:focus {
-    outline: max(2px, 0.15em) solid currentColor;
+    outline: max(2px, 0.15em) solid var(--accent-color);
     outline-offset: max(2px, 0.15em);
 }
 

--- a/types/stimulusCheckboxOptions.ts
+++ b/types/stimulusCheckboxOptions.ts
@@ -1,0 +1,3 @@
+//? Enums for locking in possible stimulus checkbox options
+export type stimulusCheckboxOptions =
+    "individual" | "family" | "business"


### PR DESCRIPTION
Now the form has custom-made text, number, radio and checkbox inputs, plus a select dropdown menu. It's essentially done for what most forms required and the validation is done without external libraries, although if this was for a real product, I would validate on the backend using Zod instead of writing custom logic and reinventing the wheel.

Closes #35.