### PR TITLE
feat: enable users to add pension/starting savings

### DIFF
--- a/components/retirement-calculator/RetirementCalculationTable.tsx
+++ b/components/retirement-calculator/RetirementCalculationTable.tsx
@@ -38,6 +38,14 @@ export function RetirementCalculationTable(
     const lastYearCoumpound = recentEntry.totalSaved *
       (+values.returns / 100);
 
+    //? Add a new year to the calculation array
+    retirementCalculation.push({
+      age: recentEntry.age + 1,
+      totalSaved: recentEntry.totalSaved + lastYearCoumpound +
+        yearlyInvestment,
+      lastYearCompound: lastYearCoumpound,
+    });
+
     //? If last year's returns are above what you make on an average year and
     //? you are past the retiring age, end the calculation
     if (
@@ -46,14 +54,6 @@ export function RetirementCalculationTable(
     ) {
       break;
     }
-
-    //? Add a new year to the calculation array
-    retirementCalculation.push({
-      age: recentEntry.age + 1,
-      totalSaved: recentEntry.totalSaved + lastYearCoumpound +
-        yearlyInvestment,
-      lastYearCompound: lastYearCoumpound,
-    });
   }
 
   //? Remove the first/current year from the calculation

--- a/components/retirement-calculator/RetirementCalculationTable.tsx
+++ b/components/retirement-calculator/RetirementCalculationTable.tsx
@@ -98,10 +98,10 @@ export function RetirementCalculationTable(
         ))}
       </table>
       {/* Colors explanation: red = unable to retire / green = enough money to retire */}
-      <p>
-        Red: you reached your target retiring age without being able to retire
+      <p class="text-center">
+        Red: you are at/past your target retiring age unable to retire
       </p>
-      <p>
+      <p class="text-center">
         Green: you make enough from your investments returns to retire
       </p>
     </>

--- a/components/retirement-calculator/RetirementCalculationTable.tsx
+++ b/components/retirement-calculator/RetirementCalculationTable.tsx
@@ -21,7 +21,7 @@ export function RetirementCalculationTable(
   //! Starts with only starting year data
   const retirementCalculation = [{
     age: +values.currentAge,
-    totalSaved: 0,
+    totalSaved: +values.starterSavings,
     lastYearCompound: 0,
   }];
   const yearlyInvestment = (+values.yearlySavings * +values.compensation) / 100;
@@ -38,12 +38,18 @@ export function RetirementCalculationTable(
     const lastYearCoumpound = recentEntry.totalSaved *
       (+values.returns / 100);
 
+    //? Calculate if the person can retire adding lastYearCoumpound+values.additionalIncome
+    const cantRetire =
+      lastYearCoumpound + +values.additionalIncome < +values.compensation;
+
     //? Add a new year to the calculation array
     retirementCalculation.push({
       age: recentEntry.age + 1,
       totalSaved: recentEntry.totalSaved + lastYearCoumpound +
         yearlyInvestment,
-      lastYearCompound: lastYearCoumpound,
+      lastYearCompound: cantRetire
+        ? lastYearCoumpound
+        : lastYearCoumpound + +values.additionalIncome,
     });
 
     //? If last year's returns are above what you make on an average year and
@@ -92,7 +98,11 @@ export function RetirementCalculationTable(
             </td>
             {/* Interest returns from last year */}
             <td class="custom-bo-ac">
-              ${Math.floor(yearCalculation.lastYearCompound).toLocaleString()}
+              ${Math.floor(yearCalculation.lastYearCompound).toLocaleString() +
+                (+values.additionalIncome > 0 &&
+                    yearCalculation.lastYearCompound >= +values.compensation
+                  ? ` (+$${values.additionalIncome.toLocaleString()})`
+                  : "")}
             </td>
           </tr>
         ))}

--- a/islands/RetirementCalculationForm.tsx
+++ b/islands/RetirementCalculationForm.tsx
@@ -11,16 +11,19 @@ import { validateAge as validateCurrentAge } from "../services/form-validation/v
 import { validateRetiringAge } from "../services/form-validation/validateRetirementAge.ts";
 import { validateCompensation } from "../services/form-validation/validateCompensation.ts";
 import { validateYearlyInvestment } from "../services/form-validation/validateInvestment.ts";
+import { validateReturns } from "../services/form-validation/validateReturns.ts";
+import { validateZeroOrGreater } from "../services/form-validation/validateZeroOrGreater.ts";
 
 //? Base state data
 import { baseRetirementStats } from "../types/retirement-calculator/baseRetirementStats.ts";
-import { validateReturns } from "../services/form-validation/validateReturns.ts";
 const defaultFormValidation = {
   currentAge: validationStatus.Unchanged,
   plannedRetiringAge: validationStatus.Unchanged,
   compensation: validationStatus.Unchanged,
   yearlySavings: validationStatus.Unchanged,
   returns: validationStatus.Unchanged,
+  starterSavings: validationStatus.Unchanged,
+  additionalIncome: validationStatus.Unchanged,
 };
 
 //? Export form with values to be used to calculate the retirement projection
@@ -82,6 +85,8 @@ export default function RetirementCalculatorForm(
         compensation: validationsArray[2],
         yearlySavings: validationsArray[3],
         returns: validationsArray[4],
+        starterSavings: validationsArray[5],
+        additionalIncome: validationsArray[6],
       });
       updateValidationError(true);
       validInput = false;
@@ -134,7 +139,7 @@ export default function RetirementCalculatorForm(
         }}
         min={18}
         max={100}
-        helpInformation="Validation: Number between 18 and 100 years (18 < age < 100)"
+        helpInformation="Validation: Number between 18 and 100 years (18 < age < 100)."
       />
       {/* Retiring Age */}
       <StyledInput
@@ -198,7 +203,7 @@ export default function RetirementCalculatorForm(
           return result;
         }}
         min={20000}
-        helpInformation="Validation: Number must be higher than 20K/year."
+        helpInformation="Validation: Number must be higher than 20K/year. You should include here any income from side hustles as well."
       />
       {/* Yearly Investment */}
       <StyledInput
@@ -257,7 +262,63 @@ export default function RetirementCalculatorForm(
         min={1}
         helpInformation="Validation: Number greater than 1%."
       />
-      {/* Confirm form input (prints to text area) */}
+      {/* Current savings */}
+      <StyledInput
+        key="current-savings"
+        inputType="number"
+        label="Current savings"
+        name="retirement"
+        value={formValues.starterSavings}
+        inputFunction={(value) =>
+          setValues((currentData) => ({
+            ...currentData,
+            starterSavings: value,
+          }))}
+        validationReference={formValidationStatus.starterSavings}
+        validationFunction={() => {
+          const result = patternValidation(
+            formValues.starterSavings,
+            baseRetirementStats.starterSavings,
+            validateZeroOrGreater,
+          );
+          updateValidation((currentValidation) => ({
+            ...currentValidation,
+            starterSavings: result,
+          }));
+          return result;
+        }}
+        min={0}
+        helpInformation="Validation: Number must not be negative."
+      />
+      {/* Extra income */}
+      <StyledInput
+        key="other-income"
+        inputType="number"
+        label="Pension/other ($/year)"
+        name="retirement"
+        value={formValues.additionalIncome}
+        inputFunction={(value) =>
+          setValues((currentData) => ({
+            ...currentData,
+            additionalIncome: value,
+          }))}
+        validationReference={formValidationStatus.additionalIncome}
+        validationFunction={() => {
+          const result = patternValidation(
+            formValues.additionalIncome,
+            baseRetirementStats.additionalIncome,
+            validateZeroOrGreater,
+          );
+          updateValidation((currentValidation) => ({
+            ...currentValidation,
+            additionalIncome: result,
+          }));
+          return result;
+        }}
+        min={0}
+        helpInformation="Validation: Number must not be negative. Only add here income that you would make use of after retiring."
+      />
+      {/* Confirm input */}
       <StyledButton
         classes="mt-2 self-center"
         text="Calculate"

--- a/services/form-validation/validateZeroOrGreater.ts
+++ b/services/form-validation/validateZeroOrGreater.ts
@@ -1,0 +1,13 @@
+//? Types for typecasting
+import { validationStatus } from "../../types/misc/validationStatus.ts";
+
+//? Validates the form's numeric input field for a value equal to 0 or greater
+export function validateZeroOrGreater(
+  value: string,
+): validationStatus.Invalid | validationStatus.Valid {
+  if (Number(value) >= 0) {
+    return validationStatus.Valid;
+  } else {
+    return validationStatus.Invalid;
+  }
+}

--- a/types/retirement-calculator/baseRetirementStats.ts
+++ b/types/retirement-calculator/baseRetirementStats.ts
@@ -1,8 +1,10 @@
 //? Starting values for the form
 export const baseRetirementStats = {
-  currentAge: "18",
-  plannedRetiringAge: "30",
-  compensation: "20000",
+  currentAge: "20",
+  plannedRetiringAge: "60",
+  compensation: "25000",
   yearlySavings: "10",
   returns: "6",
+  starterSavings: "2000",
+  additionalIncome: "0",
 };


### PR DESCRIPTION
Because not everyone is on the same step of their retirement journey (aka at the very start), some more fields needed to be added to account for that. This PR adds those fields.

Closes #76.