### PR TITLE
feat: added /projects/food-order

### DIFF
--- a/assets/CartIcon.tsx
+++ b/assets/CartIcon.tsx
@@ -1,0 +1,19 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/IconProperties.ts";
+
+//? Renders a Cart Icon with fill
+export default function CartIcon(
+  { iconHeight, iconWidth, iconFillColor }: IconProperties,
+) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height={iconHeight ?? "1em"}
+      width={iconWidth ?? "1em"}
+      viewBox="0 0 576 512"
+      fill={iconFillColor ?? "var(--neutral-color)"}
+    >
+      <path d="M0 24C0 10.7 10.7 0 24 0H69.5c22 0 41.5 12.8 50.6 32h411c26.3 0 45.5 25 38.6 50.4l-41 152.3c-8.5 31.4-37 53.3-69.5 53.3H170.7l5.4 28.5c2.2 11.3 12.1 19.5 23.6 19.5H488c13.3 0 24 10.7 24 24s-10.7 24-24 24H199.7c-34.6 0-64.3-24.6-70.7-58.5L77.4 54.5c-.7-3.8-4-6.5-7.9-6.5H24C10.7 48 0 37.3 0 24zM128 464a48 48 0 1 1 96 0 48 48 0 1 1 -96 0zm336-48a48 48 0 1 1 0 96 48 48 0 1 1 0-96z" />
+    </svg>
+  );
+}

--- a/assets/ChevronIcon.tsx
+++ b/assets/ChevronIcon.tsx
@@ -1,0 +1,22 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/IconProperties.ts";
+
+//? Renders a chevron Icon with fill, can be rotated using transform
+export default function ChevronIcon(
+  { iconHeight, iconWidth, iconFillColor, rotation }: IconProperties & {
+    rotation?: string;
+  },
+) {
+  return (
+    <svg
+      transform={`rotate(${rotation ?? "0"})`}
+      height={iconHeight}
+      width={iconWidth}
+      fill={iconFillColor ?? "var(--neutral-color)"}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 32 32"
+    >
+      <path d="M14.19 16.005l7.869 7.868-2.129 2.129-9.996-9.997L19.937 6.002l2.127 2.129z" />
+    </svg>
+  );
+}

--- a/assets/InformationIcon.tsx
+++ b/assets/InformationIcon.tsx
@@ -1,0 +1,19 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/IconProperties.ts";
+
+//? Renders an Information Icon with fill
+export default function InformationIcon(
+  { iconHeight, iconWidth, iconFillColor }: IconProperties,
+) {
+  return (
+    <svg
+      height={iconHeight}
+      width={iconWidth}
+      fill={iconFillColor ?? "var(--neutral-color)"}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 416.979 416.979"
+    >
+      <path d="M356.004,61.156c-81.37-81.47-213.377-81.551-294.848-0.182c-81.47,81.371-81.552,213.379-0.181,294.85 c81.369,81.47,213.378,81.551,294.849,0.181C437.293,274.636,437.375,142.626,356.004,61.156z M237.6,340.786 c0,3.217-2.607,5.822-5.822,5.822h-46.576c-3.215,0-5.822-2.605-5.822-5.822V167.885c0-3.217,2.607-5.822,5.822-5.822h46.576 c3.215,0,5.822,2.604,5.822,5.822V340.786z M208.49,137.901c-18.618,0-33.766-15.146-33.766-33.765 c0-18.617,15.147-33.766,33.766-33.766c18.619,0,33.766,15.148,33.766,33.766C242.256,122.755,227.107,137.901,208.49,137.901z" />
+    </svg>
+  );
+}

--- a/assets/LoadingAnimation.tsx
+++ b/assets/LoadingAnimation.tsx
@@ -1,0 +1,29 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/IconProperties.ts";
+
+//? Renders a spinning animation with fill
+//! Needs to import the loading-animation.css file for @keyframes!
+export default function LoadingAnimation(
+  { iconHeight, iconWidth, iconStrokeColor }: Pick<
+    IconProperties,
+    "iconHeight" | "iconWidth" | "iconStrokeColor"
+  >,
+) {
+  return (
+    <svg
+      height={iconHeight}
+      width={iconWidth}
+      viewBox="0 0 100 100"
+    >
+      <circle
+        id="spinner"
+        style={`fill:transparent;stroke: ${
+          iconStrokeColor ?? "var(--neutral-color)"
+        };stroke-width: 0.5em;stroke-linecap: round;`}
+        cx="50"
+        cy="50"
+        r="45"
+      />
+    </svg>
+  );
+}

--- a/assets/LoadingAnimation.tsx
+++ b/assets/LoadingAnimation.tsx
@@ -1,11 +1,11 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/IconProperties.ts";
+import { IconPropertiesWithStroke } from "../types/IconProperties.ts";
 
 //? Renders a spinning animation with fill
 //! Needs to import the loading-animation.css file for @keyframes!
 export default function LoadingAnimation(
   { iconHeight, iconWidth, iconStrokeColor }: Pick<
-    IconProperties,
+    IconPropertiesWithStroke,
     "iconHeight" | "iconWidth" | "iconStrokeColor"
   >,
 ) {

--- a/assets/MealIcon.tsx
+++ b/assets/MealIcon.tsx
@@ -1,0 +1,19 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/IconProperties.ts";
+
+//? Renders a Knife and Fork Icon with fill
+export default function MealIcon(
+  { iconHeight, iconWidth, iconFillColor }: IconProperties,
+) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height={iconHeight}
+      width={iconWidth}
+      fill={iconFillColor ?? "var(--neutral-color)"}
+      viewBox="0 0 24 24"
+    >
+      <path d="M18 3a1 1 0 0 1 .993.883L19 4v16a1 1 0 0 1-1.993.117L17 20v-5h-1a1 1 0 0 1-.993-.883L15 14V8c0-2.21 1.5-5 3-5Zm-6 0a1 1 0 0 1 .993.883L13 4v5a4.002 4.002 0 0 1-3 3.874V20a1 1 0 0 1-1.993.117L8 20v-7.126a4.002 4.002 0 0 1-2.995-3.668L5 9V4a1 1 0 0 1 1.993-.117L7 4v5a2 2 0 0 0 1 1.732V4a1 1 0 0 1 1.993-.117L10 4l.001 6.732a2 2 0 0 0 .992-1.563L11 9V4a1 1 0 0 1 1-1Z" />
+    </svg>
+  );
+}

--- a/assets/MinusIcon.tsx
+++ b/assets/MinusIcon.tsx
@@ -1,0 +1,19 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/IconProperties.ts";
+
+//? Renders a Minus Icon with fill
+export default function MinusIcon(
+  { iconHeight, iconWidth, iconFillColor }: IconProperties,
+) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height={iconHeight ?? "1em"}
+      width={iconWidth ?? "1em"}
+      viewBox="0 0 576 512"
+      fill={iconFillColor ?? "var(--neutral-color)"}
+    >
+      <path d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z" />
+    </svg>
+  );
+}

--- a/assets/MoonIcon.tsx
+++ b/assets/MoonIcon.tsx
@@ -1,0 +1,19 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/IconProperties.ts";
+
+//? Renders a moon Icon with fill
+export default function MoonIcon(
+  { iconHeight, iconWidth, iconFillColor }: IconProperties,
+) {
+  return (
+    <svg
+      height={iconHeight}
+      width={iconWidth}
+      fill={iconFillColor ?? "var(--neutral-color)"}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+    >
+      <path d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z" />
+    </svg>
+  );
+}

--- a/assets/PlusIcon.tsx
+++ b/assets/PlusIcon.tsx
@@ -1,0 +1,19 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/IconProperties.ts";
+
+//? Renders a XMark Icon with fill color, defaults to 'neutral-color' fill
+export default function PlusIcon(
+  { iconHeight, iconWidth, iconFillColor }: IconProperties,
+) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height={iconHeight ?? "1em"}
+      width={iconWidth ?? "1em"}
+      viewBox="0 0 576 512"
+      fill={iconFillColor ?? "var(--neutral-color)"}
+    >
+      <path d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32V224H48c-17.7 0-32 14.3-32 32s14.3 32 32 32H192V432c0 17.7 14.3 32 32 32s32-14.3 32-32V288H400c17.7 0 32-14.3 32-32s-14.3-32-32-32H256V80z" />
+    </svg>
+  );
+}

--- a/assets/SunIcon.tsx
+++ b/assets/SunIcon.tsx
@@ -1,0 +1,19 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/IconProperties.ts";
+
+//? Renders a sun Icon with fill
+export default function SunIcon(
+  { iconHeight, iconWidth, iconFillColor }: IconProperties,
+) {
+  return (
+    <svg
+      height={iconHeight}
+      width={iconWidth}
+      fill={iconFillColor ?? "var(--neutral-color)"}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+    >
+      <path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z" />
+    </svg>
+  );
+}

--- a/assets/XMarkIcon.tsx
+++ b/assets/XMarkIcon.tsx
@@ -1,10 +1,10 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/IconProperties.ts";
+import { IconPropertiesWithStroke } from "../types/IconProperties.ts";
 
 //? Renders a XMark Icon with fill, stroke and stroke-width
 export default function XMarkIcon(
   { iconHeight, iconWidth, iconFillColor, iconStrokeColor, iconStrokeWidth }:
-    IconProperties,
+    IconPropertiesWithStroke,
 ) {
   return (
     <svg

--- a/assets/XMarkIcon.tsx
+++ b/assets/XMarkIcon.tsx
@@ -1,0 +1,25 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/IconProperties.ts";
+
+//? Renders a XMark Icon with fill, stroke and stroke-width
+export default function XMarkIcon(
+  { iconHeight, iconWidth, iconFillColor, iconStrokeColor, iconStrokeWidth }:
+    IconProperties,
+) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height={iconHeight}
+      width={iconWidth}
+      viewBox="0 0 384 512"
+    >
+      <g
+        fill={iconFillColor}
+        stroke={iconStrokeColor}
+        stroke-width={iconStrokeWidth}
+      >
+        <path d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z" />
+      </g>
+    </svg>
+  );
+}

--- a/blog_posts/all-blog-posts.ts
+++ b/blog_posts/all-blog-posts.ts
@@ -4,17 +4,17 @@ import BlogPostSummaryProperties from "../types/BlogPostSummaryProperties.ts";
 //? Mock array of posts
 // todo Implement pagination
 const createdPosts: Array<BlogPostSummaryProperties> = [{
-    link: "/how-create-theme-switcher-deno-fresh",
-    title: "How to Create a Theme Switcher with Fresh",
-    shortSummary:
-        "A guide on how to create your own Theme Switcher using Deno and Fresh",
-    date: 1684849328672,
+  link: "/how-create-theme-switcher-deno-fresh",
+  title: "How to Create a Theme Switcher with Fresh",
+  shortSummary:
+    "A guide on how to create your own Theme Switcher using Deno and Fresh",
+  date: 1684849328672,
 }, {
-    link: "/stopping-theme-flickering-deno-fresh",
-    title: "How to stop Theme flickering in Fresh",
-    shortSummary:
-        "A guide on how to make your Theme Switcher stop flickering when the page loads",
-    date: 1684951466007,
+  link: "/stopping-theme-flickering-deno-fresh",
+  title: "How to stop Theme flickering in Fresh",
+  shortSummary:
+    "A guide on how to make your Theme Switcher stop flickering when the page loads",
+  date: 1684951466007,
 }];
 
 export default createdPosts;

--- a/components/blog/BlogNavigationButtons.tsx
+++ b/components/blog/BlogNavigationButtons.tsx
@@ -1,5 +1,6 @@
 //? Import LinkProperties to type what is required for the
 //? optional "back" and "next" buttons
+import ChevronIcon from "../../assets/ChevronIcon.tsx";
 import { LinkProperties } from "../../types/LinkProperties.ts";
 //? Define optional properties for the buttons
 interface BlogNavigationButtonProperties {
@@ -16,9 +17,7 @@ export default function BlogNavigationButtons(
   const backButton = back
     ? (
       <a class="navigation-button" href={back.link} title={back.title}>
-        <svg viewBox="0 0 32 32" aria-hidden="true" fill="currentColor">
-          <path d="M14.19 16.005l7.869 7.868-2.129 2.129-9.996-9.997L19.937 6.002l2.127 2.129z" />
-        </svg>
+        <ChevronIcon iconHeight="1.8em" iconWidth="1.5em" rotation="0" />
         Back
       </a>
     )
@@ -32,14 +31,7 @@ export default function BlogNavigationButtons(
     ? (
       <a class="navigation-button" href={next.link} title={next.title}>
         Next
-        <svg
-          viewBox="0 0 32 32"
-          class="icon icon-chevron-right"
-          aria-hidden="true"
-          fill="currentColor"
-        >
-          <path d="M18.629 15.997l-7.083-7.081L13.462 7l8.997 8.997L13.457 25l-1.916-1.916z" />
-        </svg>
+        <ChevronIcon iconHeight="1.8em" iconWidth="1.5em" rotation="180" />
       </a>
     )
     : <span style="width: 5rem;"></span>; //? Empty span to center the Home button

--- a/components/food-order/CartButton.tsx
+++ b/components/food-order/CartButton.tsx
@@ -2,6 +2,7 @@ import AccentButton from "../../islands/AccentButton.tsx";
 
 //? Define Cart Button properties
 interface CartButtonProperties {
+  pulseState: boolean;
   openModal: () => void;
   totalItems: number;
   cost: number;
@@ -9,12 +10,17 @@ interface CartButtonProperties {
 
 //? Renders a cart button that will open the cart modal
 export default function CartButton({
+  pulseState,
   openModal,
   totalItems,
   cost,
 }: CartButtonProperties) {
   return (
     <AccentButton
+      //? Adds the pulsing animation when a food item is added
+      style={pulseState
+        ? "animation: pulseCartOnItemAdd 0.3s ease-in-out;"
+        : ""}
       onClickFunction={openModal}
     >
       <span class="cart-total-items">

--- a/components/food-order/CartButton.tsx
+++ b/components/food-order/CartButton.tsx
@@ -5,7 +5,7 @@ interface CartButtonProperties {
   cost: number;
 }
 
-//todo
+//? Renders a cart button that will open the cart modal
 export default function CartButton({
   openModal,
   totalItems,

--- a/components/food-order/CartButton.tsx
+++ b/components/food-order/CartButton.tsx
@@ -1,0 +1,33 @@
+//? Define Cart Button properties
+interface CartButtonProperties {
+  openModal: () => void;
+  totalItems: number;
+  cost: number;
+}
+
+//todo
+export default function CartButton({
+  openModal,
+  totalItems,
+  cost,
+}: CartButtonProperties) {
+  return (
+    <button
+      class="food-cart styled-button"
+      onClick={openModal}
+    >
+      <span class="cart-total-items">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          height="1em"
+          viewBox="0 0 576 512"
+          fill="var(--neutral-color)"
+        >
+          <path d="M0 24C0 10.7 10.7 0 24 0H69.5c22 0 41.5 12.8 50.6 32h411c26.3 0 45.5 25 38.6 50.4l-41 152.3c-8.5 31.4-37 53.3-69.5 53.3H170.7l5.4 28.5c2.2 11.3 12.1 19.5 23.6 19.5H488c13.3 0 24 10.7 24 24s-10.7 24-24 24H199.7c-34.6 0-64.3-24.6-70.7-58.5L77.4 54.5c-.7-3.8-4-6.5-7.9-6.5H24C10.7 48 0 37.3 0 24zM128 464a48 48 0 1 1 96 0 48 48 0 1 1 -96 0zm336-48a48 48 0 1 1 0 96 48 48 0 1 1 0-96z" />
+        </svg>
+        {totalItems}
+      </span>
+      <span>${cost.toFixed(2)}</span>
+    </button>
+  );
+}

--- a/components/food-order/CartButton.tsx
+++ b/components/food-order/CartButton.tsx
@@ -1,3 +1,4 @@
+import CartIcon from "../../assets/CartIcon.tsx";
 import AccentButton from "../../islands/AccentButton.tsx";
 
 //? Define Cart Button properties
@@ -24,14 +25,11 @@ export default function CartButton({
       onClickFunction={openModal}
     >
       <span class="cart-total-items">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          height="1em"
-          viewBox="0 0 576 512"
-          fill="var(--neutral-color)"
-        >
-          <path d="M0 24C0 10.7 10.7 0 24 0H69.5c22 0 41.5 12.8 50.6 32h411c26.3 0 45.5 25 38.6 50.4l-41 152.3c-8.5 31.4-37 53.3-69.5 53.3H170.7l5.4 28.5c2.2 11.3 12.1 19.5 23.6 19.5H488c13.3 0 24 10.7 24 24s-10.7 24-24 24H199.7c-34.6 0-64.3-24.6-70.7-58.5L77.4 54.5c-.7-3.8-4-6.5-7.9-6.5H24C10.7 48 0 37.3 0 24zM128 464a48 48 0 1 1 96 0 48 48 0 1 1 -96 0zm336-48a48 48 0 1 1 0 96 48 48 0 1 1 0-96z" />
-        </svg>
+        {
+          /* Islands can't render children directly, they need to be
+         rendered as the result of a function instead */
+        }
+        {CartIcon({ iconHeight: "1em", iconWidth: "1em" })}
         {totalItems}
       </span>
       <span>${cost.toFixed(2)}</span>

--- a/components/food-order/CartButton.tsx
+++ b/components/food-order/CartButton.tsx
@@ -1,3 +1,5 @@
+import AccentButton from "../../islands/AccentButton.tsx";
+
 //? Define Cart Button properties
 interface CartButtonProperties {
   openModal: () => void;
@@ -12,9 +14,8 @@ export default function CartButton({
   cost,
 }: CartButtonProperties) {
   return (
-    <button
-      class="food-cart styled-button"
-      onClick={openModal}
+    <AccentButton
+      onClickFunction={openModal}
     >
       <span class="cart-total-items">
         <svg
@@ -28,6 +29,6 @@ export default function CartButton({
         {totalItems}
       </span>
       <span>${cost.toFixed(2)}</span>
-    </button>
+    </AccentButton>
   );
 }

--- a/components/food-order/CartModal.tsx
+++ b/components/food-order/CartModal.tsx
@@ -1,20 +1,21 @@
 //? Import the StyledButton to close the modal on empty carts or
 //? confirm orders on a filled cart
 import StyledButton from "../../islands/StyledButton.tsx";
-//
-import { StateUpdater } from "preact/hooks";
+//? Import the functions that will update the Cart state
+import {
+  deleteItemFromCart,
+  increaseCartItemByOne,
+  reduceCartItemByOne,
+} from "../../services/food-order/updateFoodOrder.ts";
+//? Import types for typecasting
+import type { foodCartItemsMap } from "../../types/food-order/foodCartItemsMap.ts";
+import type { updateCartFunction } from "../../types/food-order/updateCartFunction.ts";
 
 //? Define Cart Modal properties
 interface CartModalProperties {
   closeModal: () => void;
-  updateCartFunction: StateUpdater<
-    {
-      totalItems: number;
-      items: Map<string, { quantity: number; cost: number }>;
-      cost: number;
-    }
-  >;
-  items: Map<string, { quantity: number; cost: number }>;
+  updateCartFunction: updateCartFunction;
+  items: foodCartItemsMap;
   cost: number;
 }
 
@@ -27,7 +28,7 @@ export default function CartModal({
   cost,
 }: CartModalProperties) {
   //? If no items are in the cartContent, return a simple "empty cart" message
-  if (cost === 0) {
+  if (items.size === 0) {
     return (
       <div class="food-cart-content">
         <span class="food-cart-content__header">
@@ -65,37 +66,14 @@ export default function CartModal({
                 <span
                   style="margin-right: 0.5em"
                   onClick={() => {
-                    updateCartFunction((curr) => {
-                      //? Instantiate current cart
-                      const updatedCart = { ...curr };
-
-                      //? Decrease the total item count by 1
-                      updatedCart.totalItems -= 1;
-                      //? Discount the overall cart price by the
-                      //? cost of another of this item
-                      updatedCart.cost -= cost;
-
-                      //? Increase the count of this specific item on the cart
-                      const decreasedCountItem = updatedCart.items.get(
-                        foodName,
-                      );
-                      if (decreasedCountItem !== undefined) {
-                        if (decreasedCountItem.quantity > 1) {
-                          decreasedCountItem.quantity -= 1;
-                          updatedCart.items.set(
-                            foodName,
-                            decreasedCountItem,
-                          );
-                        } else {
-                          updatedCart.items.delete(foodName);
-                        }
-                      }
-
-                      //? Return the updated cart as updated state
-                      return updatedCart;
+                    reduceCartItemByOne({
+                      foodName,
+                      foodCost: cost,
+                      updateCartFunction,
                     });
                   }}
                 >
+                  {/* Minus sign SVG */}
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     height="1.5em"
@@ -108,33 +86,14 @@ export default function CartModal({
                 {/* Increase item count */}
                 <span
                   onClick={() => {
-                    updateCartFunction((curr) => {
-                      //? Instantiate current cart
-                      const updatedCart = { ...curr };
-
-                      //? Increase the total item count by 1
-                      updatedCart.totalItems += 1;
-                      //? Increase the overall cart price by the
-                      //? cost of another of this item
-                      updatedCart.cost += cost;
-
-                      //? Increase the count of this specific item on the cart
-                      const increasedCountItem = updatedCart.items.get(
-                        foodName,
-                      );
-                      if (increasedCountItem !== undefined) {
-                        increasedCountItem.quantity += 1;
-                        updatedCart.items.set(
-                          foodName,
-                          increasedCountItem,
-                        );
-                      }
-
-                      //? Return the updated cart as updated state
-                      return updatedCart;
+                    increaseCartItemByOne({
+                      foodName,
+                      foodCost: cost,
+                      updateCartFunction,
                     });
                   }}
                 >
+                  {/* Plus sign SVG */}
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     height="1.5em"
@@ -144,26 +103,19 @@ export default function CartModal({
                     <path d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32V224H48c-17.7 0-32 14.3-32 32s14.3 32 32 32H192V432c0 17.7 14.3 32 32 32s32-14.3 32-32V288H400c17.7 0 32-14.3 32-32s-14.3-32-32-32H256V80z" />
                   </svg>
                 </span>
-                {/* Remove item */}
+                {/* Remove item completely from cart */}
                 <span
                   style="margin-left: 0.5em"
                   onClick={() => {
-                    updateCartFunction((curr) => {
-                      //? Instantiate current cart
-                      const updatedCart = { ...curr };
-
-                      //? Remove as many items from the cart as were added of this item
-                      updatedCart.totalItems -= quantity;
-                      //? Discount the cart by the cost of all items of this type
-                      updatedCart.cost -= quantity * cost;
-                      //? Remove this item from the tracked items
-                      updatedCart.items.delete(foodName);
-
-                      //? Return the updated cart as updated state
-                      return updatedCart;
+                    deleteItemFromCart({
+                      foodName,
+                      foodQuantity: quantity,
+                      foodCost: cost,
+                      updateCartFunction,
                     });
                   }}
                 >
+                  {/* XMark SVG */}
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     height="1.5em"

--- a/components/food-order/CartModal.tsx
+++ b/components/food-order/CartModal.tsx
@@ -8,7 +8,11 @@ import { StateUpdater } from "preact/hooks";
 interface CartModalProperties {
   closeModal: () => void;
   updateCartFunction: StateUpdater<
-    { totalItems: number; items: Map<string, number>; cost: number }
+    {
+      totalItems: number;
+      items: Map<string, { quantity: number; cost: number }>;
+      cost: number;
+    }
   >;
   items: Map<string, { quantity: number; cost: number }>;
   cost: number;
@@ -50,11 +54,42 @@ export default function CartModal({
       <ol>
         {cartItems.map(([foodName, { quantity, cost }]) => (
           <li>
-            <div style="display: flex; justify-content: space-between;">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
               <span>
                 {foodName}: {quantity}x ${cost.toFixed(2)}
               </span>
               <div style="display: inline-flex;">
+                {/* Increase item count */}
+                <span
+                  style="margin-left: 0.5em"
+                  onClick={() => {
+                    updateCartFunction((curr) => {
+                      const updatedCart = { ...curr };
+                      ++updatedCart.totalItems;
+                      updatedCart.cost += cost;
+                      const increasedCountItem = updatedCart.items.get(
+                        foodName,
+                      );
+                      if (increasedCountItem !== undefined) {
+                        increasedCountItem.quantity += 1;
+                        updatedCart.items.set(
+                          foodName,
+                          increasedCountItem,
+                        );
+                      }
+                      return updatedCart;
+                    });
+                  }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="1.5em"
+                    fill="var(--neutral-color)"
+                    viewBox="0 0 448 512"
+                  >
+                    <path d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32V224H48c-17.7 0-32 14.3-32 32s14.3 32 32 32H192V432c0 17.7 14.3 32 32 32s32-14.3 32-32V288H400c17.7 0 32-14.3 32-32s-14.3-32-32-32H256V80z" />
+                  </svg>
+                </span>
                 {/* Remove item */}
                 <span
                   style="margin-left: 0.5em"

--- a/components/food-order/CartModal.tsx
+++ b/components/food-order/CartModal.tsx
@@ -55,18 +55,70 @@ export default function CartModal({
         {cartItems.map(([foodName, { quantity, cost }]) => (
           <li>
             <div style="display: flex; justify-content: space-between; align-items: center;">
+              {/* Cart item name */}
               <span>
                 {foodName}: {quantity}x ${cost.toFixed(2)}
               </span>
+              {/* Update cart item count */}
               <div style="display: inline-flex;">
-                {/* Increase item count */}
+                {/* Decrease item count. If last item, remove it from the cart */}
                 <span
-                  style="margin-left: 0.5em"
+                  style="margin-right: 0.5em"
                   onClick={() => {
                     updateCartFunction((curr) => {
+                      //? Instantiate current cart
                       const updatedCart = { ...curr };
-                      ++updatedCart.totalItems;
+
+                      //? Decrease the total item count by 1
+                      updatedCart.totalItems -= 1;
+                      //? Discount the overall cart price by the
+                      //? cost of another of this item
+                      updatedCart.cost -= cost;
+
+                      //? Increase the count of this specific item on the cart
+                      const decreasedCountItem = updatedCart.items.get(
+                        foodName,
+                      );
+                      if (decreasedCountItem !== undefined) {
+                        if (decreasedCountItem.quantity > 1) {
+                          decreasedCountItem.quantity -= 1;
+                          updatedCart.items.set(
+                            foodName,
+                            decreasedCountItem,
+                          );
+                        } else {
+                          updatedCart.items.delete(foodName);
+                        }
+                      }
+
+                      //? Return the updated cart as updated state
+                      return updatedCart;
+                    });
+                  }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="1.5em"
+                    fill="var(--neutral-color)"
+                    viewBox="0 0 448 512"
+                  >
+                    <path d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z" />
+                  </svg>
+                </span>
+                {/* Increase item count */}
+                <span
+                  onClick={() => {
+                    updateCartFunction((curr) => {
+                      //? Instantiate current cart
+                      const updatedCart = { ...curr };
+
+                      //? Increase the total item count by 1
+                      updatedCart.totalItems += 1;
+                      //? Increase the overall cart price by the
+                      //? cost of another of this item
                       updatedCart.cost += cost;
+
+                      //? Increase the count of this specific item on the cart
                       const increasedCountItem = updatedCart.items.get(
                         foodName,
                       );
@@ -77,6 +129,8 @@ export default function CartModal({
                           increasedCountItem,
                         );
                       }
+
+                      //? Return the updated cart as updated state
                       return updatedCart;
                     });
                   }}
@@ -95,10 +149,17 @@ export default function CartModal({
                   style="margin-left: 0.5em"
                   onClick={() => {
                     updateCartFunction((curr) => {
+                      //? Instantiate current cart
                       const updatedCart = { ...curr };
+
+                      //? Remove as many items from the cart as were added of this item
                       updatedCart.totalItems -= quantity;
+                      //? Discount the cart by the cost of all items of this type
                       updatedCart.cost -= quantity * cost;
+                      //? Remove this item from the tracked items
                       updatedCart.items.delete(foodName);
+
+                      //? Return the updated cart as updated state
                       return updatedCart;
                     });
                   }}

--- a/components/food-order/CartModal.tsx
+++ b/components/food-order/CartModal.tsx
@@ -1,0 +1,67 @@
+//todo
+import StyledButton from "../../islands/StyledButton.tsx";
+
+//? Define Cart Modal properties
+interface CartModalProperties {
+  closeModal: () => void;
+  items: Map<string, { quantity: number; cost: number }>;
+  cost: number;
+}
+
+//todo
+export default function CartModal({
+  closeModal,
+  items,
+  cost,
+}: CartModalProperties) {
+  //? If no items are in the cartContent, return a simple "empty cart" message
+  if (cost === 0) {
+    return (
+      <div class="food-cart-content">
+        <span class="food-cart-content__header">
+          No items in your cart yet!
+        </span>
+        <StyledButton
+          style="align-self: end;"
+          text="Close"
+          onClickFunction={closeModal}
+        />
+      </div>
+    );
+  }
+
+  //? Destructure the cart items to render them one by one in a list
+  const cartItems = [...items];
+
+  //? Return the cart items and the total
+  return (
+    <div class="food-cart-content">
+      {/* Modal header */}
+      <span class="food-cart-content__header">Items in cart</span>
+      {/* List of items in cart */}
+      <ol>
+        {cartItems.map(([foodName, { quantity, cost }]) => (
+          <li>{foodName}: {quantity}x ${cost.toFixed(2)}</li>
+        ))}
+      </ol>
+      {/* Cart total cost */}
+      <span class="food-cart-content__total">Total: ${cost.toFixed(2)}</span>
+      {/* Row of buttons to close or complete the order */}
+      <div class="food-cart-content__button-row">
+        <button
+          key="modal__add-more"
+          onClick={closeModal}
+          title="Close the modal"
+        >
+          Add more
+        </button>
+        <StyledButton
+          style="margin-left: 1em;"
+          key="modal__order"
+          text="Order"
+          onClickFunction={closeModal}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/food-order/CartModal.tsx
+++ b/components/food-order/CartModal.tsx
@@ -1,10 +1,15 @@
 //? Import the StyledButton to close the modal on empty carts or
 //? confirm orders on a filled cart
 import StyledButton from "../../islands/StyledButton.tsx";
+//
+import { StateUpdater } from "preact/hooks";
 
 //? Define Cart Modal properties
 interface CartModalProperties {
   closeModal: () => void;
+  updateCartFunction: StateUpdater<
+    { totalItems: number; items: Map<string, number>; cost: number }
+  >;
   items: Map<string, { quantity: number; cost: number }>;
   cost: number;
 }
@@ -13,6 +18,7 @@ interface CartModalProperties {
 //? information about the cart being empty or a list with all cart items
 export default function CartModal({
   closeModal,
+  updateCartFunction,
   items,
   cost,
 }: CartModalProperties) {
@@ -43,7 +49,42 @@ export default function CartModal({
       {/* List of items in cart */}
       <ol>
         {cartItems.map(([foodName, { quantity, cost }]) => (
-          <li>{foodName}: {quantity}x ${cost.toFixed(2)}</li>
+          <li>
+            <div style="display: flex; justify-content: space-between;">
+              <span>
+                {foodName}: {quantity}x ${cost.toFixed(2)}
+              </span>
+              <div style="display: inline-flex;">
+                {/* Remove item */}
+                <span
+                  style="margin-left: 0.5em"
+                  onClick={() => {
+                    updateCartFunction((curr) => {
+                      const updatedCart = { ...curr };
+                      updatedCart.totalItems -= quantity;
+                      updatedCart.cost -= quantity * cost;
+                      updatedCart.items.delete(foodName);
+                      return updatedCart;
+                    });
+                  }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="1.5em"
+                    viewBox="0 0 384 512"
+                  >
+                    <g
+                      fill="red"
+                      stroke="var(--neutral-color)"
+                      stroke-width="20"
+                    >
+                      <path d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z" />
+                    </g>
+                  </svg>
+                </span>
+              </div>
+            </div>
+          </li>
         ))}
       </ol>
       {/* Cart total cost */}

--- a/components/food-order/CartModal.tsx
+++ b/components/food-order/CartModal.tsx
@@ -1,4 +1,5 @@
-//todo
+//? Import the StyledButton to close the modal on empty carts or
+//? confirm orders on a filled cart
 import StyledButton from "../../islands/StyledButton.tsx";
 
 //? Define Cart Modal properties
@@ -8,7 +9,8 @@ interface CartModalProperties {
   cost: number;
 }
 
-//todo
+//? Exports the content of the cart modal that will either display the
+//? information about the cart being empty or a list with all cart items
 export default function CartModal({
   closeModal,
   items,

--- a/components/food-order/CartModal.tsx
+++ b/components/food-order/CartModal.tsx
@@ -1,5 +1,8 @@
 //? Import the StyledButton to close the modal on empty carts or
 //? confirm orders on a filled cart
+import MinusIcon from "../../assets/MinusIcon.tsx";
+import PlusIcon from "../../assets/PlusIcon.tsx";
+import XMarkIcon from "../../assets/XMarkIcon.tsx";
 import StyledButton from "../../islands/StyledButton.tsx";
 //? Import the functions that will update the Cart state
 import {
@@ -74,14 +77,7 @@ export default function CartModal({
                   }}
                 >
                   {/* Minus sign SVG */}
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    height="1.5em"
-                    fill="var(--neutral-color)"
-                    viewBox="0 0 448 512"
-                  >
-                    <path d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z" />
-                  </svg>
+                  <MinusIcon iconHeight="1.5em" iconWidth="1.5em" />
                 </span>
                 {/* Increase item count */}
                 <span
@@ -94,14 +90,7 @@ export default function CartModal({
                   }}
                 >
                   {/* Plus sign SVG */}
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    height="1.5em"
-                    fill="var(--neutral-color)"
-                    viewBox="0 0 448 512"
-                  >
-                    <path d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32V224H48c-17.7 0-32 14.3-32 32s14.3 32 32 32H192V432c0 17.7 14.3 32 32 32s32-14.3 32-32V288H400c17.7 0 32-14.3 32-32s-14.3-32-32-32H256V80z" />
-                  </svg>
+                  <PlusIcon iconHeight="1.5em" iconWidth="1.5em" />
                 </span>
                 {/* Remove item completely from cart */}
                 <span
@@ -116,19 +105,13 @@ export default function CartModal({
                   }}
                 >
                   {/* XMark SVG */}
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    height="1.5em"
-                    viewBox="0 0 384 512"
-                  >
-                    <g
-                      fill="red"
-                      stroke="var(--neutral-color)"
-                      stroke-width="20"
-                    >
-                      <path d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z" />
-                    </g>
-                  </svg>
+                  <XMarkIcon
+                    iconHeight="1.5em"
+                    iconWidth="1.5em"
+                    iconFillColor="red"
+                    iconStrokeColor="var(--neutral-color)"
+                    iconStrokeWidth="30"
+                  />
                 </span>
               </div>
             </div>
@@ -148,7 +131,6 @@ export default function CartModal({
         </button>
         <StyledButton
           style="margin-left: 1em;"
-          key="modal__order"
           text="Order"
           onClickFunction={closeModal}
         />

--- a/components/food-order/FoodItem.tsx
+++ b/components/food-order/FoodItem.tsx
@@ -1,9 +1,9 @@
-//todo
+//? Import the StyledButton to enable users to add the current FoodItem to the cart
 import StyledButton from "../../islands/StyledButton.tsx";
 //? Import Food type to typecast the data received
 import type { Food } from "../../types/Food.ts";
 
-//todo
+//? Renders a single FoodItem with image, name, description and button to add to Cart
 export function FoodItem(
   {
     imageLink,
@@ -35,6 +35,7 @@ export function FoodItem(
             class="food-for-how-many"
             title={"Feeds " + feedsHowMany}
           >
+            {/* people icon */}
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
@@ -44,6 +45,7 @@ export function FoodItem(
                 d="M18 3a1 1 0 0 1 .993.883L19 4v16a1 1 0 0 1-1.993.117L17 20v-5h-1a1 1 0 0 1-.993-.883L15 14V8c0-2.21 1.5-5 3-5Zm-6 0a1 1 0 0 1 .993.883L13 4v5a4.002 4.002 0 0 1-3 3.874V20a1 1 0 0 1-1.993.117L8 20v-7.126a4.002 4.002 0 0 1-2.995-3.668L5 9V4a1 1 0 0 1 1.993-.117L7 4v5a2 2 0 0 0 1 1.732V4a1 1 0 0 1 1.993-.117L10 4l.001 6.732a2 2 0 0 0 .992-1.563L11 9V4a1 1 0 0 1 1-1Z"
               />
             </svg>
+            {/* Number of people that this meal can feed */}
             {feedsHowMany}
           </span>
         </div>

--- a/components/food-order/FoodItem.tsx
+++ b/components/food-order/FoodItem.tsx
@@ -1,7 +1,9 @@
+//todo
 import StyledButton from "../../islands/StyledButton.tsx";
 //? Import Food type to typecast the data received
 import type { Food } from "../../types/Food.ts";
 
+//todo
 export function FoodItem(
   {
     imageLink,

--- a/components/food-order/FoodItem.tsx
+++ b/components/food-order/FoodItem.tsx
@@ -1,0 +1,34 @@
+import StyledButton from "../../islands/StyledButton.tsx";
+//? Import Food type to typecast the data received
+import type { Food } from "../../types/Food.ts";
+
+export function FoodItem(
+  {
+    imageLink,
+    imageAlt,
+    imageTitle,
+    name,
+    description,
+    price,
+    addToCartFunction,
+  }: Food,
+) {
+  return (
+    <div class="card single-food">
+      <img
+        class="food-image"
+        src={imageLink}
+        alt={imageAlt}
+        title={imageTitle}
+      />
+      <div class="food-name-and-description">
+        <span class="food-name">{name}</span>
+        <span class="food-description">{description}</span>
+      </div>
+      <StyledButton
+        text={"Buy now: $" + price}
+        onClickFunction={addToCartFunction}
+      />
+    </div>
+  );
+}

--- a/components/food-order/FoodItem.tsx
+++ b/components/food-order/FoodItem.tsx
@@ -1,4 +1,5 @@
 //? Import the StyledButton to enable users to add the current FoodItem to the cart
+import MealIcon from "../../assets/MealIcon.tsx";
 import StyledButton from "../../islands/StyledButton.tsx";
 //? Import Food type to typecast the data received
 import type { Food } from "../../types/Food.ts";
@@ -35,16 +36,8 @@ export function FoodItem(
             class="food-for-how-many"
             title={"Feeds " + feedsHowMany}
           >
-            {/* people icon */}
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-            >
-              <path
-                fill="currentColor"
-                d="M18 3a1 1 0 0 1 .993.883L19 4v16a1 1 0 0 1-1.993.117L17 20v-5h-1a1 1 0 0 1-.993-.883L15 14V8c0-2.21 1.5-5 3-5Zm-6 0a1 1 0 0 1 .993.883L13 4v5a4.002 4.002 0 0 1-3 3.874V20a1 1 0 0 1-1.993.117L8 20v-7.126a4.002 4.002 0 0 1-2.995-3.668L5 9V4a1 1 0 0 1 1.993-.117L7 4v5a2 2 0 0 0 1 1.732V4a1 1 0 0 1 1.993-.117L10 4l.001 6.732a2 2 0 0 0 .992-1.563L11 9V4a1 1 0 0 1 1-1Z"
-              />
-            </svg>
+            {/* Knife and Fork icon */}
+            <MealIcon iconHeight="1.3em" iconWidth="1.3em" />
             {/* Number of people that this meal can feed */}
             {feedsHowMany}
           </span>
@@ -55,7 +48,7 @@ export function FoodItem(
       {/* Button to add to cart */}
       <StyledButton
         style="flex-shrink: 0;"
-        text={"Add: $" + price.toFixed(2)}
+        text={"Add for $" + price.toFixed(2)}
         onClickFunction={addToCartFunction}
       />
     </div>

--- a/components/food-order/FoodItem.tsx
+++ b/components/food-order/FoodItem.tsx
@@ -9,9 +9,10 @@ export function FoodItem(
     imageTitle,
     name,
     description,
+    feedsHowMany,
     price,
     addToCartFunction,
-  }: Food,
+  }: Food & { addToCartFunction: () => void },
 ) {
   return (
     <div class="card single-food">
@@ -22,11 +23,29 @@ export function FoodItem(
         title={imageTitle}
       />
       <div class="food-name-and-description">
-        <span class="food-name">{name}</span>
+        <div class="food-name">
+          {name}{" "}
+          <span
+            class="food-for-how-many"
+            title={"Feeds " + feedsHowMany}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+            >
+              <path
+                fill="currentColor"
+                d="M18 3a1 1 0 0 1 .993.883L19 4v16a1 1 0 0 1-1.993.117L17 20v-5h-1a1 1 0 0 1-.993-.883L15 14V8c0-2.21 1.5-5 3-5Zm-6 0a1 1 0 0 1 .993.883L13 4v5a4.002 4.002 0 0 1-3 3.874V20a1 1 0 0 1-1.993.117L8 20v-7.126a4.002 4.002 0 0 1-2.995-3.668L5 9V4a1 1 0 0 1 1.993-.117L7 4v5a2 2 0 0 0 1 1.732V4a1 1 0 0 1 1.993-.117L10 4l.001 6.732a2 2 0 0 0 .992-1.563L11 9V4a1 1 0 0 1 1-1Z"
+              />
+            </svg>
+            {feedsHowMany}
+          </span>
+        </div>
         <span class="food-description">{description}</span>
       </div>
       <StyledButton
-        text={"Buy now: $" + price}
+        style="flex-shrink: 0;"
+        text={"Add: $" + price}
         onClickFunction={addToCartFunction}
       />
     </div>

--- a/components/food-order/FoodItem.tsx
+++ b/components/food-order/FoodItem.tsx
@@ -15,16 +15,20 @@ export function FoodItem(
   }: Food & { addToCartFunction: () => void },
 ) {
   return (
+    //? Whole card
     <div class="card single-food">
+      {/* Food image */}
       <img
         class="food-image"
         src={imageLink}
         alt={imageAlt}
         title={imageTitle}
       />
+      {/* Column with food name + how many it feeds and food description */}
       <div class="food-name-and-description">
+        {/* Food name + how many it feeds */}
         <div class="food-name">
-          {name}{" "}
+          {name} {/* How many it feeds icon + count */}
           <span
             class="food-for-how-many"
             title={"Feeds " + feedsHowMany}
@@ -41,11 +45,13 @@ export function FoodItem(
             {feedsHowMany}
           </span>
         </div>
+        {/* Food description */}
         <span class="food-description">{description}</span>
       </div>
+      {/* Button to add to cart */}
       <StyledButton
         style="flex-shrink: 0;"
-        text={"Add: $" + price}
+        text={"Add: $" + price.toFixed(2)}
         onClickFunction={addToCartFunction}
       />
     </div>

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -7,18 +7,19 @@ import * as $0 from "./routes/[blog]/[post].tsx";
 import * as $1 from "./routes/[blog]/how-create-theme-switcher-deno-fresh.tsx";
 import * as $2 from "./routes/[blog]/stopping-theme-flickering-deno-fresh.tsx";
 import * as $3 from "./routes/[projects]/expenses-tracker.tsx";
-import * as $4 from "./routes/[toys]/insanity.tsx";
-import * as $5 from "./routes/[toys]/spinners.tsx";
-import * as $6 from "./routes/[work]/form.tsx";
-import * as $7 from "./routes/_404.tsx";
-import * as $8 from "./routes/api/joke.ts";
-import * as $9 from "./routes/blog.tsx";
-import * as $10 from "./routes/index.tsx";
-import * as $11 from "./routes/me.tsx";
-import * as $12 from "./routes/projects.tsx";
-import * as $13 from "./routes/toys.tsx";
-import * as $14 from "./routes/what-is-this.tsx";
-import * as $15 from "./routes/work.tsx";
+import * as $4 from "./routes/[projects]/food-order.tsx";
+import * as $5 from "./routes/[toys]/insanity.tsx";
+import * as $6 from "./routes/[toys]/spinners.tsx";
+import * as $7 from "./routes/[work]/form.tsx";
+import * as $8 from "./routes/_404.tsx";
+import * as $9 from "./routes/api/joke.ts";
+import * as $10 from "./routes/blog.tsx";
+import * as $11 from "./routes/index.tsx";
+import * as $12 from "./routes/me.tsx";
+import * as $13 from "./routes/projects.tsx";
+import * as $14 from "./routes/toys.tsx";
+import * as $15 from "./routes/what-is-this.tsx";
+import * as $16 from "./routes/work.tsx";
 import * as $$0 from "./islands/AddNewExpense.tsx";
 import * as $$1 from "./islands/ExpensesTracker.tsx";
 import * as $$2 from "./islands/ExpensesYearSelect.tsx";
@@ -39,18 +40,19 @@ const manifest = {
     "./routes/[blog]/how-create-theme-switcher-deno-fresh.tsx": $1,
     "./routes/[blog]/stopping-theme-flickering-deno-fresh.tsx": $2,
     "./routes/[projects]/expenses-tracker.tsx": $3,
-    "./routes/[toys]/insanity.tsx": $4,
-    "./routes/[toys]/spinners.tsx": $5,
-    "./routes/[work]/form.tsx": $6,
-    "./routes/_404.tsx": $7,
-    "./routes/api/joke.ts": $8,
-    "./routes/blog.tsx": $9,
-    "./routes/index.tsx": $10,
-    "./routes/me.tsx": $11,
-    "./routes/projects.tsx": $12,
-    "./routes/toys.tsx": $13,
-    "./routes/what-is-this.tsx": $14,
-    "./routes/work.tsx": $15,
+    "./routes/[projects]/food-order.tsx": $4,
+    "./routes/[toys]/insanity.tsx": $5,
+    "./routes/[toys]/spinners.tsx": $6,
+    "./routes/[work]/form.tsx": $7,
+    "./routes/_404.tsx": $8,
+    "./routes/api/joke.ts": $9,
+    "./routes/blog.tsx": $10,
+    "./routes/index.tsx": $11,
+    "./routes/me.tsx": $12,
+    "./routes/projects.tsx": $13,
+    "./routes/toys.tsx": $14,
+    "./routes/what-is-this.tsx": $15,
+    "./routes/work.tsx": $16,
   },
   islands: {
     "./islands/AddNewExpense.tsx": $$0,

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -23,16 +23,17 @@ import * as $16 from "./routes/work.tsx";
 import * as $$0 from "./islands/AddNewExpense.tsx";
 import * as $$1 from "./islands/ExpensesTracker.tsx";
 import * as $$2 from "./islands/ExpensesYearSelect.tsx";
-import * as $$3 from "./islands/FormWithValidation.tsx";
-import * as $$4 from "./islands/InsanitySection.tsx";
-import * as $$5 from "./islands/ProjectDiscovery.tsx";
-import * as $$6 from "./islands/StyledButton.tsx";
-import * as $$7 from "./islands/StyledCheckboxGroup.tsx";
-import * as $$8 from "./islands/StyledInput.tsx";
-import * as $$9 from "./islands/StyledRadio.tsx";
-import * as $$10 from "./islands/StyledSelect.tsx";
-import * as $$11 from "./islands/StyledSingleCheckbox.tsx";
-import * as $$12 from "./islands/ThemeSwitcher.tsx";
+import * as $$3 from "./islands/FoodOrder.tsx";
+import * as $$4 from "./islands/FormWithValidation.tsx";
+import * as $$5 from "./islands/InsanitySection.tsx";
+import * as $$6 from "./islands/ProjectDiscovery.tsx";
+import * as $$7 from "./islands/StyledButton.tsx";
+import * as $$8 from "./islands/StyledCheckboxGroup.tsx";
+import * as $$9 from "./islands/StyledInput.tsx";
+import * as $$10 from "./islands/StyledRadio.tsx";
+import * as $$11 from "./islands/StyledSelect.tsx";
+import * as $$12 from "./islands/StyledSingleCheckbox.tsx";
+import * as $$13 from "./islands/ThemeSwitcher.tsx";
 
 const manifest = {
   routes: {
@@ -58,16 +59,17 @@ const manifest = {
     "./islands/AddNewExpense.tsx": $$0,
     "./islands/ExpensesTracker.tsx": $$1,
     "./islands/ExpensesYearSelect.tsx": $$2,
-    "./islands/FormWithValidation.tsx": $$3,
-    "./islands/InsanitySection.tsx": $$4,
-    "./islands/ProjectDiscovery.tsx": $$5,
-    "./islands/StyledButton.tsx": $$6,
-    "./islands/StyledCheckboxGroup.tsx": $$7,
-    "./islands/StyledInput.tsx": $$8,
-    "./islands/StyledRadio.tsx": $$9,
-    "./islands/StyledSelect.tsx": $$10,
-    "./islands/StyledSingleCheckbox.tsx": $$11,
-    "./islands/ThemeSwitcher.tsx": $$12,
+    "./islands/FoodOrder.tsx": $$3,
+    "./islands/FormWithValidation.tsx": $$4,
+    "./islands/InsanitySection.tsx": $$5,
+    "./islands/ProjectDiscovery.tsx": $$6,
+    "./islands/StyledButton.tsx": $$7,
+    "./islands/StyledCheckboxGroup.tsx": $$8,
+    "./islands/StyledInput.tsx": $$9,
+    "./islands/StyledRadio.tsx": $$10,
+    "./islands/StyledSelect.tsx": $$11,
+    "./islands/StyledSingleCheckbox.tsx": $$12,
+    "./islands/ThemeSwitcher.tsx": $$13,
   },
   baseUrl: import.meta.url,
   config,

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -20,21 +20,22 @@ import * as $13 from "./routes/projects.tsx";
 import * as $14 from "./routes/toys.tsx";
 import * as $15 from "./routes/what-is-this.tsx";
 import * as $16 from "./routes/work.tsx";
-import * as $$0 from "./islands/AddNewExpense.tsx";
-import * as $$1 from "./islands/ExpensesTracker.tsx";
-import * as $$2 from "./islands/ExpensesYearSelect.tsx";
-import * as $$3 from "./islands/FoodOrder.tsx";
-import * as $$4 from "./islands/FormWithValidation.tsx";
-import * as $$5 from "./islands/InsanitySection.tsx";
-import * as $$6 from "./islands/ModalWithBackdrop.tsx";
-import * as $$7 from "./islands/ProjectDiscovery.tsx";
-import * as $$8 from "./islands/StyledButton.tsx";
-import * as $$9 from "./islands/StyledCheckboxGroup.tsx";
-import * as $$10 from "./islands/StyledInput.tsx";
-import * as $$11 from "./islands/StyledRadio.tsx";
-import * as $$12 from "./islands/StyledSelect.tsx";
-import * as $$13 from "./islands/StyledSingleCheckbox.tsx";
-import * as $$14 from "./islands/ThemeSwitcher.tsx";
+import * as $$0 from "./islands/AccentButton.tsx";
+import * as $$1 from "./islands/AddNewExpense.tsx";
+import * as $$2 from "./islands/ExpensesTracker.tsx";
+import * as $$3 from "./islands/ExpensesYearSelect.tsx";
+import * as $$4 from "./islands/FoodOrder.tsx";
+import * as $$5 from "./islands/FormWithValidation.tsx";
+import * as $$6 from "./islands/InsanitySection.tsx";
+import * as $$7 from "./islands/ModalWithBackdrop.tsx";
+import * as $$8 from "./islands/ProjectDiscovery.tsx";
+import * as $$9 from "./islands/StyledButton.tsx";
+import * as $$10 from "./islands/StyledCheckboxGroup.tsx";
+import * as $$11 from "./islands/StyledInput.tsx";
+import * as $$12 from "./islands/StyledRadio.tsx";
+import * as $$13 from "./islands/StyledSelect.tsx";
+import * as $$14 from "./islands/StyledSingleCheckbox.tsx";
+import * as $$15 from "./islands/ThemeSwitcher.tsx";
 
 const manifest = {
   routes: {
@@ -57,21 +58,22 @@ const manifest = {
     "./routes/work.tsx": $16,
   },
   islands: {
-    "./islands/AddNewExpense.tsx": $$0,
-    "./islands/ExpensesTracker.tsx": $$1,
-    "./islands/ExpensesYearSelect.tsx": $$2,
-    "./islands/FoodOrder.tsx": $$3,
-    "./islands/FormWithValidation.tsx": $$4,
-    "./islands/InsanitySection.tsx": $$5,
-    "./islands/ModalWithBackdrop.tsx": $$6,
-    "./islands/ProjectDiscovery.tsx": $$7,
-    "./islands/StyledButton.tsx": $$8,
-    "./islands/StyledCheckboxGroup.tsx": $$9,
-    "./islands/StyledInput.tsx": $$10,
-    "./islands/StyledRadio.tsx": $$11,
-    "./islands/StyledSelect.tsx": $$12,
-    "./islands/StyledSingleCheckbox.tsx": $$13,
-    "./islands/ThemeSwitcher.tsx": $$14,
+    "./islands/AccentButton.tsx": $$0,
+    "./islands/AddNewExpense.tsx": $$1,
+    "./islands/ExpensesTracker.tsx": $$2,
+    "./islands/ExpensesYearSelect.tsx": $$3,
+    "./islands/FoodOrder.tsx": $$4,
+    "./islands/FormWithValidation.tsx": $$5,
+    "./islands/InsanitySection.tsx": $$6,
+    "./islands/ModalWithBackdrop.tsx": $$7,
+    "./islands/ProjectDiscovery.tsx": $$8,
+    "./islands/StyledButton.tsx": $$9,
+    "./islands/StyledCheckboxGroup.tsx": $$10,
+    "./islands/StyledInput.tsx": $$11,
+    "./islands/StyledRadio.tsx": $$12,
+    "./islands/StyledSelect.tsx": $$13,
+    "./islands/StyledSingleCheckbox.tsx": $$14,
+    "./islands/ThemeSwitcher.tsx": $$15,
   },
   baseUrl: import.meta.url,
   config,

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -26,14 +26,15 @@ import * as $$2 from "./islands/ExpensesYearSelect.tsx";
 import * as $$3 from "./islands/FoodOrder.tsx";
 import * as $$4 from "./islands/FormWithValidation.tsx";
 import * as $$5 from "./islands/InsanitySection.tsx";
-import * as $$6 from "./islands/ProjectDiscovery.tsx";
-import * as $$7 from "./islands/StyledButton.tsx";
-import * as $$8 from "./islands/StyledCheckboxGroup.tsx";
-import * as $$9 from "./islands/StyledInput.tsx";
-import * as $$10 from "./islands/StyledRadio.tsx";
-import * as $$11 from "./islands/StyledSelect.tsx";
-import * as $$12 from "./islands/StyledSingleCheckbox.tsx";
-import * as $$13 from "./islands/ThemeSwitcher.tsx";
+import * as $$6 from "./islands/ModalWithBackdrop.tsx";
+import * as $$7 from "./islands/ProjectDiscovery.tsx";
+import * as $$8 from "./islands/StyledButton.tsx";
+import * as $$9 from "./islands/StyledCheckboxGroup.tsx";
+import * as $$10 from "./islands/StyledInput.tsx";
+import * as $$11 from "./islands/StyledRadio.tsx";
+import * as $$12 from "./islands/StyledSelect.tsx";
+import * as $$13 from "./islands/StyledSingleCheckbox.tsx";
+import * as $$14 from "./islands/ThemeSwitcher.tsx";
 
 const manifest = {
   routes: {
@@ -62,14 +63,15 @@ const manifest = {
     "./islands/FoodOrder.tsx": $$3,
     "./islands/FormWithValidation.tsx": $$4,
     "./islands/InsanitySection.tsx": $$5,
-    "./islands/ProjectDiscovery.tsx": $$6,
-    "./islands/StyledButton.tsx": $$7,
-    "./islands/StyledCheckboxGroup.tsx": $$8,
-    "./islands/StyledInput.tsx": $$9,
-    "./islands/StyledRadio.tsx": $$10,
-    "./islands/StyledSelect.tsx": $$11,
-    "./islands/StyledSingleCheckbox.tsx": $$12,
-    "./islands/ThemeSwitcher.tsx": $$13,
+    "./islands/ModalWithBackdrop.tsx": $$6,
+    "./islands/ProjectDiscovery.tsx": $$7,
+    "./islands/StyledButton.tsx": $$8,
+    "./islands/StyledCheckboxGroup.tsx": $$9,
+    "./islands/StyledInput.tsx": $$10,
+    "./islands/StyledRadio.tsx": $$11,
+    "./islands/StyledSelect.tsx": $$12,
+    "./islands/StyledSingleCheckbox.tsx": $$13,
+    "./islands/ThemeSwitcher.tsx": $$14,
   },
   baseUrl: import.meta.url,
   config,

--- a/islands/AccentButton.tsx
+++ b/islands/AccentButton.tsx
@@ -1,0 +1,36 @@
+//? Import Preact JSX so we can define the props.children type
+import { JSX, toChildArray } from "preact";
+
+//? Define button properties
+interface AccentButtonProperties {
+  children: string | JSX.Element | JSX.Element[];
+  style?: string;
+  onClickFunction: () => void;
+}
+
+//? Simple button that uses accent color for fill and neutral neutral for text color and border
+//! Style buttons on-demand by providing a optional style prop!
+export default function AccentButton({
+  children,
+  style,
+  onClickFunction,
+}: AccentButtonProperties) {
+  return (
+    <button
+      //? Apply default styling
+      class="accent-button"
+      //? Apply additional styling, if provided
+      style={style}
+      //? When clicked, run provided function
+      onClick={(event) => {
+        event.preventDefault();
+        if (onClickFunction) {
+          onClickFunction();
+        }
+      }}
+    >
+      {/* Renders children as pure text if needed, else create array of elements */}
+      {typeof children === "string" ? children : [...toChildArray(children)]}
+    </button>
+  );
+}

--- a/islands/FoodOrder.tsx
+++ b/islands/FoodOrder.tsx
@@ -10,6 +10,7 @@ import ModalWithBackdrop from "./ModalWithBackdrop.tsx";
 import CartButton from "../components/food-order/CartButton.tsx";
 //? Content of the current Cart in a modal for the user to view Cart Items
 import CartModal from "../components/food-order/CartModal.tsx";
+import AccentButton from "./AccentButton.tsx";
 
 //? Define properties required for this component
 interface FoodOrderProperties {
@@ -95,7 +96,16 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
           }}
         />
       ))}
-      {/* //todo Add a "complete order" button at the bottom of the page */}
+      {cartContent.totalItems > 0
+        ? (
+          <AccentButton
+            style="align-self: end; margin: 0.5em 1em;"
+            onClickFunction={() => toggleDisplayModal(true)}
+          >
+            View order
+          </AccentButton>
+        )
+        : <></>}
       {/* //todo Add the loading spinner to the modal when completing the order */}
       {/* //todo disable clicking out of the modal when submitted */}
     </section>

--- a/islands/FoodOrder.tsx
+++ b/islands/FoodOrder.tsx
@@ -6,8 +6,10 @@ import type { Food } from "../types/Food.ts";
 import { FoodItem } from "../components/food-order/FoodItem.tsx";
 //todo
 import ModalWithBackdrop from "./ModalWithBackdrop.tsx";
-
 //todo
+import CartButton from "../components/food-order/CartButton.tsx";
+
+//? Define properties required for this component
 interface FoodOrderProperties {
   foods: Food[];
 }
@@ -40,24 +42,11 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
       {/* Header with cart */}
       <div class="food-header">
         <h2 class="subtopic">Meals of the day</h2>
-        {/* <CartButton /> */}
-        <button
-          class="food-cart styled-button"
-          onClick={() => toggleDisplayModal(true)}
-        >
-          <span class="cart-total-items">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="1em"
-              viewBox="0 0 576 512"
-              fill="var(--neutral-color)"
-            >
-              <path d="M0 24C0 10.7 10.7 0 24 0H69.5c22 0 41.5 12.8 50.6 32h411c26.3 0 45.5 25 38.6 50.4l-41 152.3c-8.5 31.4-37 53.3-69.5 53.3H170.7l5.4 28.5c2.2 11.3 12.1 19.5 23.6 19.5H488c13.3 0 24 10.7 24 24s-10.7 24-24 24H199.7c-34.6 0-64.3-24.6-70.7-58.5L77.4 54.5c-.7-3.8-4-6.5-7.9-6.5H24C10.7 48 0 37.3 0 24zM128 464a48 48 0 1 1 96 0 48 48 0 1 1 -96 0zm336-48a48 48 0 1 1 0 96 48 48 0 1 1 0-96z" />
-            </svg>
-            {cartContent.totalItems}
-          </span>
-          <span>${cartContent.cost.toFixed(2)}</span>
-        </button>
+        <CartButton
+          openModal={() => toggleDisplayModal(true)}
+          totalItems={cartContent.totalItems}
+          cost={cartContent.cost}
+        />
       </div>
       {/* List of invidual food options */}
       {foods.map((food) => (

--- a/islands/FoodOrder.tsx
+++ b/islands/FoodOrder.tsx
@@ -4,6 +4,8 @@ import { useState } from "preact/hooks";
 import type { Food } from "../types/Food.ts";
 //todo
 import { FoodItem } from "../components/food-order/FoodItem.tsx";
+//todo
+import ModalWithBackdrop from "./ModalWithBackdrop.tsx";
 
 //todo
 interface FoodOrderProperties {
@@ -12,21 +14,37 @@ interface FoodOrderProperties {
 
 //todo
 export default function FoodOrder({ foods }: FoodOrderProperties) {
+  //todo
   const [cartContent, updateCartContent] = useState({
     totalItems: 0,
     items: new Map(),
     cost: 0,
   });
+  //todo
+  const [displayModal, toggleDisplayModal] = useState(false);
 
   return (
     <section class="food-group">
-      {/* Backdrop */}
-      {/* Modal */}
+      <ModalWithBackdrop
+        key="backdrop-modal"
+        display={displayModal}
+        closeModalFunction={() => toggleDisplayModal(false)}
+      >
+        <div>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi
+          magnam maiores ad ipsum, architecto corporis. Voluptas totam nostrum
+          doloribus, voluptate quod voluptatum, cum necessitatibus atque quos
+          architecto beatae, perspiciatis porro!
+        </div>
+      </ModalWithBackdrop>
       {/* Header with cart */}
       <div class="food-header">
         <h2 class="subtopic">Meals of the day</h2>
-        {/* <FoodCart /> */}
-        <button class="food-cart styled-button">
+        {/* <CartButton /> */}
+        <button
+          class="food-cart styled-button"
+          onClick={() => toggleDisplayModal(true)}
+        >
           <span class="cart-total-items">
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/islands/FoodOrder.tsx
+++ b/islands/FoodOrder.tsx
@@ -1,0 +1,92 @@
+//? Import from Preact to be able to change state
+import { useState } from "preact/hooks";
+//? Import Food type to typecast the data received
+import type { Food } from "../types/Food.ts";
+//todo
+import { FoodItem } from "../components/food-order/FoodItem.tsx";
+
+//todo
+interface FoodOrderProperties {
+  foods: Food[];
+}
+
+//todo
+export default function FoodOrder({ foods }: FoodOrderProperties) {
+  const [cartContent, updateCartContent] = useState({
+    totalItems: 0,
+    items: new Map(),
+    cost: 0,
+  });
+
+  return (
+    <section class="food-group">
+      {/* Backdrop */}
+      {/* Modal */}
+      {/* Header with cart */}
+      <div class="food-header">
+        <h2 class="subtopic">Meals of the day</h2>
+        {/* <FoodCart /> */}
+        <button class="food-cart styled-button">
+          <span class="cart-total-items">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="1em"
+              viewBox="0 0 576 512"
+              fill="var(--neutral-color)"
+            >
+              <path d="M0 24C0 10.7 10.7 0 24 0H69.5c22 0 41.5 12.8 50.6 32h411c26.3 0 45.5 25 38.6 50.4l-41 152.3c-8.5 31.4-37 53.3-69.5 53.3H170.7l5.4 28.5c2.2 11.3 12.1 19.5 23.6 19.5H488c13.3 0 24 10.7 24 24s-10.7 24-24 24H199.7c-34.6 0-64.3-24.6-70.7-58.5L77.4 54.5c-.7-3.8-4-6.5-7.9-6.5H24C10.7 48 0 37.3 0 24zM128 464a48 48 0 1 1 96 0 48 48 0 1 1 -96 0zm336-48a48 48 0 1 1 0 96 48 48 0 1 1 0-96z" />
+            </svg>
+            {cartContent.totalItems}
+          </span>
+          <span>${cartContent.cost.toFixed(2)}</span>
+        </button>
+      </div>
+      {/* List of invidual food options */}
+      {foods.map((food) => (
+        <FoodItem
+          {
+            //? Add all food properties
+            ...food
+          }
+          //? Add the clicked food to the cart
+          addToCartFunction={() => {
+            //? Update the cart with the food clicked
+            updateCartContent((curr) => {
+              //? Instantiate a new cart with the updated information
+              const newCart = {
+                totalItems: ++curr.totalItems,
+                items: curr.items,
+                cost: curr.cost + food.price,
+              };
+
+              //? Attempt to fetch existing cart data for this food
+              const currentCartItems:
+                | undefined
+                | Record<string, number> = newCart.items.get(
+                  food.name,
+                );
+
+              //? If the clicked food is already in the cart,
+              //? increase the quantity in the cart
+              if (currentCartItems !== undefined) {
+                newCart.items.set(food.name, {
+                  quantity: currentCartItems.quantity + 1,
+                  cost: food.price,
+                });
+              } //? If the clicked food isn't in the cart yet, add one
+              else {
+                newCart.items.set(food.name, {
+                  quantity: 1,
+                  cost: food.price,
+                });
+              }
+
+              //? Return the updated cart
+              return newCart;
+            });
+          }}
+        />
+      ))}
+    </section>
+  );
+}

--- a/islands/FoodOrder.tsx
+++ b/islands/FoodOrder.tsx
@@ -38,6 +38,7 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
         <CartModal
           items={cartContent.items}
           cost={cartContent.cost}
+          updateCartFunction={updateCartContent}
           closeModal={() => toggleDisplayModal(false)}
         />
       </ModalWithBackdrop>

--- a/islands/FoodOrder.tsx
+++ b/islands/FoodOrder.tsx
@@ -10,6 +10,7 @@ import ModalWithBackdrop from "./ModalWithBackdrop.tsx";
 import CartButton from "../components/food-order/CartButton.tsx";
 //? Content of the current Cart in a modal for the user to view Cart Items
 import CartModal from "../components/food-order/CartModal.tsx";
+//? Import accent button to create the Order now! button at the bottom
 import AccentButton from "./AccentButton.tsx";
 
 //? Define properties required for this component
@@ -51,7 +52,7 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
           cost={cartContent.cost}
         />
       </div>
-      {/* List of invidual food options */}
+      {/* List of individual food options */}
       {foods.map((food) => (
         <FoodItem
           {

--- a/islands/FoodOrder.tsx
+++ b/islands/FoodOrder.tsx
@@ -1,5 +1,5 @@
 //? Import from Preact to be able to change state
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 //? Import Food type to typecast the data received
 import type { Food } from "../types/Food.ts";
 //? Renders invidual food items on the page
@@ -28,6 +28,27 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
   });
   //? Manages if the modal should be toggled on or off
   const [displayModal, toggleDisplayModal] = useState(false);
+  //? Tracks if the pulsing animation should be triggered
+  const [pulseState, togglePulse] = useState(false);
+  //? Tracks if the if pulsing animation is active and remove
+  //? the pulsing style once it ends
+  useEffect(() => {
+    //? If the pulsing animation isn't active, stop
+    if (pulseState === false) return;
+
+    //? Create a debouncer that tracks when the pulsing
+    //? animation should be stopped
+    const debouncer = setTimeout(() => {
+      togglePulse(false);
+    }, 300);
+
+    //? Cleanup function to avoid restarting the animation
+    //? when a new item is clicked, before the previous
+    //? addition has completed animating
+    return () => {
+      clearTimeout(debouncer);
+    };
+  }, [pulseState]);
 
   return (
     <section class="food-group">
@@ -47,6 +68,9 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
       <div class="food-header">
         <h2 class="subtopic">Meals of the day</h2>
         <CartButton
+          //? Pulses the cart when a new item is added
+          pulseState={pulseState}
+          //? Opens the modal when clicked
           openModal={() => toggleDisplayModal(true)}
           totalItems={cartContent.totalItems}
           cost={cartContent.cost}
@@ -91,6 +115,10 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
                   cost: food.price,
                 });
               }
+
+              //? Triggers the pulsing animation when an item
+              //? is added to the cart
+              togglePulse(true);
 
               //? Return the updated cart
               return newCart;

--- a/islands/FoodOrder.tsx
+++ b/islands/FoodOrder.tsx
@@ -2,12 +2,13 @@
 import { useState } from "preact/hooks";
 //? Import Food type to typecast the data received
 import type { Food } from "../types/Food.ts";
-//todo
+//? Renders invidual food items on the page
 import { FoodItem } from "../components/food-order/FoodItem.tsx";
-//todo
+//? Creates a modal with a shaded/blurred backdrop over the content behind it
 import ModalWithBackdrop from "./ModalWithBackdrop.tsx";
-//todo
+//? Cart Button that opens the current Cart as a Modal
 import CartButton from "../components/food-order/CartButton.tsx";
+//? Content of the current Cart in a modal for the user to view Cart Items
 import CartModal from "../components/food-order/CartModal.tsx";
 
 //? Define properties required for this component
@@ -15,15 +16,15 @@ interface FoodOrderProperties {
   foods: Food[];
 }
 
-//todo
+//? Renders the card with all food options and the header with the cart
 export default function FoodOrder({ foods }: FoodOrderProperties) {
-  //todo
+  //? Manages what items are currently in a cart and the overall cart price
   const [cartContent, updateCartContent] = useState({
     totalItems: 0,
     items: new Map(),
     cost: 0,
   });
-  //todo
+  //? Manages if the modal should be toggled on or off
   const [displayModal, toggleDisplayModal] = useState(false);
 
   return (
@@ -94,6 +95,9 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
           }}
         />
       ))}
+      {/* //todo Add a "complete order" button at the bottom of the page */}
+      {/* //todo Add the loading spinner to the modal when completing the order */}
+      {/* //todo disable clicking out of the modal when submitted */}
     </section>
   );
 }

--- a/islands/FoodOrder.tsx
+++ b/islands/FoodOrder.tsx
@@ -8,6 +8,7 @@ import { FoodItem } from "../components/food-order/FoodItem.tsx";
 import ModalWithBackdrop from "./ModalWithBackdrop.tsx";
 //todo
 import CartButton from "../components/food-order/CartButton.tsx";
+import CartModal from "../components/food-order/CartModal.tsx";
 
 //? Define properties required for this component
 interface FoodOrderProperties {
@@ -27,17 +28,16 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
 
   return (
     <section class="food-group">
+      {/* Cart modal with currently selected food items, if any */}
       <ModalWithBackdrop
-        key="backdrop-modal"
         display={displayModal}
         closeModalFunction={() => toggleDisplayModal(false)}
       >
-        <div>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi
-          magnam maiores ad ipsum, architecto corporis. Voluptas totam nostrum
-          doloribus, voluptate quod voluptatum, cum necessitatibus atque quos
-          architecto beatae, perspiciatis porro!
-        </div>
+        <CartModal
+          items={cartContent.items}
+          cost={cartContent.cost}
+          closeModal={() => toggleDisplayModal(false)}
+        />
       </ModalWithBackdrop>
       {/* Header with cart */}
       <div class="food-header">

--- a/islands/FormWithValidation.tsx
+++ b/islands/FormWithValidation.tsx
@@ -401,6 +401,13 @@ export default function FormWithValidation() {
                 check: { ...currentFormValues.check },
               };
               editedValues.check[checkName] = !editedValues.check[checkName];
+
+              //? Reset checkbox validation if user clicked any of the options
+              updateValidation((currentValidation) => ({
+                ...currentValidation,
+                check: validationStatus.Unchanged,
+              }));
+
               return editedValues;
             });
           }}

--- a/islands/ModalWithBackdrop.tsx
+++ b/islands/ModalWithBackdrop.tsx
@@ -19,10 +19,12 @@ export default function ModalWithBackdrop(
 
   //? If the display is true, display the overlay with the content provided
   return (
-    <div class="backdrop-overlay" onClick={closeModalFunction}>
+    <>
+      <div class="backdrop-overlay" onClick={closeModalFunction}>
+      </div>
       <div class="card card-shadow modal">
         {children}
       </div>
-    </div>
+    </>
   );
 }

--- a/islands/ModalWithBackdrop.tsx
+++ b/islands/ModalWithBackdrop.tsx
@@ -1,0 +1,28 @@
+//? Import Preact JSX so we can define the props.children type
+import { JSX } from "preact";
+
+//? Define properties required for this component
+interface ModalWithBackdropProperties {
+  display: boolean;
+  children: JSX.Element;
+  closeModalFunction: () => void;
+}
+
+//? Creates and exports a modal on top of a tinted blurred overlay that covers the background
+export default function ModalWithBackdrop(
+  { display, children, closeModalFunction }: ModalWithBackdropProperties,
+) {
+  //? If the display is false, return just JSX Fragment
+  if (display === false) {
+    return <></>;
+  }
+
+  //? If the display is true, display the overlay with the content provided
+  return (
+    <div class="backdrop-overlay" onClick={closeModalFunction}>
+      <div class="card card-shadow modal">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/islands/StyledButton.tsx
+++ b/islands/StyledButton.tsx
@@ -5,9 +5,7 @@ interface ButtonProperties {
   onClickFunction?: () => void;
 }
 
-//? This file holds the content to the default button used
-//? throughout the application. It comes with default internal
-//? spacing (padding) and coloring, but has no default margins
+//? Styled button with animation on hover
 //! Style buttons on-demand by providing a optional style prop!
 export default function StyledButton({
   text,

--- a/islands/StyledInput.tsx
+++ b/islands/StyledInput.tsx
@@ -1,4 +1,5 @@
 //? Validation values for typecasting
+import InformationIcon from "../assets/InformationIcon.tsx";
 import { validationStatus } from "../types/validationStatus.ts";
 
 //? Define optional and required properties for inputs
@@ -101,16 +102,7 @@ export default function StyledInput(
           {helpInformation && (
             <div class="tooltip">
               {/* Information icon */}
-              <svg
-                height="1.5em"
-                width="1.5em"
-                fill="currentColor"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 416.979 416.979"
-              >
-                <path d="M356.004,61.156c-81.37-81.47-213.377-81.551-294.848-0.182c-81.47,81.371-81.552,213.379-0.181,294.85 c81.369,81.47,213.378,81.551,294.849,0.181C437.293,274.636,437.375,142.626,356.004,61.156z M237.6,340.786 c0,3.217-2.607,5.822-5.822,5.822h-46.576c-3.215,0-5.822-2.605-5.822-5.822V167.885c0-3.217,2.607-5.822,5.822-5.822h46.576 c3.215,0,5.822,2.604,5.822,5.822V340.786z M208.49,137.901c-18.618,0-33.766-15.146-33.766-33.765 c0-18.617,15.147-33.766,33.766-33.766c18.619,0,33.766,15.148,33.766,33.766C242.256,122.755,227.107,137.901,208.49,137.901z">
-                </path>
-              </svg>
+              <InformationIcon iconHeight="1.8em" iconWidth="1.8em" />
               <span class="tooltiptext">{helpInformation}</span>
             </div>
           )}

--- a/islands/ThemeSwitcher.tsx
+++ b/islands/ThemeSwitcher.tsx
@@ -1,6 +1,8 @@
 //? Import hooks so a theme can be loaded on pageLoad and
 //? set on a click to the Radio buttons
 import { useEffect, useRef, useState } from "preact/hooks";
+import SunIcon from "../assets/SunIcon.tsx";
+import MoonIcon from "../assets/MoonIcon.tsx";
 
 //? Exports the ThemeSwitcher Island, so users can switch
 //? themes, if so they desire
@@ -63,17 +65,9 @@ export default function ThemeSwitcher() {
   if (theme === "Light") {
     return (
       <>
-        <button onClick={() => setTheme(() => "Dark")}>
-          <div class="theme-switcher">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="currentColor"
-              viewBox="0 0 16 16"
-            >
-              <path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z" />
-            </svg>
-            Light
-          </div>
+        <button class="theme-switcher" onClick={() => setTheme(() => "Dark")}>
+          <SunIcon iconHeight="1em" iconWidth="1em" />
+          Light
         </button>
       </>
     );
@@ -81,16 +75,9 @@ export default function ThemeSwitcher() {
   else if (theme === "Dark") {
     return (
       <>
-        <button onClick={() => setTheme(() => "Light")}>
-          <div class="theme-switcher">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-              <path
-                fill="currentColor"
-                d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z"
-              />
-            </svg>
-            Dark
-          </div>
+        <button class="theme-switcher" onClick={() => setTheme(() => "Light")}>
+          <MoonIcon iconHeight="1em" iconWidth="1em" />
+          Dark
         </button>
       </>
     );
@@ -99,7 +86,6 @@ export default function ThemeSwitcher() {
   else {
     return (
       <>
-        <div></div>
       </>
     );
   }

--- a/routes/[projects]/expenses-tracker.tsx
+++ b/routes/[projects]/expenses-tracker.tsx
@@ -1,6 +1,6 @@
 // //? To know what is the current route
 import { Handlers } from "$fresh/server.ts";
-//? Fetch a post from source and return it as a CompletePost type
+//? Import the function to fetch expenses from the database
 import fetchExpenses from "../../services/fetchExpenses.ts";
 //? Import the custom error to throw if the database fetch fails
 import FetchExpenseError from "../../types/FetchExpenseError.ts";
@@ -17,8 +17,8 @@ import ExpensesTracker from "../../islands/ExpensesTracker.tsx";
 //? Describe things that were learned with this current project
 import ProjectDiscovery from "../../islands/ProjectDiscovery.tsx";
 
-//? Runs before the render function to fetch the post from the files, then
-//? pushes
+//? Runs before the render function to fetch the expenses from the
+//? database, then pushes the data into the rendered page function
 export const handler: Handlers = {
   async GET(req, ctx) {
     const expenses = await fetchExpenses();

--- a/routes/[projects]/food-order.tsx
+++ b/routes/[projects]/food-order.tsx
@@ -28,6 +28,7 @@ export const handler: Handlers = {
   },
 };
 
+//todo
 export default function Home(
   { data: foods }: { data: Food[] },
 ) {
@@ -47,6 +48,7 @@ export default function Home(
         <link rel="stylesheet" href="/form.css" />
         <link rel="stylesheet" href="/styled-button.css" />
         <link rel="stylesheet" href="/food-order.css" />
+        <link rel="stylesheet" href="/modal.css" />
       </CustomHead>
       {/* Base page layout with theme switching and footer outside of accent box */}
       <Base>

--- a/routes/[projects]/food-order.tsx
+++ b/routes/[projects]/food-order.tsx
@@ -9,35 +9,28 @@ import BlogNavigationButtons from "../../components/blog/BlogNavigationButtons.t
 import { FoodItem } from "../../components/food-order/FoodItem.tsx";
 //? Describe things that were learned with this current project
 import ProjectDiscovery from "../../islands/ProjectDiscovery.tsx";
+//? Fetch food options from the database
+import fetchFood from "../../services/fetchFood.ts";
 //? Import Food type to typecast the data received
 import type { Food } from "../../types/Food.ts";
+//? Import database error instance to check for errors
+import DatabaseFetchError from "../../types/error/DatabaseFetchError.ts";
 
 //? Runs before the render function to fetch the food from the
 //? database, then pushes the data into the rendered page function
-// export const handler: Handlers = {
-//   async GET(req, ctx) {
-//     const expenses = await fetchExpenses();
-//     if (expenses instanceof FetchExpenseError) {
-//       return ctx.render([]);
-//     }
-//     return ctx.render(expenses);
-//   },
-// };
+export const handler: Handlers = {
+  async GET(req, ctx) {
+    const foods = await fetchFood();
+    if (foods instanceof DatabaseFetchError) {
+      return ctx.render([]);
+    }
+    return ctx.render(foods);
+  },
+};
 
 export default function Home(
-  //   { data: savedExpenses }: { data: Expense[] },
+  { data: foods }: { data: Food[] },
 ) {
-  const foods: Food[] = [{
-    imageLink:
-      "https://images.unsplash.com/photo-1544025162-d76694265947?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1469&q=80",
-    name: "Full buffet meal",
-    description:
-      "Pork ribs, vegetables, beans and french fries with cheese. Food for 2.",
-    price: "70",
-    imageAlt: "",
-    imageTitle: "",
-    addToCartFunction: () => {},
-  }];
   return (
     <>
       {
@@ -64,11 +57,15 @@ export default function Home(
           <ProjectDiscovery
             innerText={[
               // first paragraph
-              "Between the previous project (expenses tracker) and this one, there was an extended section about useContext and useRef, that was very interesting and helped solidify what I learned on the Preact tutorial. The things I've learned on that section are used in this project.",
+              "Between the previous project (expenses tracker) and this one, there was an extended section about 'useContext' and 'useRef', that was very interesting and helped solidify what I learned on the Preact tutorial. The things I've learned on that section are used in this project.",
+              // second paragraph
+              "I've also realized that this design looks very similar to the previous project, which just reminded me about how little creativity I have to design things and that designers are important. I could have just copied and pasted the styling from the course, but then this project would not fit in the overall theme for my website.",
+              // third paragraph
+              "However, since this project could become an actual freelance gig (there are plenty of business owners needing a website), I might just make a mockup website and put it on my Work page. I'll check with my designer if she can come up with something pretty.",
             ]}
           />
           {/* <FoodCart /> */}
-          <section class="card card-shadow food-group">
+          <section class="food-group">
             {foods.map((food) => (
               <FoodItem
                 imageLink={food.imageLink}
@@ -77,7 +74,8 @@ export default function Home(
                 name={food.name}
                 description={food.description}
                 price={food.price}
-                addToCartFunction={food.addToCartFunction}
+                feedsHowMany={food.feedsHowMany}
+                addToCartFunction={() => {}}
               />
             ))}
           </section>

--- a/routes/[projects]/food-order.tsx
+++ b/routes/[projects]/food-order.tsx
@@ -1,0 +1,88 @@
+//? To know what is the current route
+import { Handlers } from "$fresh/server.ts";
+//? Create blog content inside Base component
+import { Base } from "../../components/base/Base.tsx";
+//? Head component with all Meta tags pre-set
+import { CustomHead } from "../../components/base/CustomHead.tsx";
+//? Navigation Buttons to go back to the previous page or to the next article
+import BlogNavigationButtons from "../../components/blog/BlogNavigationButtons.tsx";
+import { FoodItem } from "../../components/food-order/FoodItem.tsx";
+//? Describe things that were learned with this current project
+import ProjectDiscovery from "../../islands/ProjectDiscovery.tsx";
+//? Import Food type to typecast the data received
+import type { Food } from "../../types/Food.ts";
+
+//? Runs before the render function to fetch the food from the
+//? database, then pushes the data into the rendered page function
+// export const handler: Handlers = {
+//   async GET(req, ctx) {
+//     const expenses = await fetchExpenses();
+//     if (expenses instanceof FetchExpenseError) {
+//       return ctx.render([]);
+//     }
+//     return ctx.render(expenses);
+//   },
+// };
+
+export default function Home(
+  //   { data: savedExpenses }: { data: Expense[] },
+) {
+  const foods: Food[] = [{
+    imageLink:
+      "https://images.unsplash.com/photo-1544025162-d76694265947?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1469&q=80",
+    name: "Full buffet meal",
+    description:
+      "Pork ribs, vegetables, beans and french fries with cheese. Food for 2.",
+    price: "70",
+    imageAlt: "",
+    imageTitle: "",
+    addToCartFunction: () => {},
+  }];
+  return (
+    <>
+      {
+        /* Base Head with all common required imports, plus added
+        meta-tags and imports required for this specific route */
+      }
+      <CustomHead
+        title="Food order"
+        description="Order your favorite food in our theorical restaurant and feast upon the delicious pixels!"
+        link="https://www.theyurig.com/projects/food-order"
+      >
+        <link rel="stylesheet" href="/content.css" />
+        <link rel="stylesheet" href="/navigation-buttons.css" />
+        <link rel="stylesheet" href="/form.css" />
+        <link rel="stylesheet" href="/styled-button.css" />
+        <link rel="stylesheet" href="/food-order.css" />
+      </CustomHead>
+      {/* Base page layout with theme switching and footer outside of accent box */}
+      <Base>
+        <BlogNavigationButtons
+          back={{ title: "Return to projects overview", link: "/projects" }}
+        />
+        <section class="center">
+          <ProjectDiscovery
+            innerText={[
+              // first paragraph
+              "Between the previous project (expenses tracker) and this one, there was an extended section about useContext and useRef, that was very interesting and helped solidify what I learned on the Preact tutorial. The things I've learned on that section are used in this project.",
+            ]}
+          />
+          {/* <FoodCart /> */}
+          <section class="card card-shadow food-group">
+            {foods.map((food) => (
+              <FoodItem
+                imageLink={food.imageLink}
+                imageAlt={food.imageAlt}
+                imageTitle={food.imageTitle}
+                name={food.name}
+                description={food.description}
+                price={food.price}
+                addToCartFunction={food.addToCartFunction}
+              />
+            ))}
+          </section>
+        </section>
+      </Base>
+    </>
+  );
+}

--- a/routes/[projects]/food-order.tsx
+++ b/routes/[projects]/food-order.tsx
@@ -28,7 +28,7 @@ export const handler: Handlers = {
   },
 };
 
-//todo
+//? Renders the food-order page, with a list of items and a cart
 export default function Home(
   { data: foods }: { data: Food[] },
 ) {
@@ -65,6 +65,8 @@ export default function Home(
               "I've also realized that this design looks very similar to the previous project, which just reminded me about how little creativity I have to design things and that designers are important. I could have just copied and pasted the styling from the course, but then this project would not fit in the overall theme for my website.",
               // third paragraph
               "However, since this project could become an actual freelance gig (there are plenty of business owners needing a website), I might just make a mockup website and put it on my Work page. I'll check with my designer if she can come up with something pretty.",
+              // fourth paragraph
+              "This section also made me look up how to create a modal in React (I've previously only made them with pure JS and in Vue), so that was a fun component to build and that I'll be reusing quite a few times.",
             ]}
           />
           {/* Page content */}

--- a/routes/[projects]/food-order.tsx
+++ b/routes/[projects]/food-order.tsx
@@ -47,6 +47,7 @@ export default function Home(
         <link rel="stylesheet" href="/navigation-buttons.css" />
         <link rel="stylesheet" href="/form.css" />
         <link rel="stylesheet" href="/styled-button.css" />
+        <link rel="stylesheet" href="/accent-button.css" />
         <link rel="stylesheet" href="/food-order.css" />
         <link rel="stylesheet" href="/modal.css" />
       </CustomHead>

--- a/routes/[projects]/food-order.tsx
+++ b/routes/[projects]/food-order.tsx
@@ -6,7 +6,7 @@ import { Base } from "../../components/base/Base.tsx";
 import { CustomHead } from "../../components/base/CustomHead.tsx";
 //? Navigation Buttons to go back to the previous page or to the next article
 import BlogNavigationButtons from "../../components/blog/BlogNavigationButtons.tsx";
-import { FoodItem } from "../../components/food-order/FoodItem.tsx";
+import FoodOrder from "../../islands/FoodOrder.tsx";
 //? Describe things that were learned with this current project
 import ProjectDiscovery from "../../islands/ProjectDiscovery.tsx";
 //? Fetch food options from the database
@@ -54,6 +54,7 @@ export default function Home(
           back={{ title: "Return to projects overview", link: "/projects" }}
         />
         <section class="center">
+          {/* Insights */}
           <ProjectDiscovery
             innerText={[
               // first paragraph
@@ -64,21 +65,8 @@ export default function Home(
               "However, since this project could become an actual freelance gig (there are plenty of business owners needing a website), I might just make a mockup website and put it on my Work page. I'll check with my designer if she can come up with something pretty.",
             ]}
           />
-          {/* <FoodCart /> */}
-          <section class="food-group">
-            {foods.map((food) => (
-              <FoodItem
-                imageLink={food.imageLink}
-                imageAlt={food.imageAlt}
-                imageTitle={food.imageTitle}
-                name={food.name}
-                description={food.description}
-                price={food.price}
-                feedsHowMany={food.feedsHowMany}
-                addToCartFunction={() => {}}
-              />
-            ))}
-          </section>
+          {/* Page content */}
+          <FoodOrder foods={foods} />
         </section>
       </Base>
     </>

--- a/routes/projects.tsx
+++ b/routes/projects.tsx
@@ -24,8 +24,8 @@ export default function Home() {
         <article class="center">
           <h1>List of Projects</h1>
           <p class="space">
-            Below you can find some of the projects I needed to complete while
-            undertaking the{" "}
+            Below you can find the projects I completed while going through the
+            {" "}
             <GradientLink
               content=" React - The Complete Guide"
               link="https://www.udemy.com/course/react-the-complete-guide-incl-redux/"
@@ -62,14 +62,35 @@ export default function Home() {
             to make them look like the way I like them, rather than using the
             default course styling.
           </p>
+          <p class="space">
+            Every project page includes a toggleable summary of what I learned
+            when completing the project. Overall, I don't think it was that
+            useful for me because I had already learned the large bulk of React
+            features previously by building websites for my freelance clients.
+            While it was nice to learn about Fragments, React.createElement(),
+            Portals and Context, almost none of my clients jobs would benefit by
+            any of those, so it was mostly nice-to-know course for me.
+          </p>
           <ol
             start={1}
             style="align-self: start; list-style-type: lower-greek;"
           >
+            {/* Expenses tracker */}
             <li>
               <GradientLink
                 content="Expenses tracker"
                 link="/projects/expenses-tracker"
+                title="Expenses tracker that allow filtering by year and provides simple bar charts for each month's totals"
+                newTab={false}
+              />
+            </li>
+            {/* Food order */}
+            <li>
+              <GradientLink
+                content="Food order"
+                link="/projects/food-order"
+                title="Mock of a food order app. Comes with a built-in cart system that allows the user to manage their items"
+                newTab={false}
               />
             </li>
           </ol>

--- a/services/fetchExpenses.ts
+++ b/services/fetchExpenses.ts
@@ -5,42 +5,43 @@ import FetchExpenseError from "../types/FetchExpenseError.ts";
 
 //todo remove the warning below once this is moved to a database fetch
 // deno-lint-ignore require-await
-export default async function fetchExpenses(
-): Promise<FetchExpenseError | Expense[]> {
-    try {
-        //? Mock expenses
-        const expenses = [
-            {
-                date: new Date(2020, 1, 1),
-                description: "Medical Insurance",
-                cost: 3600,
-            },
-            {
-                date: new Date(2020, 5, 3),
-                description: "Shoes",
-                cost: 200,
-            },
-            {
-                date: new Date(2020, 8, 18),
-                description: "House",
-                cost: 250000,
-            },
-            {
-                date: new Date(2020, 9, 20),
-                description: "Car",
-                cost: 40000,
-            },
-            {
-                date: new Date(2020, 11, 28),
-                description: "Kids",
-                cost: 10000,
-            },
-        ];
-        return expenses;
-    } catch (error) {
-        return new FetchExpenseError(
-            "Unable to find any Expenses!",
-            error.trace,
-        );
-    }
+export default async function fetchExpenses(): Promise<
+  FetchExpenseError | Expense[]
+> {
+  try {
+    //? Mock expenses
+    const expenses = [
+      {
+        date: new Date(2020, 1, 1),
+        description: "Medical Insurance",
+        cost: 3600,
+      },
+      {
+        date: new Date(2020, 5, 3),
+        description: "Shoes",
+        cost: 200,
+      },
+      {
+        date: new Date(2020, 8, 18),
+        description: "House",
+        cost: 250000,
+      },
+      {
+        date: new Date(2020, 9, 20),
+        description: "Car",
+        cost: 40000,
+      },
+      {
+        date: new Date(2020, 11, 28),
+        description: "Kids",
+        cost: 10000,
+      },
+    ];
+    return expenses;
+  } catch (error) {
+    return new FetchExpenseError(
+      "Unable to find any Expenses!",
+      error.trace,
+    );
+  }
 }

--- a/services/fetchFood.ts
+++ b/services/fetchFood.ts
@@ -5,67 +5,70 @@ import DatabaseFetchError from "../types/error/DatabaseFetchError.ts";
 
 //todo remove the warning below once this is moved to a database fetch
 // deno-lint-ignore require-await
-export default async function fetchFood(
-): Promise<DatabaseFetchError | Food[]> {
-    try {
-        //? Mock food
-        const foods: Food[] = [{
-            imageLink:
-                "https://images.unsplash.com/photo-1514516345957-556ca7d90a29?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80",
-            imageAlt: "Delicious ceasar salad",
-            imageTitle:
-                "Very healthy salad with low fat meat. Good appetizer for the main dish.",
-            name: "Ceasar Salad",
-            description:
-                "Medium meat, onion and well seasoned vegetables, raspberries for extra flavor.",
-            feedsHowMany: "2",
-            price: 7.2,
-        }, {
-            imageLink:
-                "https://images.unsplash.com/photo-1559847844-1ff4d5bcd3b4?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1458&q=80",
-            imageAlt: "Breaded steak with sauce on the side",
-            imageTitle: "Ordering this makes you sad, because eventually you can't eat it anymore and that's depressing",
-            name: "Breaded Steak",
-            description:
-                "Seasoned thin steak, coated in cracker meal and fried. Traditional Cuban meal. Onion sauce included.",
-            feedsHowMany: "1",
-            price: 16.8,
-        }, {
-            imageLink:
-                "https://images.unsplash.com/photo-1554502078-ef0fc409efce?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1084&q=80",
-            imageAlt: "Sushi with shrimp",
-            imageTitle: "Won't turn your skin pink... hopefully",
-            name: "Nigiri Sushi",
-            description:
-                "Excellent seafood for even the most traditional customers. Wasabi paste included.",
-            feedsHowMany: "2",
-            price: 25.4,
-        }, {
-            imageLink:
-                "https://images.unsplash.com/photo-1604908176997-125f25cc6f3d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1013&q=80",
-            imageAlt: "Plate of chicken cut in cubes",
-            imageTitle: "It tastes even better than it looks",
-            name: "Seasoned Chicken",
-            description:
-                "Chicken breast in cubes, seasoned and with slices of tomato. Low fat, high nutrients, ideal for post-workouts.",
-            feedsHowMany: "1",
-            price: 13.99,
-        }, {
-            imageLink:
-                "https://images.unsplash.com/photo-1617093727343-374698b1b08d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80",
-            imageAlt: "Ramen bowl",
-            imageTitle: "If this can turn a Genin into a Kage, it can also turn a hangry person into a happy one.",
-            name: "Ramen",
-            description:
-                "Japanese noodle soup, with a combination of a rich flavoured broth, one of a variety of types of noodle and a selection of meats or vegetables.",
-            feedsHowMany: "1",
-            price: 8.15,
-        }];
-        return foods;
-    } catch (error) {
-        return new DatabaseFetchError(
-            "Unable to find any Food!",
-            error.trace,
-        );
-    }
+export default async function fetchFood(): Promise<
+  DatabaseFetchError | Food[]
+> {
+  try {
+    //? Mock food
+    const foods: Food[] = [{
+      imageLink:
+        "https://images.unsplash.com/photo-1514516345957-556ca7d90a29?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80",
+      imageAlt: "Delicious ceasar salad",
+      imageTitle:
+        "Very healthy salad with low fat meat. Good appetizer for the main dish.",
+      name: "Ceasar Salad",
+      description:
+        "Medium meat, onion and well seasoned vegetables, raspberries for extra flavor.",
+      feedsHowMany: "2",
+      price: 7.2,
+    }, {
+      imageLink:
+        "https://images.unsplash.com/photo-1559847844-1ff4d5bcd3b4?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1458&q=80",
+      imageAlt: "Breaded steak with sauce on the side",
+      imageTitle:
+        "Ordering this makes you sad, because eventually you can't eat it anymore and that's depressing",
+      name: "Breaded Steak",
+      description:
+        "Seasoned thin steak, coated in cracker meal and fried. Traditional Cuban meal. Onion sauce included.",
+      feedsHowMany: "1",
+      price: 16.8,
+    }, {
+      imageLink:
+        "https://images.unsplash.com/photo-1554502078-ef0fc409efce?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1084&q=80",
+      imageAlt: "Sushi with shrimp",
+      imageTitle: "Won't turn your skin pink... hopefully",
+      name: "Nigiri Sushi",
+      description:
+        "Excellent seafood for even the most traditional customers. Wasabi paste included.",
+      feedsHowMany: "2",
+      price: 25.4,
+    }, {
+      imageLink:
+        "https://images.unsplash.com/photo-1604908176997-125f25cc6f3d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1013&q=80",
+      imageAlt: "Plate of chicken cut in cubes",
+      imageTitle: "It tastes even better than it looks",
+      name: "Seasoned Chicken",
+      description:
+        "Chicken breast in cubes, seasoned and with slices of tomato. Low fat, high nutrients, ideal for post-workouts.",
+      feedsHowMany: "1",
+      price: 13.99,
+    }, {
+      imageLink:
+        "https://images.unsplash.com/photo-1617093727343-374698b1b08d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80",
+      imageAlt: "Ramen bowl",
+      imageTitle:
+        "If this can turn a Genin into a Kage, it can also turn a hangry person into a happy one.",
+      name: "Ramen",
+      description:
+        "Japanese noodle soup, with a combination of a rich flavoured broth, one of a variety of types of noodle and a selection of meats or vegetables.",
+      feedsHowMany: "1",
+      price: 8.15,
+    }];
+    return foods;
+  } catch (error) {
+    return new DatabaseFetchError(
+      "Unable to find any Food!",
+      error.trace,
+    );
+  }
 }

--- a/services/fetchFood.ts
+++ b/services/fetchFood.ts
@@ -1,0 +1,71 @@
+//? Import Food to typecast outbound data
+import type { Food } from "../types/Food.ts";
+//? Import fetch error
+import DatabaseFetchError from "../types/error/DatabaseFetchError.ts";
+
+//todo remove the warning below once this is moved to a database fetch
+// deno-lint-ignore require-await
+export default async function fetchFood(
+): Promise<DatabaseFetchError | Food[]> {
+    try {
+        //? Mock food
+        const foods: Food[] = [{
+            imageLink:
+                "https://images.unsplash.com/photo-1514516345957-556ca7d90a29?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80",
+            imageAlt: "Delicious ceasar salad",
+            imageTitle:
+                "Very healthy salad with low fat meat. Good appetizer for the main dish.",
+            name: "Ceasar salad",
+            description:
+                "Medium meat, onion and well seasoned vegetables, raspberries for extra flavor.",
+            feedsHowMany: "2",
+            price: 7,
+        }, {
+            imageLink:
+                "https://images.unsplash.com/photo-1559847844-1ff4d5bcd3b4?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1458&q=80",
+            imageAlt: "",
+            imageTitle: "",
+            name: "Breaded steak",
+            description:
+                "Seasoned thin steak, coated in cracker meal and fried. Traditional Cuban meal. Onion sauce included.",
+            feedsHowMany: "1",
+            price: 17,
+        }, {
+            imageLink:
+                "https://images.unsplash.com/photo-1554502078-ef0fc409efce?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1084&q=80",
+            imageAlt: "",
+            imageTitle: "",
+            name: "Nigiri Sushi",
+            description:
+                "Excellent seafood for even the most traditional customers. Wasabi paste included.",
+            feedsHowMany: "2",
+            price: 25,
+        }, {
+            imageLink:
+                "https://images.unsplash.com/photo-1604908176997-125f25cc6f3d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1013&q=80",
+            imageAlt: "",
+            imageTitle: "",
+            name: "High protein chicken meal",
+            description:
+                "Seasoned chicken with tomatoes. Low fat, high nutrients, ideal for post-workouts.",
+            feedsHowMany: "1",
+            price: 13,
+        }, {
+            imageLink:
+                "https://images.unsplash.com/photo-1617093727343-374698b1b08d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80",
+            imageAlt: "",
+            imageTitle: "",
+            name: "Ramen",
+            description:
+                "Japanese noodle soup, with a combination of a rich flavoured broth, one of a variety of types of noodle and a selection of meats or vegetables.",
+            feedsHowMany: "1",
+            price: 8,
+        }];
+        return foods;
+    } catch (error) {
+        return new DatabaseFetchError(
+            "Unable to find any Food!",
+            error.trace,
+        );
+    }
+}

--- a/services/fetchFood.ts
+++ b/services/fetchFood.ts
@@ -15,51 +15,51 @@ export default async function fetchFood(
             imageAlt: "Delicious ceasar salad",
             imageTitle:
                 "Very healthy salad with low fat meat. Good appetizer for the main dish.",
-            name: "Ceasar salad",
+            name: "Ceasar Salad",
             description:
                 "Medium meat, onion and well seasoned vegetables, raspberries for extra flavor.",
             feedsHowMany: "2",
-            price: 7,
+            price: 7.2,
         }, {
             imageLink:
                 "https://images.unsplash.com/photo-1559847844-1ff4d5bcd3b4?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1458&q=80",
-            imageAlt: "",
-            imageTitle: "",
-            name: "Breaded steak",
+            imageAlt: "Breaded steak with sauce on the side",
+            imageTitle: "Ordering this makes you sad, because eventually you can't eat it anymore and that's depressing",
+            name: "Breaded Steak",
             description:
                 "Seasoned thin steak, coated in cracker meal and fried. Traditional Cuban meal. Onion sauce included.",
             feedsHowMany: "1",
-            price: 17,
+            price: 16.8,
         }, {
             imageLink:
                 "https://images.unsplash.com/photo-1554502078-ef0fc409efce?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1084&q=80",
-            imageAlt: "",
-            imageTitle: "",
+            imageAlt: "Sushi with shrimp",
+            imageTitle: "Won't turn your skin pink... hopefully",
             name: "Nigiri Sushi",
             description:
                 "Excellent seafood for even the most traditional customers. Wasabi paste included.",
             feedsHowMany: "2",
-            price: 25,
+            price: 25.4,
         }, {
             imageLink:
                 "https://images.unsplash.com/photo-1604908176997-125f25cc6f3d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1013&q=80",
-            imageAlt: "",
-            imageTitle: "",
-            name: "High protein chicken meal",
+            imageAlt: "Plate of chicken cut in cubes",
+            imageTitle: "It tastes even better than it looks",
+            name: "Seasoned Chicken",
             description:
-                "Seasoned chicken with tomatoes. Low fat, high nutrients, ideal for post-workouts.",
+                "Chicken breast in cubes, seasoned and with slices of tomato. Low fat, high nutrients, ideal for post-workouts.",
             feedsHowMany: "1",
-            price: 13,
+            price: 13.99,
         }, {
             imageLink:
                 "https://images.unsplash.com/photo-1617093727343-374698b1b08d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80",
-            imageAlt: "",
-            imageTitle: "",
+            imageAlt: "Ramen bowl",
+            imageTitle: "If this can turn a Genin into a Kage, it can also turn a hangry person into a happy one.",
             name: "Ramen",
             description:
                 "Japanese noodle soup, with a combination of a rich flavoured broth, one of a variety of types of noodle and a selection of meats or vegetables.",
             feedsHowMany: "1",
-            price: 8,
+            price: 8.15,
         }];
         return foods;
     } catch (error) {

--- a/services/food-order/updateFoodOrder.ts
+++ b/services/food-order/updateFoodOrder.ts
@@ -3,99 +3,99 @@ import type { updateCartFunction } from "../../types/food-order/updateCartFuncti
 
 //? Export the function responsible for increasing a Cart item by one
 export function increaseCartItemByOne(
-    { foodName, foodCost, updateCartFunction }: {
-        foodName: string;
-        foodCost: number;
-        updateCartFunction: updateCartFunction;
-    },
+  { foodName, foodCost, updateCartFunction }: {
+    foodName: string;
+    foodCost: number;
+    updateCartFunction: updateCartFunction;
+  },
 ) {
-    updateCartFunction((curr) => {
-        //? Instantiate current cart
-        const updatedCart = { ...curr };
+  updateCartFunction((curr) => {
+    //? Instantiate current cart
+    const updatedCart = { ...curr };
 
-        //? Increase the total item count by 1
-        updatedCart.totalItems += 1;
-        //? Increase the overall cart price by the
-        //? cost of another of this item
-        updatedCart.cost += foodCost;
+    //? Increase the total item count by 1
+    updatedCart.totalItems += 1;
+    //? Increase the overall cart price by the
+    //? cost of another of this item
+    updatedCart.cost += foodCost;
 
-        //? Increase the count of this specific item on the cart
-        const increasedCountItem = updatedCart.items.get(
-            foodName,
-        );
-        if (increasedCountItem !== undefined) {
-            increasedCountItem.quantity += 1;
-            updatedCart.items.set(
-                foodName,
-                increasedCountItem,
-            );
-        }
+    //? Increase the count of this specific item on the cart
+    const increasedCountItem = updatedCart.items.get(
+      foodName,
+    );
+    if (increasedCountItem !== undefined) {
+      increasedCountItem.quantity += 1;
+      updatedCart.items.set(
+        foodName,
+        increasedCountItem,
+      );
+    }
 
-        //? Return the updated cart as updated state
-        return updatedCart;
-    });
+    //? Return the updated cart as updated state
+    return updatedCart;
+  });
 }
 
 //? Export the function responsible for reducing a Cart item by one
 export function reduceCartItemByOne(
-    { foodName, foodCost, updateCartFunction }: {
-        foodName: string;
-        foodCost: number;
-        updateCartFunction: updateCartFunction;
-    },
+  { foodName, foodCost, updateCartFunction }: {
+    foodName: string;
+    foodCost: number;
+    updateCartFunction: updateCartFunction;
+  },
 ) {
-    updateCartFunction((curr) => {
-        //? Instantiate current cart
-        const updatedCart = { ...curr };
+  updateCartFunction((curr) => {
+    //? Instantiate current cart
+    const updatedCart = { ...curr };
 
-        //? Decrease the total item count by 1
-        updatedCart.totalItems -= 1;
-        //? Discount the overall cart price by the
-        //? cost of another of this item
-        updatedCart.cost -= foodCost;
+    //? Decrease the total item count by 1
+    updatedCart.totalItems -= 1;
+    //? Discount the overall cart price by the
+    //? cost of another of this item
+    updatedCart.cost -= foodCost;
 
-        //? Increase the count of this specific item on the cart
-        const decreasedCountItem = updatedCart.items.get(
-            foodName,
+    //? Increase the count of this specific item on the cart
+    const decreasedCountItem = updatedCart.items.get(
+      foodName,
+    );
+    if (decreasedCountItem !== undefined) {
+      if (decreasedCountItem.quantity > 1) {
+        decreasedCountItem.quantity -= 1;
+        updatedCart.items.set(
+          foodName,
+          decreasedCountItem,
         );
-        if (decreasedCountItem !== undefined) {
-            if (decreasedCountItem.quantity > 1) {
-                decreasedCountItem.quantity -= 1;
-                updatedCart.items.set(
-                    foodName,
-                    decreasedCountItem,
-                );
-            } else {
-                updatedCart.items.delete(foodName);
-            }
-        }
+      } else {
+        updatedCart.items.delete(foodName);
+      }
+    }
 
-        //? Return the updated cart as updated state
-        return updatedCart;
-    });
+    //? Return the updated cart as updated state
+    return updatedCart;
+  });
 }
 
 //? Export the function responsible for removing an item from the cart
 export function deleteItemFromCart(
-    { foodName, foodQuantity, foodCost, updateCartFunction }: {
-        foodName: string;
-        foodQuantity: number;
-        foodCost: number;
-        updateCartFunction: updateCartFunction;
-    },
+  { foodName, foodQuantity, foodCost, updateCartFunction }: {
+    foodName: string;
+    foodQuantity: number;
+    foodCost: number;
+    updateCartFunction: updateCartFunction;
+  },
 ) {
-    updateCartFunction((curr) => {
-        //? Instantiate current cart
-        const updatedCart = { ...curr };
+  updateCartFunction((curr) => {
+    //? Instantiate current cart
+    const updatedCart = { ...curr };
 
-        //? Remove as many items from the cart as were added of this item
-        updatedCart.totalItems -= foodQuantity;
-        //? Discount the cart by the cost of all items of this type
-        updatedCart.cost -= foodQuantity * foodCost;
-        //? Remove this item from the tracked items
-        updatedCart.items.delete(foodName);
+    //? Remove as many items from the cart as were added of this item
+    updatedCart.totalItems -= foodQuantity;
+    //? Discount the cart by the cost of all items of this type
+    updatedCart.cost -= foodQuantity * foodCost;
+    //? Remove this item from the tracked items
+    updatedCart.items.delete(foodName);
 
-        //? Return the updated cart as updated state
-        return updatedCart;
-    });
+    //? Return the updated cart as updated state
+    return updatedCart;
+  });
 }

--- a/services/food-order/updateFoodOrder.ts
+++ b/services/food-order/updateFoodOrder.ts
@@ -1,0 +1,101 @@
+//? Import the type of the function that updates the Cart's state
+import type { updateCartFunction } from "../../types/food-order/updateCartFunction.ts";
+
+//? Export the function responsible for increasing a Cart item by one
+export function increaseCartItemByOne(
+    { foodName, foodCost, updateCartFunction }: {
+        foodName: string;
+        foodCost: number;
+        updateCartFunction: updateCartFunction;
+    },
+) {
+    updateCartFunction((curr) => {
+        //? Instantiate current cart
+        const updatedCart = { ...curr };
+
+        //? Increase the total item count by 1
+        updatedCart.totalItems += 1;
+        //? Increase the overall cart price by the
+        //? cost of another of this item
+        updatedCart.cost += foodCost;
+
+        //? Increase the count of this specific item on the cart
+        const increasedCountItem = updatedCart.items.get(
+            foodName,
+        );
+        if (increasedCountItem !== undefined) {
+            increasedCountItem.quantity += 1;
+            updatedCart.items.set(
+                foodName,
+                increasedCountItem,
+            );
+        }
+
+        //? Return the updated cart as updated state
+        return updatedCart;
+    });
+}
+
+//? Export the function responsible for reducing a Cart item by one
+export function reduceCartItemByOne(
+    { foodName, foodCost, updateCartFunction }: {
+        foodName: string;
+        foodCost: number;
+        updateCartFunction: updateCartFunction;
+    },
+) {
+    updateCartFunction((curr) => {
+        //? Instantiate current cart
+        const updatedCart = { ...curr };
+
+        //? Decrease the total item count by 1
+        updatedCart.totalItems -= 1;
+        //? Discount the overall cart price by the
+        //? cost of another of this item
+        updatedCart.cost -= foodCost;
+
+        //? Increase the count of this specific item on the cart
+        const decreasedCountItem = updatedCart.items.get(
+            foodName,
+        );
+        if (decreasedCountItem !== undefined) {
+            if (decreasedCountItem.quantity > 1) {
+                decreasedCountItem.quantity -= 1;
+                updatedCart.items.set(
+                    foodName,
+                    decreasedCountItem,
+                );
+            } else {
+                updatedCart.items.delete(foodName);
+            }
+        }
+
+        //? Return the updated cart as updated state
+        return updatedCart;
+    });
+}
+
+//? Export the function responsible for removing an item from the cart
+export function deleteItemFromCart(
+    { foodName, foodQuantity, foodCost, updateCartFunction }: {
+        foodName: string;
+        foodQuantity: number;
+        foodCost: number;
+        updateCartFunction: updateCartFunction;
+    },
+) {
+    updateCartFunction((curr) => {
+        //? Instantiate current cart
+        const updatedCart = { ...curr };
+
+        //? Remove as many items from the cart as were added of this item
+        updatedCart.totalItems -= foodQuantity;
+        //? Discount the cart by the cost of all items of this type
+        updatedCart.cost -= foodQuantity * foodCost;
+        //? Remove this item from the tracked items
+        updatedCart.items.delete(foodName);
+
+        //? Return the updated cart as updated state
+        return updatedCart;
+    });
+}

--- a/static/accent-button.css
+++ b/static/accent-button.css
@@ -1,0 +1,19 @@
+/* Style the accent button */
+.accent-button {
+    display: flex;
+    align-items: center;
+    padding: 0.25em 0.5em;
+    background-color: var(--accent-color);
+    border: 2px solid var(--neutral-color);
+    border-radius: 2em;
+    transition: box-shadow 0.4s, transform 0.4s;
+}
+
+/* Elevate the accent button on hover/focus */
+.accent-button:hover,
+.accent-button:focus {
+    /* X-axis, Y-axis (needs to match translateY!), blur, color */
+    box-shadow: 0em 0.15em 0.1em var(--neutral-color);
+    /* Elevate button, must match Y-axis shadow above! */
+    transform: translateY(-0.15em);
+}

--- a/static/base.css
+++ b/static/base.css
@@ -22,9 +22,13 @@ html {
 /* Define default card styling to be reused */
 .card {
     padding: 0.5em 1em;
-    margin-bottom: 1em;
     border: 2px solid var(--neutral-color);
     border-radius: 1rem;
+}
+
+/* Add spacing between consecutive cards */
+.card+.card {
+    margin-top: 1em;
 }
 
 /* Define default card shadow */

--- a/static/base.css
+++ b/static/base.css
@@ -50,28 +50,24 @@ main {
     transition: border 0.7s ease-in-out 0.3s;
 }
 
-/* Position the theme switcher on the bottom left corner */
-aside {
-    width: 5em;
-    height: min-content;
-    position: fixed;
-    bottom: 3.2em;
-    rotate: -90deg;
-    translate: -75%;
-    font-size: 1.2rem;
-}
-
-/* Define theme SVG size, push text away */
-aside svg {
-    width: 1em;
-    margin-right: 0.2em;
-}
 
 /* Organize theme button horizontally and align vertically */
 .theme-switcher {
     display: flex;
-    text-justify: center;
+    align-items: center;
+    width: 4em;
+    height: 1.3em;
+    position: fixed;
+    bottom: 2.5em;
+    rotate: -90deg;
+    translate: -83%;
+    font-size: 1.3rem;
     animation: fadeThemeSwitcherIn 0.3s;
+}
+
+/* Define theme SVG size, push text away */
+.theme-switcher svg {
+    margin-right: 0.2em;
 }
 
 /* Animate the Theme Switcher to fade in gracefully instead of popping in */
@@ -100,7 +96,7 @@ aside svg {
 }
 
 /* Style the images on the footer */
-footer img {
+.page-footer img {
     margin-left: 0.4rem;
     margin-right: 0.4rem;
     height: 18px;

--- a/static/food-order.css
+++ b/static/food-order.css
@@ -21,6 +21,21 @@
     margin-right: 1em;
 }
 
+/* Defines pulsating animation for cart button when adding new food item */
+@keyframes pulseCartOnItemAdd {
+    0% {
+        transform: scale(1);
+    }
+
+    70% {
+        transform: scale(1.1);
+    }
+
+    100% {
+        transform: scale(1);
+    }
+}
+
 /* Space between the cart SVG and the total items count */
 .cart-total-items svg {
     margin-right: 0.25em;

--- a/static/food-order.css
+++ b/static/food-order.css
@@ -42,6 +42,37 @@
     fill: var(--accent-color)
 }
 
+/* Makes the modal content use all the modal width */
+.food-cart-content {
+    max-width: 100%;
+    padding: 0.7em;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Increase font size for modal header */
+.food-cart-content__header {
+    font-size: 1.3rem;
+    font-weight: 700;
+    margin-bottom: 0.5em;
+    text-align: center;
+}
+
+/* Space the total value from the other things */
+.food-cart-content__total {
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+    font-size: 1.1rem;
+    font-weight: 700;
+    text-align: end;
+}
+
+/* Row of buttons for the modal when there are items */
+.food-cart-content__button-row {
+    display: flex;
+    align-self: end;
+}
+
 /* Style each individual food item */
 .single-food {
     min-height: 8em;

--- a/static/food-order.css
+++ b/static/food-order.css
@@ -13,16 +13,6 @@
     padding: 0.5em 1em;
 }
 
-/* Style the food cart on the header */
-.food-cart {
-    display: flex;
-    align-items: center;
-    padding: 0.25em 0.5em;
-    background-color: var(--accent-color);
-    border: 2px solid var(--neutral-color);
-    border-radius: 2em;
-}
-
 /* Space the total items away from the cart price */
 .cart-total-items {
     display: flex;
@@ -34,12 +24,6 @@
 /* Space between the cart SVG and the total items count */
 .cart-total-items svg {
     margin-right: 0.25em;
-    transition: fill ease-in-out 0.8s;
-}
-
-/* Animate cart SVG on cart button hover */
-.food-cart:hover svg {
-    fill: var(--accent-color)
 }
 
 /* Makes the modal content use all the modal width */

--- a/static/food-order.css
+++ b/static/food-order.css
@@ -72,6 +72,11 @@
     align-self: end;
 }
 
+/* Row of buttons for the modal when there are items */
+.food-cart-content__button-row svg:hover {
+    cursor: pointer
+}
+
 /* Style each individual food item */
 .single-food {
     min-height: 8em;
@@ -123,15 +128,14 @@
 number of people for this meal in a line */
 .food-for-how-many {
     display: flex;
-    font-size: 1rem;
+    align-items: center;
+    font-size: 0.8em;
 }
 
 /* Defines size for the people icon near the food name */
 .food-for-how-many svg {
     margin-left: 0.5em;
-    margin-right: 0.25em;
-    height: 1.5em;
-    width: 1.5em;
+    margin-right: 0.05em;
 }
 
 /* Slightly reduces the size of food descriptions */

--- a/static/food-order.css
+++ b/static/food-order.css
@@ -1,43 +1,123 @@
-.cart {
-    border-color: var(--accent-color);
+/* Style the overarching group of food header and food items */
+.food-group {
+    border: 2px solid var(--accent-color);
+    border-radius: 0.5em;
+    padding: 0.25em;
 }
 
-/* .food-group {} */
+/* Styles the header above the food listing */
+.food-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.5em 1em;
+}
 
+/* Style the food cart on the header */
+.food-cart {
+    display: flex;
+    align-items: center;
+    padding: 0.25em 0.5em;
+    background-color: var(--accent-color);
+    border: 2px solid var(--neutral-color);
+    border-radius: 2em;
+}
+
+/* Space the total items away from the cart price */
+.cart-total-items {
+    display: flex;
+    align-items: center;
+    /* Space total items from cart price */
+    margin-right: 1em;
+}
+
+/* Space between the cart SVG and the total items count */
+.cart-total-items svg {
+    margin-right: 0.25em;
+    transition: fill ease-in-out 0.8s;
+}
+
+/* Animate cart SVG on cart button hover */
+.food-cart:hover svg {
+    fill: var(--accent-color)
+}
+
+/* Style each individual food item */
 .single-food {
-    min-height: 10em;
+    min-height: 8em;
     width: 100%;
     padding: 0;
     padding-bottom: 1em;
+    margin: 0;
+    background-color: var(--base-color);
+    border-color: var(--neutral-color);
     overflow: hidden;
     display: flex;
     flex-direction: column;
     align-items: center;
+    transition: color ease-in-out 0.8s, background-color ease-in-out 0.8s;
 }
 
+/* Define food image dimensions */
 .food-image {
-    height: 10em;
+    max-height: 20em;
     object-fit: cover;
-
+    /* Stops the name and description from squishing image */
+    flex-shrink: 0;
 }
 
+/* Organize food name and description in a column */
 .food-name-and-description {
     display: flex;
     flex-direction: column;
-    flex-shrink: 1;
+    flex-grow: 1;
+    width: 100%;
+    /* Center both on smaller resolutions.
+    Aligns left on larger resolutions */
     text-align: center;
     margin: 0.5em;
 }
 
+/* Styles food name */
 .food-name {
+    display: flex;
+    align-items: center;
+    /* Centers food name on mobile.
+    Will justify left on larger resolutions */
+    justify-content: center;
     font-size: 1.7rem;
     font-family: 'Alfa Slab One', cursive;
 }
 
+/* Organize the people icon and the 
+number of people for this meal in a line */
+.food-for-how-many {
+    display: flex;
+    font-size: 1rem;
+}
+
+/* Defines size for the people icon near the food name */
+.food-for-how-many svg {
+    margin-left: 0.5em;
+    margin-right: 0.25em;
+    height: 1.5em;
+    width: 1.5em;
+}
+
+/* Slightly reduces the size of food descriptions */
 .food-description {
     font-size: 0.9rem;
 }
 
+/* Turns the food header into a row */
+@media (min-width: 600px) {
+    .food-header {
+        flex-direction: row;
+        justify-content: space-between;
+    }
+}
+
+/* Adjust cards to become a row on larger resolutions */
 @media (min-width: 900px) {
     .single-food {
         flex-direction: row;
@@ -45,12 +125,20 @@
         padding-right: 0.5em;
     }
 
+    /* Limit food image size */
     .food-image {
+        height: 8em;
         width: 10em;
     }
 
+    /* Aligns left the food name and description */
     .food-name-and-description {
         text-align: left;
         margin: 0 0.5em;
+    }
+
+    /* Aligns left the food name */
+    .food-name {
+        justify-content: start;
     }
 }

--- a/static/food-order.css
+++ b/static/food-order.css
@@ -1,0 +1,56 @@
+.cart {
+    border-color: var(--accent-color);
+}
+
+/* .food-group {} */
+
+.single-food {
+    min-height: 10em;
+    width: 100%;
+    padding: 0;
+    padding-bottom: 1em;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.food-image {
+    height: 10em;
+    object-fit: cover;
+
+}
+
+.food-name-and-description {
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 1;
+    text-align: center;
+    margin: 0.5em;
+}
+
+.food-name {
+    font-size: 1.7rem;
+    font-family: 'Alfa Slab One', cursive;
+}
+
+.food-description {
+    font-size: 0.9rem;
+}
+
+@media (min-width: 900px) {
+    .single-food {
+        flex-direction: row;
+        padding-bottom: 0;
+        padding-right: 0.5em;
+    }
+
+    .food-image {
+        width: 10em;
+    }
+
+    .food-name-and-description {
+        text-align: left;
+        margin: 0 0.5em;
+    }
+}

--- a/static/loading-animation.css
+++ b/static/loading-animation.css
@@ -1,0 +1,24 @@
+/* Attach the animation to the proper container */
+#spinner {
+    transform-origin: center;
+    animation: 2s infinite loading-spinner;
+    animation-timing-function: cubic-bezier;
+}
+
+/* Defines the loading pacing */
+@keyframes loading-spinner {
+    0% {
+        stroke-dasharray: 1 98;
+        stroke-dashoffset: -105;
+    }
+
+    50% {
+        stroke-dasharray: 80 10;
+        stroke-dashoffset: -160;
+    }
+
+    100% {
+        stroke-dasharray: 1 98;
+        stroke-dashoffset: -300;
+    }
+}

--- a/static/modal.css
+++ b/static/modal.css
@@ -13,7 +13,8 @@
 /* Styles centered modal within backdrop-overlay */
 .modal {
     /* Centers the modal in the center of the backdrop */
-    position: absolute;
+    position: fixed;
+    z-index: 2;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);

--- a/static/modal.css
+++ b/static/modal.css
@@ -1,0 +1,25 @@
+/* Creates a blurred, shades overlay over the background */
+.backdrop-overlay {
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 100dvw;
+    height: 100dvh;
+    background-color: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(0.2em);
+}
+
+/* Styles centered modal within backdrop-overlay */
+.modal {
+    /* Centers the modal in the center of the backdrop */
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    /* Define dimensions and styles */
+    min-width: 50dvw;
+    max-width: 80dvw;
+    background-color: var(--base-color);
+}

--- a/static/navigation-buttons.css
+++ b/static/navigation-buttons.css
@@ -1,18 +1,22 @@
 /* Styling for navigation buttons above article */
 .navigation-button {
-	display: flex;
-	align-items: center;
-	padding-right: 0.25rem;
-	font-size: 1.3rem;
-	transition: color 0s ease-in-out;
+    display: flex;
+    align-items: center;
+    font-size: 1.3rem;
+    transition: color 0.4s ease-in-out;
 }
 
-/* Size for SVGs inside navigation */
+/* Style navigation SVG transition animation */
 .navigation-button svg {
-	width: 2rem;
+    transition: fill 0.4s ease-in-out;
 }
 
 /* Change navigation color on hover */
 .navigation-button:hover {
-	color: var(--accent-color);
+    color: var(--accent-color);
+}
+
+/* Change navigation SVG color on hover */
+.navigation-button:hover svg {
+    fill: var(--accent-color);
 }

--- a/types/Expense.ts
+++ b/types/Expense.ts
@@ -1,6 +1,6 @@
 //? All the data an Expense is required to have
 export interface Expense {
-    date: Date;
-    description: string,
-    cost: number,
+  date: Date;
+  description: string;
+  cost: number;
 }

--- a/types/FetchExpenseError.ts
+++ b/types/FetchExpenseError.ts
@@ -1,11 +1,11 @@
 //? Creates an instance of Error to be returned when fetchExpenses() fails
 export default class FetchExpenseError extends Error {
-    constructor(public message: string, public trace: Error["stack"]) {
-        //? Pass the Error message
-        super(message);
-        //? Names this error
-        this.name = "FetchExpenseError";
-        //? Attaches original stack trace
-        this.stack = trace;
-    }
+  constructor(public message: string, public trace: Error["stack"]) {
+    //? Pass the Error message
+    super(message);
+    //? Names this error
+    this.name = "FetchExpenseError";
+    //? Attaches original stack trace
+    this.stack = trace;
+  }
 }

--- a/types/Food.ts
+++ b/types/Food.ts
@@ -5,5 +5,5 @@ export interface Food {
     name: string;
     description: string;
     feedsHowMany: string;
-    price: string;
+    price: number;
 }

--- a/types/Food.ts
+++ b/types/Food.ts
@@ -1,9 +1,9 @@
 export interface Food {
-    imageLink: string;
-    imageAlt: string;
-    imageTitle: string;
-    name: string;
-    description: string;
-    feedsHowMany: string;
-    price: number;
+  imageLink: string;
+  imageAlt: string;
+  imageTitle: string;
+  name: string;
+  description: string;
+  feedsHowMany: string;
+  price: number;
 }

--- a/types/Food.ts
+++ b/types/Food.ts
@@ -4,6 +4,6 @@ export interface Food {
     imageTitle: string;
     name: string;
     description: string;
+    feedsHowMany: string;
     price: string;
-    addToCartFunction: () => void;
 }

--- a/types/Food.ts
+++ b/types/Food.ts
@@ -1,0 +1,9 @@
+export interface Food {
+    imageLink: string;
+    imageAlt: string;
+    imageTitle: string;
+    name: string;
+    description: string;
+    price: string;
+    addToCartFunction: () => void;
+}

--- a/types/IconProperties.ts
+++ b/types/IconProperties.ts
@@ -1,8 +1,12 @@
 //? Defines optional propertes for any Icon being instantiated
 export interface IconProperties {
-    iconHeight: string;
-    iconWidth: string;
-    iconFillColor?: string;
-    iconStrokeColor?: string;
-    iconStrokeWidth?: string;
+  iconHeight: string;
+  iconWidth: string;
+  iconFillColor?: string;
+}
+
+//? Adds stroke properties to the previous interface
+export interface IconPropertiesWithStroke extends IconProperties {
+  iconStrokeColor?: string;
+  iconStrokeWidth?: string;
 }

--- a/types/IconProperties.ts
+++ b/types/IconProperties.ts
@@ -1,0 +1,8 @@
+//? Defines optional propertes for any Icon being instantiated
+export interface IconProperties {
+    iconHeight: string;
+    iconWidth: string;
+    iconFillColor?: string;
+    iconStrokeColor?: string;
+    iconStrokeWidth?: string;
+}

--- a/types/LinkProperties.ts
+++ b/types/LinkProperties.ts
@@ -1,5 +1,5 @@
 //? Define essential properties to a link (anchor tag)
 export interface LinkProperties {
-    title: string;
-    link: string;
+  title: string;
+  link: string;
 }

--- a/types/error/DatabaseFetchError.ts
+++ b/types/error/DatabaseFetchError.ts
@@ -1,0 +1,11 @@
+//? Creates an instance of Error to be returned when a database call fails
+export default class DatabaseFetchError extends Error {
+    constructor(public message: string, public trace: Error["stack"]) {
+        //? Pass the Error message
+        super(message);
+        //? Names this error
+        this.name = "DatabaseFetchError";
+        //? Attaches original stack trace
+        this.stack = trace;
+    }
+}

--- a/types/error/DatabaseFetchError.ts
+++ b/types/error/DatabaseFetchError.ts
@@ -1,11 +1,11 @@
 //? Creates an instance of Error to be returned when a database call fails
 export default class DatabaseFetchError extends Error {
-    constructor(public message: string, public trace: Error["stack"]) {
-        //? Pass the Error message
-        super(message);
-        //? Names this error
-        this.name = "DatabaseFetchError";
-        //? Attaches original stack trace
-        this.stack = trace;
-    }
+  constructor(public message: string, public trace: Error["stack"]) {
+    //? Pass the Error message
+    super(message);
+    //? Names this error
+    this.name = "DatabaseFetchError";
+    //? Attaches original stack trace
+    this.stack = trace;
+  }
 }

--- a/types/food-order/foodCartItemsMap.ts
+++ b/types/food-order/foodCartItemsMap.ts
@@ -1,0 +1,3 @@
+
+//? Export Map typing for the items property of a Cart
+export type foodCartItemsMap = Map<string, { quantity: number; cost: number }>;

--- a/types/food-order/foodCartItemsMap.ts
+++ b/types/food-order/foodCartItemsMap.ts
@@ -1,3 +1,2 @@
-
 //? Export Map typing for the items property of a Cart
 export type foodCartItemsMap = Map<string, { quantity: number; cost: number }>;

--- a/types/food-order/updateCartFunction.ts
+++ b/types/food-order/updateCartFunction.ts
@@ -1,0 +1,12 @@
+//? Import types for typecasting
+import type { StateUpdater } from "preact/hooks";
+import type { foodCartItemsMap } from "./foodCartItemsMap.ts";
+
+//? Export what the state updating function should look like
+export type updateCartFunction = StateUpdater<
+    {
+        totalItems: number;
+        items: foodCartItemsMap;
+        cost: number;
+    }
+>;

--- a/types/food-order/updateCartFunction.ts
+++ b/types/food-order/updateCartFunction.ts
@@ -4,9 +4,9 @@ import type { foodCartItemsMap } from "./foodCartItemsMap.ts";
 
 //? Export what the state updating function should look like
 export type updateCartFunction = StateUpdater<
-    {
-        totalItems: number;
-        items: foodCartItemsMap;
-        cost: number;
-    }
+  {
+    totalItems: number;
+    items: foodCartItemsMap;
+    cost: number;
+  }
 >;

--- a/types/stimulusCheckboxOptions.ts
+++ b/types/stimulusCheckboxOptions.ts
@@ -1,3 +1,2 @@
 //? Enums for locking in possible stimulus checkbox options
-export type stimulusCheckboxOptions =
-    "individual" | "family" | "business"
+export type stimulusCheckboxOptions = "individual" | "family" | "business";

--- a/types/validationStatus.ts
+++ b/types/validationStatus.ts
@@ -1,4 +1,6 @@
 //? Enums for locking in possible validation statuses
 export enum validationStatus {
-    Invalid, Unchanged, Valid
+  Invalid,
+  Unchanged,
+  Valid,
 }


### PR DESCRIPTION
Completed a new project and added Food Order to `/projects/food-order`.

Additionally, this PR also batches the following updates:
- Moved all (or nearly all?) SVGs to an independent component on the `/assets` folder, for easier reusability.
- Reset checkbox validation when the user clicks any of the checkbox items, after failing to select one before trying to submit.
- Improved spacing between two consecutive cards.
- Added a modal+backdrop overlay component to easily create modals.
- Added a loading animation component to `/assets`.