### PR TITLE
feat: enable users to save new expenses to KV

### DIFF
--- a/components/expenses-tracker/ExpenseDate.tsx
+++ b/components/expenses-tracker/ExpenseDate.tsx
@@ -1,6 +1,6 @@
 //? Define properties required for this component
 interface ExpenseDateProperties {
-  date: Date;
+  date: number;
 }
 
 //? Make the expense date component available to everything else

--- a/components/expenses-tracker/IndividualExpense.tsx
+++ b/components/expenses-tracker/IndividualExpense.tsx
@@ -3,7 +3,7 @@ import { ExpenseDate } from "./ExpenseDate.tsx";
 
 //? Define properties required for this component
 interface IndividualExpenseProperties {
-  date: Date;
+  date: number;
   description: string;
   cost: number;
 }

--- a/data/expenses-tracker/saveNewExpenseToKV.ts
+++ b/data/expenses-tracker/saveNewExpenseToKV.ts
@@ -1,0 +1,33 @@
+//? Import the Expense type for casting
+import type { Expense } from "../../types/Expense.ts";
+
+//? Attempts to read database expenses and adds an expense to the list
+export async function saveNewExpenseToKV(newExpense: Expense) {
+  try {
+    //? Open KV
+    const kv = await Deno.openKv();
+    //? Get database expenses
+    const expenses = (await kv.get(["expenses-tracker"])).value;
+
+    //? Return early if the database is empty
+    if (expenses === null) {
+      return false;
+    }
+
+    //? Sort expenses by date to save them back on the DB
+    const sortedExpenses = [...(expenses as Expense[]), newExpense]
+      .sort((a, b) => {
+        if (a.date < b.date) {
+          return -1;
+        }
+        return 1;
+      });
+
+    //? Save sorted expenses back on the database
+    kv.set(["expenses-tracker"], sortedExpenses);
+
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}

--- a/islands/AddNewExpense.tsx
+++ b/islands/AddNewExpense.tsx
@@ -4,14 +4,8 @@ import { useState } from "preact/hooks";
 import { StyledInput } from "../components/UI/StyledInput.tsx";
 //? Styled Button to confirm sending the form
 import { StyledButton } from "../components/UI/StyledButton.tsx";
-
 //? Types for typecasting
 import { validationStatus } from "../types/validationStatus.ts";
-interface ExpenseFormProperties {
-  addNewExpenseFunction: (
-    input: { date: Date; description: string; cost: number },
-  ) => void;
-}
 
 //? Validates the form's description input field
 const descriptionValidation = (
@@ -91,17 +85,28 @@ function validateInput(
     return pattern(value);
   }
 }
+//* Date formatted as YYYY-MM-DD
 const [timezonelessDate, timezoneDateGap] = new Date().toISOString().split("T");
+//? How data is initially instantiated
 const defaultFormValues = {
   description: "",
   cost: 1,
   date: timezonelessDate,
 };
+//? Set base validation as unchanged to set as default border
 const defaultFormValidation = {
   description: validationStatus.Unchanged,
   cost: validationStatus.Unchanged,
   date: validationStatus.Unchanged,
 };
+
+//? Define how data is expected within this island.
+//! 'date' start as a Date object, but gets converted later to number to be saved
+interface ExpenseFormProperties {
+  addNewExpenseFunction: (
+    input: { date: Date; description: string; cost: number },
+  ) => void;
+}
 
 //? Creates a form that uses RegExp validation
 export default function AddNewExpenseForm(

--- a/islands/ExpensesTracker.tsx
+++ b/islands/ExpensesTracker.tsx
@@ -8,6 +8,7 @@ import AddNewExpense from "./AddNewExpense.tsx";
 import type { Expense } from "../types/Expense.ts";
 import ExpensesYearSelect from "./ExpensesYearSelect.tsx";
 import { ExpenseChart } from "../components/expenses-tracker/ExpensesChart.tsx";
+import { postNewExpense } from "../services/expenses-tracker/postNewExpense.ts";
 
 //? Filters expenses by year
 function filterExpensesByYear(year: string, savedExpenses: Expense[]) {
@@ -46,22 +47,21 @@ export default function ExpensesTracker(
       <AddNewExpense
         //? Add new expense to the database
         addNewExpenseFunction={(newExpense) => {
-          updateExpenses((currentState) => {
-            const newExpenses = [...currentState, {
-              ...newExpense,
-              date: new Date(newExpense.date).getTime(),
-            }];
+          //? Parse the expense into useful data
+          const newExpenseWithDateAsNumber: Expense = {
+            ...newExpense,
+            date: new Date(newExpense.date).getTime(),
+          };
 
-            const sortedExpenses = newExpenses
-              .sort((a, b) => {
-                if (a.date < b.date) {
-                  return -1;
-                }
-                return 1;
-              });
+          //! Can return 200 for OK or 400 for Bad Request
+          postNewExpense(newExpenseWithDateAsNumber);
 
-            return sortedExpenses;
-          });
+          //? Optimistically add the expense to the list
+          savedExpenses.push(newExpenseWithDateAsNumber);
+
+          //? Display new list of arrays for the given year
+          //! Only matters if the user added an expense to the year that is being currently viewed
+          updateExpenses(filterExpensesByYear(expensesYear, savedExpenses));
         }}
       />
       {/* Displays all expenses */}

--- a/islands/ExpensesTracker.tsx
+++ b/islands/ExpensesTracker.tsx
@@ -47,7 +47,20 @@ export default function ExpensesTracker(
         //? Add new expense to the database
         addNewExpenseFunction={(newExpense) => {
           updateExpenses((currentState) => {
-            return [...currentState, newExpense];
+            const newExpenses = [...currentState, {
+              ...newExpense,
+              date: new Date(newExpense.date).getTime(),
+            }];
+
+            const sortedExpenses = newExpenses
+              .sort((a, b) => {
+                if (a.date < b.date) {
+                  return -1;
+                }
+                return 1;
+              });
+
+            return sortedExpenses;
           });
         }}
       />

--- a/middleware/projects/__expenses-tracker.ts
+++ b/middleware/projects/__expenses-tracker.ts
@@ -1,17 +1,60 @@
 //? Import handlers to create a middleware function
 import { Handlers } from "$fresh/server.ts";
+import { saveNewExpenseToKV } from "../../data/expenses-tracker/saveNewExpenseToKV.ts";
 //? Fetch expenses from the database
 import fetchExpenses from "../../services/expenses-tracker/fetchExpenses.ts";
+//? Import the Expense type for casting
+import type { Expense } from "../../types/Expense.ts";
 //? Import database error instance to check for errors
 import DatabaseFetchError from "../../types/error/DatabaseFetchError.ts";
 
-//? Attempts to pull epxenses from the database, returns mock expense otherwise
 export const expensesTrackerMiddleware: Handlers = {
+  //? Attempts to pull expenses from the database, returns mock expense otherwise
   async GET(_req, ctx) {
     const expenses = await fetchExpenses();
     if (expenses instanceof DatabaseFetchError) {
       return ctx.render([]);
     }
     return ctx.render(expenses);
+  },
+  //? Create a new expense on the database
+  async POST(req, _ctx) {
+    const newExpense: Expense = await req.json();
+
+    //! Error if invalid request was made
+    if (typeof newExpense !== "object") {
+      return new Response(null, {
+        status: 400, // Bad Request HTTP status code
+      });
+    }
+
+    //! Error if invalid request was made
+    if (
+      typeof newExpense.date !== "number" ||
+      typeof newExpense.description !== "string" ||
+      typeof newExpense.cost !== "number"
+    ) {
+      return new Response(null, {
+        status: 400, // Bad Request HTTP status code
+      });
+    }
+
+    //? Attempt to save it to KV
+    const savedToDatabase = await saveNewExpenseToKV(newExpense);
+
+    //! Error if invalid request was made, return BAD REQUEST code
+    if (savedToDatabase === false) {
+      const responseBody = new FormData();
+      responseBody.append("message", "failed to save your data!");
+      return new Response(responseBody, {
+        status: 400, // Bad Request HTTP status code
+      });
+    }
+
+    const responseBody = new FormData();
+    responseBody.append("message", "saved successfully!");
+    return new Response(responseBody, {
+      status: 200, // OK HTTP status code
+    });
   },
 };

--- a/services/expenses-tracker/postNewExpense.ts
+++ b/services/expenses-tracker/postNewExpense.ts
@@ -1,0 +1,12 @@
+//? Import the Expense type for casting
+import type { Expense } from "../../types/Expense.ts";
+
+export async function postNewExpense(expense: Expense) {
+  const headers = new Headers({ "content-type": "application/json" });
+  const res = await fetch("/projects/expenses-tracker", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(expense),
+  });
+  return res.status;
+}

--- a/types/Expense.ts
+++ b/types/Expense.ts
@@ -1,6 +1,6 @@
 //? All the data an Expense is required to have
 export interface Expense {
-  date: Date;
+  date: number;
   description: string;
   cost: number;
 }

--- a/types/expenses-tracker/mockExpenses.ts
+++ b/types/expenses-tracker/mockExpenses.ts
@@ -1,27 +1,29 @@
+import { Expense } from "../Expense.ts";
+
 //? Mock expenses
-export const mockExpenses = [
+export const mockExpenses: Expense[] = [
   {
-    date: new Date(2020, 1, 1),
+    date: new Date(2020, 1, 1).getTime(),
     description: "Medical Insurance",
     cost: 3600,
   },
   {
-    date: new Date(2020, 5, 3),
+    date: new Date(2020, 5, 3).getTime(),
     description: "Shoes",
     cost: 200,
   },
   {
-    date: new Date(2020, 8, 18),
+    date: new Date(2020, 8, 18).getTime(),
     description: "House",
     cost: 250000,
   },
   {
-    date: new Date(2020, 9, 20),
+    date: new Date(2020, 9, 20).getTime(),
     description: "Car",
     cost: 40000,
   },
   {
-    date: new Date(2020, 11, 28),
+    date: new Date(2020, 11, 28).getTime(),
     description: "Kids",
     cost: 10000,
   },


### PR DESCRIPTION
Newly added expenses will now be persisted to the database.

Additionally, changed `Expense` to use `date` as a number of ms since Epoch instead of a `Date` object.

Closes #70.