### PR TITLE
fix: home viewport won't stretch while animating

### DIFF
--- a/components/HomeContent.tsx
+++ b/components/HomeContent.tsx
@@ -2,11 +2,11 @@ export function HomeContent() {
   return (
     <>
       {/* Greeting */}
-      <h1 class="inline-block text-4xl animate-to-left" style="--dur: 0">
+      <h1 class="inline-block text-4xl animate-to-top" style="--dur: 0">
         Hello!
       </h1>
       {/* Name */}
-      <p class="block text-2xl ml-4 animate-to-left" style="--dur: 1">
+      <p class="block text-2xl ml-4 animate-to-top" style="--dur: 1">
         I am{" "}
         <strong>
           <span class="gradient-underline">TheYuriG</span>
@@ -14,11 +14,11 @@ export function HomeContent() {
         </strong>
       </p>
       {/* Skillset */}
-      <p class="block text-2xl ml-8 animate-to-left" style="--dur: 2">
+      <p class="block text-2xl ml-8 animate-to-top" style="--dur: 2">
         Sky afficionado, gym rat, full stack developer
       </p>
       {/* Role */}
-      <p class="block ml-12 animate-to-left" style="--dur: 3">
+      <p class="block ml-12 animate-to-top" style="--dur: 3">
         Currently building greatness at{" "}
         <a href="https://trophy.place" target="_blank" class="pretty-link">
           Trophy Place

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -26,7 +26,6 @@ export default function Home() {
       <StarryNight />
       {/* Base page layout with theme switching and footer outside of accent box */}
       <Base>
-        <div style="background-color: var(--base-color);"></div>
         {/* Content with greeting, name, workplace */}
         <HomeContent />
         {/* Navigation menu to other routes */}

--- a/static/animate.css
+++ b/static/animate.css
@@ -1,19 +1,19 @@
 /* Animate header items in sequence */
-.animate-to-left {
-    animation: 0.5s linear calc(var(--dur)*0.2s) to-left;
+.animate-to-top {
+    animation: 0.6s ease-in-out calc(var(--dur)*0.3s) to-top;
     animation-fill-mode: both;
 }
 
-/* Start invisible right, fade in left */
-@keyframes to-left {
+/* Start invisible right, fade in top */
+@keyframes to-top {
     0% {
         opacity: 0;
-        transform: translateX(3em);
+        transform: translateY(5em);
     }
 
     100% {
         opacity: 1;
-        transform: translateX(0);
+        transform: translateY(0);
     }
 }
 

--- a/static/animate.css
+++ b/static/animate.css
@@ -1,6 +1,6 @@
 /* Animate header items in sequence */
 .animate-to-left {
-    animation: 0.5s linear calc(var(--dur)*0.4s) to-left;
+    animation: 0.5s linear calc(var(--dur)*0.2s) to-left;
     animation-fill-mode: both;
 }
 
@@ -19,7 +19,7 @@
 
 /* Animate menu items in sequence, after header items */
 .animate-to-right {
-    animation: 0.5s linear calc(var(--dur)*0.4s) to-right;
+    animation: 0.5s linear calc(var(--dur)*0.2s) to-right;
     animation-fill-mode: both;
 }
 

--- a/static/base.css
+++ b/static/base.css
@@ -14,7 +14,6 @@ body::-webkit-scrollbar-thumb {
 
 /* Expand page to use full screen and set page default font and color scheme */
 html {
-    max-height: fit-content;
     font-family: 'Fragment Mono', monospace;
     background-color: var(--base-color);
     color: var(--neutral-color);
@@ -36,20 +35,17 @@ main {
 
 /* Position the theme switcher on the bottom left corner */
 aside {
-    height: 1em;
     width: 5em;
     height: min-content;
     position: fixed;
     bottom: 3.2em;
     rotate: -90deg;
-    translate: -78%;
-    font-size: 1.25rem;
-    line-height: 1em;
+    translate: -75%;
+    font-size: 1.2rem;
 }
 
 /* Define theme SVG size, push text away */
 aside svg {
-    height: 1em;
     width: 1em;
     margin-right: 0.2em;
 }
@@ -57,7 +53,6 @@ aside svg {
 /* Organize theme button horizontally and align vertically */
 .theme-switcher {
     display: flex;
-    flex-direction: row;
     text-justify: center;
     animation: fadeThemeSwitcherIn 0.3s;
 }


### PR DESCRIPTION
Fixed a bug with animation using translateX() causing the viewport to stretch while animating.

Additionally, this PR accomplishes the following:
- Hastened Home animations. It was annoying to wait for them to finish before being able to click any of the menu options. Now it's fast enough that you don't have to wait a whole lot.
- Changed the animation of the main text to animate from below, changed respective animation and class names.
- Removed a dead div in the Home.
- Focus border for the Theme Switcher is now a consistent rectangle. Also removed dead, overridden and duplicated properties.

Closes #41.