### PR TITLE
feat: better display items on food-order cart

### DIFF
--- a/assets/MinusIcon.tsx
+++ b/assets/MinusIcon.tsx
@@ -10,7 +10,7 @@ export default function MinusIcon(
       xmlns="http://www.w3.org/2000/svg"
       height={iconHeight ?? "1em"}
       width={iconWidth ?? "1em"}
-      viewBox="0 0 576 512"
+      viewBox="0 0 500 512"
       fill={iconFillColor ?? "var(--neutral-color)"}
     >
       <path d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z" />

--- a/assets/PlusIcon.tsx
+++ b/assets/PlusIcon.tsx
@@ -10,7 +10,7 @@ export default function PlusIcon(
       xmlns="http://www.w3.org/2000/svg"
       height={iconHeight ?? "1em"}
       width={iconWidth ?? "1em"}
-      viewBox="0 0 576 512"
+      viewBox="0 0 500 512"
       fill={iconFillColor ?? "var(--neutral-color)"}
     >
       <path d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32V224H48c-17.7 0-32 14.3-32 32s14.3 32 32 32H192V432c0 17.7 14.3 32 32 32s32-14.3 32-32V288H400c17.7 0 32-14.3 32-32s-14.3-32-32-32H256V80z" />

--- a/components/food-order/CartModal.tsx
+++ b/components/food-order/CartModal.tsx
@@ -57,65 +57,70 @@ export default function CartModal({
       {/* List of items in cart */}
       <ol>
         {cartItems.map(([foodName, { quantity, cost }]) => (
-          <li>
-            <div style="display: flex; justify-content: space-between; align-items: center;">
+          <li class="flex flex-col">
+            <div class="flex justify-between items-center">
               {/* Cart item name */}
-              <span>
-                {foodName}: {quantity}x ${cost.toFixed(2)}
+              <h3 class="text-xl">
+                {foodName}
+              </h3>
+              {/* Remove item completely from cart */}
+              <span
+                class="hover:cursor-pointer"
+                onClick={() => {
+                  deleteItemFromCart({
+                    foodName,
+                    foodQuantity: quantity,
+                    foodCost: cost,
+                    updateCartFunction,
+                  });
+                }}
+              >
+                {/* XMark SVG */}
+                <XMarkIcon
+                  iconHeight="1.5em"
+                  iconWidth="1.5em"
+                  iconFillColor="red"
+                  iconStrokeColor="var(--neutral-color)"
+                  iconStrokeWidth="30"
+                />
               </span>
-              {/* Update cart item count */}
-              <div style="display: inline-flex;">
-                {/* Decrease item count. If last item, remove it from the cart */}
-                <span
-                  class="mr-2 hover:cursor-pointer"
-                  onClick={() => {
-                    reduceCartItemByOne({
-                      foodName,
-                      foodCost: cost,
-                      updateCartFunction,
-                    });
-                  }}
-                >
-                  {/* Minus sign SVG */}
-                  <MinusIcon iconHeight="1.5em" iconWidth="1.5em" />
-                </span>
-                {/* Increase item count */}
-                <span
-                  class="hover:cursor-pointer"
-                  onClick={() => {
-                    increaseCartItemByOne({
-                      foodName,
-                      foodCost: cost,
-                      updateCartFunction,
-                    });
-                  }}
-                >
-                  {/* Plus sign SVG */}
-                  <PlusIcon iconHeight="1.5em" iconWidth="1.5em" />
-                </span>
-                {/* Remove item completely from cart */}
-                <span
-                  class="ml-2 hover:cursor-pointer"
-                  onClick={() => {
-                    deleteItemFromCart({
-                      foodName,
-                      foodQuantity: quantity,
-                      foodCost: cost,
-                      updateCartFunction,
-                    });
-                  }}
-                >
-                  {/* XMark SVG */}
-                  <XMarkIcon
-                    iconHeight="1.5em"
-                    iconWidth="1.5em"
-                    iconFillColor="red"
-                    iconStrokeColor="var(--neutral-color)"
-                    iconStrokeWidth="30"
-                  />
-                </span>
-              </div>
             </div>
+            {/* Update cart item count */}
+            <div class="mt-2 inline-flex items-center self-end">
+              {/* Decrease item count. If last item, remove it from the cart */}
+              <span
+                class="mr-2 hover:cursor-pointer"
+                onClick={() => {
+                  reduceCartItemByOne({
+                    foodName,
+                    foodCost: cost,
+                    updateCartFunction,
+                  });
+                }}
+              >
+                {/* Minus sign SVG */}
+                <MinusIcon iconHeight="1.5em" iconWidth="1.5em" />
+              </span>
+              {quantity}x ${cost.toFixed(2)}
+              {/* Increase item count */}
+              <span
+                class="ml-2 hover:cursor-pointer"
+                onClick={() => {
+                  increaseCartItemByOne({
+                    foodName,
+                    foodCost: cost,
+                    updateCartFunction,
+                  });
+                }}
+              >
+                {/* Plus sign SVG */}
+                <PlusIcon iconHeight="1.5em" iconWidth="1.5em" />
+              </span>
+            </div>
+            <hr
+              class="my-2 border-solid border"
+              style="border-color: var(--neutral-color)"
+            />
           </li>
         ))}
       </ol>

--- a/components/food-order/CartModal.tsx
+++ b/components/food-order/CartModal.tsx
@@ -51,14 +51,15 @@ export default function CartModal({
 
   //? Return the cart items and the total
   return (
-    <div class="food-cart-content">
+    <div class="food-cart-content max-h-[90dvh]">
       {/* Modal header */}
-      <span class="food-cart-content__header">Items in cart</span>
+      <h2 class="food-cart-content__header">Items in cart</h2>
       {/* List of items in cart */}
-      <ol>
+      <ol class="overflow-auto styled-scrollbar">
         {cartItems.map(([foodName, { quantity, cost }]) => (
           <li class="flex flex-col">
-            <div class="flex justify-between items-center">
+            {/* Food item name, remove item from cart */}
+            <div class="flex justify-between items-center pr-1.5">
               {/* Cart item name */}
               <h3 class="text-xl">
                 {foodName}
@@ -85,8 +86,8 @@ export default function CartModal({
                 />
               </span>
             </div>
-            {/* Update cart item count */}
-            <div class="mt-2 inline-flex items-center self-end">
+            {/* Food item count, update cart item count */}
+            <div class="mt-2 inline-flex items-center self-end pr-1">
               {/* Decrease item count. If last item, remove it from the cart */}
               <span
                 class="mr-2 hover:cursor-pointer"
@@ -101,7 +102,9 @@ export default function CartModal({
                 {/* Minus sign SVG */}
                 <MinusIcon iconHeight="1.5em" iconWidth="1.5em" />
               </span>
-              {quantity}x ${cost.toFixed(2)}
+              <span class="text-center">
+                {quantity}x ${cost.toFixed(2)}
+              </span>
               {/* Increase item count */}
               <span
                 class="ml-2 hover:cursor-pointer"
@@ -117,6 +120,7 @@ export default function CartModal({
                 <PlusIcon iconHeight="1.5em" iconWidth="1.5em" />
               </span>
             </div>
+            {/* Divider */}
             <hr
               class="my-2 border-solid border"
               style="border-color: var(--neutral-color)"

--- a/static/base.css
+++ b/static/base.css
@@ -1,11 +1,13 @@
 /* Note: Color scheme variables are set on components/base/CustomHead.tsx script tag */
 
 /* Scrollbar styling */
-body::-webkit-scrollbar {
+body::-webkit-scrollbar,
+.styled-scrollbar::-webkit-scrollbar {
     width: 0.8em;
 }
 
-body::-webkit-scrollbar-thumb {
+body::-webkit-scrollbar-thumb,
+.styled-scrollbar::-webkit-scrollbar-thumb {
     background-color: transparent;
     outline: 2px solid var(--accent-color);
     outline-offset: -0.1rem;

--- a/static/modal.css
+++ b/static/modal.css
@@ -21,6 +21,7 @@
 
     /* Define dimensions and styles */
     min-width: 50dvw;
+    width: 100%;
     max-width: 80dvw;
     background-color: var(--base-color);
 }


### PR DESCRIPTION
Moved the display of items in the cart, will now display a horizontal line below every item, which closes #55.

Additionally, this PR also does the following:
- Plus and Minus SVG components will now display better width, greatly reducing (or hopefully) removing the unnecessary built-in right padding.
- Cart height was limited to 90dvh, the items list will become scrollable (with custom scrollbar) when there are too many items to display.
- Modals will now be able to expand between 50 and 80 dynamic viewport width, making the modal not seem so squished on smaller devices.
- Fixed a bug (introduced by #61) that would make the cart unable to be cleared when trying to remove the last item. The `useEffect()` algo was revamped to delete data from `localStorage` if you clear your cart. One less cookie to delete whenever you clear you cache, no need to thank me.