### PR TITLE
refactor: created .card CSS class for reused styles

### DIFF
--- a/components/expenses-tracker/ExpensesChart.tsx
+++ b/components/expenses-tracker/ExpensesChart.tsx
@@ -14,6 +14,7 @@ interface ExpenseChartProperties {
 export default function ExpenseChart(
   { year, expenses }: ExpenseChartProperties,
 ) {
+  //? Create an expense object for every month
   const monthExpenses = [
     { label: "Jan", cost: 0 },
     { label: "Feb", cost: 0 },
@@ -29,11 +30,14 @@ export default function ExpenseChart(
     { label: "Dez", cost: 0 },
   ];
 
+  //? Cycle through all expenses received and
+  //? assign them to the appropriate months
   for (const expense of expenses) {
     const monthNumber = new Date(expense.date).getMonth();
     monthExpenses[monthNumber].cost += expense.cost;
   }
 
+  //? Calculate how much was spent through the entire year
   const yearTotalCost = monthExpenses.reduce(
     (oldValue, currentValue) => oldValue + currentValue.cost,
     0,

--- a/components/expenses-tracker/ExpensesChartMonthBar.tsx
+++ b/components/expenses-tracker/ExpensesChartMonthBar.tsx
@@ -12,9 +12,10 @@ export default function ExpensesChartMonthBar(
   //? Using the month's expenses and the year's expenses,
   //? calculate how much this given month expenses were
   //? in comparison to the whole year
-  const percentageOfYearExpenses =
-    Math.round((cost / maxCost) * 100).toString() +
-    "%";
+  const percentageOfYearExpenses = maxCost === 0
+    ? "0%" // If the whole month has no expenses, set the percentage to 0%
+    : Math.round((cost / maxCost) * 100).toString() +
+      "%";
 
   //? Render the expense bar for the given month
   return (

--- a/components/expenses-tracker/IndividualExpense.tsx
+++ b/components/expenses-tracker/IndividualExpense.tsx
@@ -15,7 +15,7 @@ export function IndividualExpense(
   return (
     <>
       {/* The entire Expense */}
-      <div class="single-expense">
+      <div class="card card-shadow single-expense">
         {/* Expense Date */}
         <ExpenseDate date={date} />
         {/* Expense Description */}

--- a/import_map.json
+++ b/import_map.json
@@ -3,6 +3,10 @@
     "$fresh/": "https://deno.land/x/fresh@1.1.5/",
     "preact": "https://esm.sh/preact@10.13.1",
     "preact/": "https://esm.sh/preact@10.13.1/",
-    "twind": "https://esm.sh/twind@0.16.19"
+    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@5.2.6",
+    "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
+    "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.2.3",
+    "twind": "https://esm.sh/twind@0.16.19",
+    "twind/": "https://esm.sh/twind@0.16.19/"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -3,10 +3,6 @@
     "$fresh/": "https://deno.land/x/fresh@1.1.5/",
     "preact": "https://esm.sh/preact@10.13.1",
     "preact/": "https://esm.sh/preact@10.13.1/",
-    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@5.2.6",
-    "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
-    "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.2.3",
-    "twind": "https://esm.sh/twind@0.16.19",
-    "twind/": "https://esm.sh/twind@0.16.19/"
+    "twind": "https://esm.sh/twind@0.16.19"
   }
 }

--- a/islands/AddNewExpense.tsx
+++ b/islands/AddNewExpense.tsx
@@ -343,7 +343,7 @@ export default function AddNewExpenseForm(
   );
 
   return (
-    <div class="add-new-expense">
+    <div class="card card-shadow">
       {
         /* If the user never clicked to display the form or cancelled the form,
         show the button that prompts to display the form */

--- a/islands/ExpensesTracker.tsx
+++ b/islands/ExpensesTracker.tsx
@@ -28,7 +28,7 @@ export default function ExpensesTracker(
 
   return (
     <div style="width: 100%;">
-      <div class="year-expenses">
+      <div class="card card-shadow year-expenses">
         {/* Displays bars for  */}
         <ExpenseChart year={expensesYear} expenses={expenses} />
         <ExpensesYearSelect

--- a/routes/[projects]/expenses-tracker.tsx
+++ b/routes/[projects]/expenses-tracker.tsx
@@ -44,7 +44,6 @@ export default function Home(
         link="https://www.theyurig.com/projects/expenses-tracker"
       >
         <link rel="stylesheet" href="/content.css" />
-        <link rel="stylesheet" href="/blog.css" />
         <link rel="stylesheet" href="/navigation-buttons.css" />
         <link rel="stylesheet" href="/expenses-tracker.css" />
         <link rel="stylesheet" href="/form.css" />

--- a/routes/[projects]/expenses-tracker.tsx
+++ b/routes/[projects]/expenses-tracker.tsx
@@ -64,7 +64,7 @@ export default function Home(
               // second paragraph
               "I learned some theorical things which might be useful when dealing with" +
               " legacy codebases, like how React (the course's focus) can render components " +
-              "by nesting React.render(component, properties, child1, child2, child3, ...," +
+              "by nesting React.createElement(component, properties, child1, child2, child3, ...," +
               " childN) and this is the way that it was done before JSX.",
               // third paragraph
               "It makes sense why everything is a component, otherwise it would get really " +

--- a/routes/[toys]/spinners.tsx
+++ b/routes/[toys]/spinners.tsx
@@ -16,7 +16,6 @@ export default function Home() {
         link="https://www.theyurig.com/toys/spinners"
       >
         <link rel="stylesheet" href="/content.css" />
-        <link rel="stylesheet" href="/blog.css" />
         <link rel="stylesheet" href="/navigation-buttons.css" />
         <link rel="stylesheet" href="/spinners.css" />
         <link rel="stylesheet" href="/gradient-underline.css" />
@@ -133,7 +132,7 @@ export default function Home() {
             </div>
             <div id="spacer-top" style="flex: 1;"></div>
           </section>
-          <footer class="blog-footer" style="margin-top: 1em;">
+          <footer style="margin-top: 1em; align-self: end;">
             this experimentation helped me learn{" "}
             <GradientLink
               link="https://codepen.io/TheYuriG/pen/yLRQqmr?editors=1100"

--- a/routes/[work]/form.tsx
+++ b/routes/[work]/form.tsx
@@ -17,7 +17,6 @@ export default function Home() {
       >
         <link rel="stylesheet" href="/navigation-buttons.css" />
         <link rel="stylesheet" href="/content.css" />
-        <link rel="stylesheet" href="/blog.css" />
         <link rel="stylesheet" href="/form.css" />
         <link rel="stylesheet" href="/gradient-underline.css" />
         <link rel="stylesheet" href="/styled-button.css" />

--- a/routes/_404.tsx
+++ b/routes/_404.tsx
@@ -19,21 +19,17 @@ export default function NotFoundPage({ url }: UnknownPageProps) {
         <link rel="stylesheet" href="/home.css" />
         <link rel="stylesheet" href="/navigation-buttons.css" />
         <link rel="stylesheet" href="/content.css" />
-        <link rel="stylesheet" href="/blog.css" />
       </CustomHead>
       {/* Base page layout with theme switching and footer outside of accent box */}
       <Base>
-        {/* Back button */}
         <BlogNavigationButtons />
-        <article class="center">
-          <h2 class="navigation-link blog-title">Page not found!</h2>
-          <p>
+        <section class="center">
+          <h1 class="navigation-link">Page not found!</h1>
+          <p class="space">
             Hi there! Seems like you have reached a page that doesn't exist
             (...yet?). 🤔
           </p>
-          <p>↖️ Maybe go back to the previous page?</p>
-          <details>Dead URL path: {url.href}</details>
-        </article>
+        </section>
       </Base>
     </>
   );

--- a/routes/projects.tsx
+++ b/routes/projects.tsx
@@ -15,7 +15,6 @@ export default function Home() {
         link="https://www.theyurig.com/projects"
       >
         <link rel="stylesheet" href="/content.css" />
-        <link rel="stylesheet" href="/blog.css" />
         <link rel="stylesheet" href="/navigation-buttons.css" />
         <link rel="stylesheet" href="/gradient-underline.css" />
       </CustomHead>

--- a/routes/work.tsx
+++ b/routes/work.tsx
@@ -17,7 +17,6 @@ export default function Home() {
       >
         <link rel="stylesheet" href="/navigation-buttons.css" />
         <link rel="stylesheet" href="/content.css" />
-        <link rel="stylesheet" href="/blog.css" />
         <link rel="stylesheet" href="/gradient-underline.css" />
       </CustomHead>
       {/* Base page layout with theme switching and footer outside of accent box */}

--- a/static/base.css
+++ b/static/base.css
@@ -19,6 +19,19 @@ html {
     color: var(--neutral-color);
 }
 
+/* Define default card styling to be reused */
+.card {
+    padding: 0.5em 1em;
+    margin-bottom: 1em;
+    border: 2px solid var(--neutral-color);
+    border-radius: 1rem;
+}
+
+/* Define default card shadow */
+.card-shadow {
+    box-shadow: 0.1em 0.1em 0.3em var(--neutral-color);
+}
+
 /* Positioning for the main frame, border color, transition for theme switch */
 main {
     --main-padding: 1rem;

--- a/static/blog.css
+++ b/static/blog.css
@@ -26,26 +26,16 @@
     object-fit: cover;
 }
 
-/* Align text to the left */
-p {
-    align-self: self-start;
-}
-
-/* Add some space around the blog post paragraphs */
-p.space {
-    margin: 0.5em 0;
-}
-
-/* Size a subtopic header */
-h2.subtopic {
-    font-size: 2rem;
-    font-family: 'Alfa Slab One', cursive;
-}
-
 /* Add margin-left to lists on smaller resolutions */
 li {
     margin-left: 2.5em;
     transition: margin-left ease-in-out 0.5s;
+}
+
+/* Ending note at the end of a blog post */
+.blog-footer {
+    font-size: 0.75rem;
+    align-self: end;
 }
 
 /* Remove margin-left to lists on larger resolutions */

--- a/static/carousel-card.css
+++ b/static/carousel-card.css
@@ -4,7 +4,6 @@
     flex-direction: column;
     margin: var(--card-margin);
     height: 25em;
-    /* height: calc(100% - 2 * var(--card-margin)); */
     width: 15em;
     border: 0.25em solid var(--neutral-color);
     border-radius: 2em;
@@ -32,10 +31,12 @@
     }
 }
 
+/* Define size for insanity emoji */
 .insanity {
     font-size: 10rem;
 }
 
+/* Assign animation for insanity emoji when hovered */
 .insanity:hover {
     animation: grow-and-shrink 1.2s ease-out infinite;
 }

--- a/static/content.css
+++ b/static/content.css
@@ -26,7 +26,19 @@ section {
 
 /* Justify blog post body */
 p {
+    align-self: self-start;
     text-align: justify;
+}
+
+/* Add some space around the blog post paragraphs */
+p.space {
+    margin: 0.5em 0;
+}
+
+/* Size a subtopic header */
+.subtopic {
+    font-size: 2rem;
+    font-family: 'Alfa Slab One', cursive;
 }
 
 /* Spacer to push the blog footer to the end of the page,
@@ -34,12 +46,6 @@ p {
     the height by itself */
 .spacer {
     flex-grow: 1;
-}
-
-/* Ending note at the end of a blog post */
-.blog-footer {
-    font-size: 0.75rem;
-    align-self: end;
 }
 
 /* Reduce heading font size on smaller resolutions */

--- a/static/expenses-tracker.css
+++ b/static/expenses-tracker.css
@@ -5,9 +5,6 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    border: 2px solid var(--neutral-color);
-    border-radius: 1em;
-    box-shadow: 0.1em 0.1em 0.3em var(--neutral-color);
 }
 
 /* Cluster all 12 month expense bars together */
@@ -52,15 +49,6 @@
     text-align: center;
 }
 
-/* Group together the input fields to add a new expense */
-.add-new-expense {
-    padding: 0.5em 1em;
-    margin-bottom: 1em;
-    border: 2px solid var(--neutral-color);
-    border-radius: 1em;
-    box-shadow: 0.1em 0.1em 0.3em var(--neutral-color);
-}
-
 /* Style the "Add new expense" title after clicking to add new expense */
 .new-expense-title {
     font-size: 1.5rem;
@@ -83,9 +71,6 @@
     text-align: center;
     margin: 0.5em 0em;
     padding: 0.5em;
-    border: 2px solid var(--neutral-color);
-    border-radius: 1em;
-    box-shadow: 0.1em 0.1em 0.3em var(--neutral-color);
 }
 
 /* Create a border to cluster together the expense date */


### PR DESCRIPTION
Seemed like there was a pattern of reusing styles for `border` and `border radius`, so that's now delegated to `.card` on `base.css`. Additionally, also added `.card-shadow` for styling shadow to these card components, also at `base.css`.

Additional changes attached to this PR:
- Fixed a typo with the learning text, it's actually `React.createElement()` instead of `React.render()`. Whoops!
- Fixed a bug that would cause NaN% for years with no expenses created.
- Moved some reused classes from `/blog.css` to `/content.css` so there will be no need to import both when just one is enough.

Closes #51.