### PR TITLE
feat: clicking food-order image will display high resolution version

### DIFF
--- a/components/food-order/CartModal.tsx
+++ b/components/food-order/CartModal.tsx
@@ -67,7 +67,7 @@ export default function CartModal({
               <div style="display: inline-flex;">
                 {/* Decrease item count. If last item, remove it from the cart */}
                 <span
-                  style="margin-right: 0.5em"
+                  class="mr-2 hover:cursor-pointer"
                   onClick={() => {
                     reduceCartItemByOne({
                       foodName,
@@ -81,6 +81,7 @@ export default function CartModal({
                 </span>
                 {/* Increase item count */}
                 <span
+                  class="hover:cursor-pointer"
                   onClick={() => {
                     increaseCartItemByOne({
                       foodName,
@@ -94,7 +95,7 @@ export default function CartModal({
                 </span>
                 {/* Remove item completely from cart */}
                 <span
-                  style="margin-left: 0.5em"
+                  class="ml-2 hover:cursor-pointer"
                   onClick={() => {
                     deleteItemFromCart({
                       foodName,

--- a/components/food-order/CartModal.tsx
+++ b/components/food-order/CartModal.tsx
@@ -130,11 +130,13 @@ export default function CartModal({
         >
           Add more
         </button>
-        <StyledButton
+        {
+          /* <StyledButton
           style="margin-left: 1em;"
           text="Order"
           onClickFunction={closeModal}
-        />
+        /> */
+        }
       </div>
     </div>
   );

--- a/components/food-order/FoodItem.tsx
+++ b/components/food-order/FoodItem.tsx
@@ -15,17 +15,22 @@ export function FoodItem(
     feedsHowMany,
     price,
     addToCartFunction,
-  }: Food & { addToCartFunction: () => void },
+    expandImageFunction,
+  }: Food & {
+    addToCartFunction: () => void;
+    expandImageFunction: (imageLink: string) => void;
+  },
 ) {
   return (
     //? Whole card
     <div class="card single-food">
       {/* Food image */}
       <img
-        class="food-image"
+        class="food-image hover:cursor-pointer"
         src={imageLink}
         alt={imageAlt}
         title={imageTitle}
+        onClick={() => expandImageFunction(imageLink)}
       />
       {/* Column with food name + how many it feeds and food description */}
       <div class="food-name-and-description">

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -28,15 +28,16 @@ import * as $$3 from "./islands/ExpensesYearSelect.tsx";
 import * as $$4 from "./islands/FoodOrder.tsx";
 import * as $$5 from "./islands/FormWithValidation.tsx";
 import * as $$6 from "./islands/InsanitySection.tsx";
-import * as $$7 from "./islands/ModalWithBackdrop.tsx";
-import * as $$8 from "./islands/ProjectDiscovery.tsx";
-import * as $$9 from "./islands/StyledButton.tsx";
-import * as $$10 from "./islands/StyledCheckboxGroup.tsx";
-import * as $$11 from "./islands/StyledInput.tsx";
-import * as $$12 from "./islands/StyledRadio.tsx";
-import * as $$13 from "./islands/StyledSelect.tsx";
-import * as $$14 from "./islands/StyledSingleCheckbox.tsx";
-import * as $$15 from "./islands/ThemeSwitcher.tsx";
+import * as $$7 from "./islands/ModalExtendedImage.tsx";
+import * as $$8 from "./islands/ModalWithBackdrop.tsx";
+import * as $$9 from "./islands/ProjectDiscovery.tsx";
+import * as $$10 from "./islands/StyledButton.tsx";
+import * as $$11 from "./islands/StyledCheckboxGroup.tsx";
+import * as $$12 from "./islands/StyledInput.tsx";
+import * as $$13 from "./islands/StyledRadio.tsx";
+import * as $$14 from "./islands/StyledSelect.tsx";
+import * as $$15 from "./islands/StyledSingleCheckbox.tsx";
+import * as $$16 from "./islands/ThemeSwitcher.tsx";
 
 const manifest = {
   routes: {
@@ -67,15 +68,16 @@ const manifest = {
     "./islands/FoodOrder.tsx": $$4,
     "./islands/FormWithValidation.tsx": $$5,
     "./islands/InsanitySection.tsx": $$6,
-    "./islands/ModalWithBackdrop.tsx": $$7,
-    "./islands/ProjectDiscovery.tsx": $$8,
-    "./islands/StyledButton.tsx": $$9,
-    "./islands/StyledCheckboxGroup.tsx": $$10,
-    "./islands/StyledInput.tsx": $$11,
-    "./islands/StyledRadio.tsx": $$12,
-    "./islands/StyledSelect.tsx": $$13,
-    "./islands/StyledSingleCheckbox.tsx": $$14,
-    "./islands/ThemeSwitcher.tsx": $$15,
+    "./islands/ModalExtendedImage.tsx": $$7,
+    "./islands/ModalWithBackdrop.tsx": $$8,
+    "./islands/ProjectDiscovery.tsx": $$9,
+    "./islands/StyledButton.tsx": $$10,
+    "./islands/StyledCheckboxGroup.tsx": $$11,
+    "./islands/StyledInput.tsx": $$12,
+    "./islands/StyledRadio.tsx": $$13,
+    "./islands/StyledSelect.tsx": $$14,
+    "./islands/StyledSingleCheckbox.tsx": $$15,
+    "./islands/ThemeSwitcher.tsx": $$16,
   },
   baseUrl: import.meta.url,
   config,

--- a/islands/FoodOrder.tsx
+++ b/islands/FoodOrder.tsx
@@ -12,6 +12,7 @@ import CartButton from "../components/food-order/CartButton.tsx";
 import CartModal from "../components/food-order/CartModal.tsx";
 //? Import accent button to create the Order now! button at the bottom
 import AccentButton from "./AccentButton.tsx";
+import ModalExtendedImage from "./ModalExtendedImage.tsx";
 
 //? Define properties required for this component
 interface FoodOrderProperties {
@@ -30,6 +31,12 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
   const [displayModal, toggleDisplayModal] = useState(false);
   //? Tracks if the pulsing animation should be triggered
   const [pulseState, togglePulse] = useState(false);
+
+  //? Manages if the expanded image modal should be toggled on or off
+  const [expandFoodImage, displayExpandedFoodImage] = useState(false);
+  //todo
+  const [expandedModalImageLink, updateExpandedModalImageLink] = useState("");
+
   //? Tracks if the if pulsing animation is active and remove
   //? the pulsing style once it ends
   useEffect(() => {
@@ -64,6 +71,11 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
           closeModal={() => toggleDisplayModal(false)}
         />
       </ModalWithBackdrop>
+      <ModalExtendedImage
+        display={expandFoodImage}
+        imageLink={expandedModalImageLink}
+        closeModalFunction={() => displayExpandedFoodImage(false)}
+      />
       {/* Header with cart */}
       <div class="food-header">
         <h2 class="subtopic">Meals of the day</h2>
@@ -123,6 +135,10 @@ export default function FoodOrder({ foods }: FoodOrderProperties) {
               //? Return the updated cart
               return newCart;
             });
+          }}
+          expandImageFunction={(imageLink) => {
+            updateExpandedModalImageLink(imageLink);
+            displayExpandedFoodImage(true);
           }}
         />
       ))}

--- a/islands/ModalExtendedImage.tsx
+++ b/islands/ModalExtendedImage.tsx
@@ -1,0 +1,34 @@
+//? Define properties required for this component
+interface ModalExtendedImageProperties {
+  display: boolean;
+  imageLink: string;
+  closeModalFunction: () => void;
+}
+
+//? Creates and exports a modal that expands an image on top of
+//? a tinted blurred overlay that covers the background
+export default function ModalExtendedImage(
+  { display, imageLink, closeModalFunction }: ModalExtendedImageProperties,
+) {
+  //? If the display is false, return just JSX Fragment
+  if (display === false) {
+    return <></>;
+  }
+
+  //? If the display is true, display the overlay with the content provided
+  return (
+    <>
+      <div
+        class="backdrop-overlay"
+        style="background-color: rgba(0, 0, 0, 0.8);"
+        onClick={closeModalFunction}
+      >
+        <img
+          class="fixed top-1/2 left-1/2 -translate-y-1/2 -translate-x-1/2"
+          src={imageLink}
+          alt="Delicious food"
+        />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
When viewing a food order item, you can now click the food image to expand the image to its largest resolution.
Closes #58.

Additionally, this PR also fixes cart icons now turning the cursor into a pointer on hover, which was bad UX for desktop users.