### PR TITLE
refactor: move validation functions to /services

### DIFF
--- a/islands/AddNewExpense.tsx
+++ b/islands/AddNewExpense.tsx
@@ -127,7 +127,7 @@ export default function AddNewExpenseForm(
 
   //? Runs when the user clicks the "Send" button. Validates if the data
   //? should be accepted and wiped or kept and have errors informed.
-  function validateBeforeSend(): void {
+  function validateBeforeAcceptInput(): void {
     //? Initialize the number of errors variable
     let validationErrors = 0;
 
@@ -230,10 +230,11 @@ export default function AddNewExpenseForm(
       <form class="w-full mb-2 flex flex-col">
         {/* Expense description */}
         <StyledInput
-          key={"text_input"}
+          key="expense-description"
           inputType="text"
           validationReference={formValidationStatus.description}
           label="Description"
+          labelLink="expense-description"
           name="description"
           value={formValues.description}
           inputFunction={(inputName) => {
@@ -257,10 +258,11 @@ export default function AddNewExpenseForm(
         />
         {/* Expense Cost */}
         <StyledInput
-          key={"number_input"}
+          key="expense-cost"
           inputType="number"
           validationReference={formValidationStatus.cost as validationStatus}
           label="Cost ($)"
+          labelLink="expense-cost"
           name="cost"
           value={formValues.cost.toString()}
           inputFunction={(inputAge) => {
@@ -285,11 +287,12 @@ export default function AddNewExpenseForm(
         />
         {/* Expense Date */}
         <StyledInput
-          key={"date_input"}
+          key="expense-date"
           inputType="date"
           validationReference={formValidationStatus
             .date as validationStatus}
           label="Date"
+          labelLink="expense-date"
           name="date"
           value={formValues.date}
           inputFunction={(inputDate) => {
@@ -331,7 +334,7 @@ export default function AddNewExpenseForm(
           <StyledButton
             classes="mt-2"
             text="Send"
-            onClickFunction={validateBeforeSend}
+            onClickFunction={validateBeforeAcceptInput}
           />
         </div>
         {validationError === true && (

--- a/islands/AddNewExpense.tsx
+++ b/islands/AddNewExpense.tsx
@@ -8,85 +8,12 @@ import { StyledInput } from "../components/UI/StyledInput.tsx";
 import { StyledButton } from "../components/UI/StyledButton.tsx";
 //? Types for typecasting
 import { validationStatus } from "../types/misc/validationStatus.ts";
+//? Validation functions
+import { validateExpenseDescription } from "../services/form-validation/validateExpenseDescription.ts";
+import { validateExpenseDate } from "../services/form-validation/validateExpenseDate.ts";
+import { validateOneOrGreater } from "../services/form-validation/validateOneOrGreater.ts";
+import { patternValidation } from "../services/form-validation/patternValidation.ts";
 
-//? Validates the form's description input field
-const descriptionValidation = (
-  description: string,
-): validationStatus.Invalid | validationStatus.Valid => {
-  //? This RegEx looks for a string of 3 to 40 alphabet characters + space
-  //? and dash, but will fail validation if two consecutive spaces/dashes
-  //? are provided
-  const regularExpression = "^(?!.*[ -]{2}).{3,}$";
-  //? Creates a RegEx with the expression above
-  const validation = new RegExp(regularExpression);
-  //? Validates the input against the RegEx, returning 1 for
-  //? valid and -1 for invalid input
-  if (validation.test(description)) {
-    return validationStatus.Valid;
-  } else {
-    return validationStatus.Invalid;
-  }
-};
-
-//? Validates the form's date input field
-const dateValidation = (
-  date: string,
-): validationStatus.Invalid | validationStatus.Valid => {
-  //? This RegEx looks for a string of 6 to 20 alphabet characters + space
-  //? and dash, but will fail validation if two consecutive spaces/dashes
-  //? are provided
-  const regularExpression = "^\\d{4}-\\d{2}-\\d{2}$";
-  //? Creates a RegEx with the expression above
-  const validation = new RegExp(regularExpression);
-  //? Validates the input against the RegEx, returning
-  //? validationStatus.Invalid if not in the proper format
-  if (validation.test(date)) {
-    //! Should we limit expenses to past expenses,
-    //! rather than allowing to calculate future needs?
-    const today = new Date().getTime();
-    const jan1st2020 = new Date(2020, 1, 1).getTime();
-    const inputDate = new Date(date).getTime();
-    //? If the format is correct, check if the date is within
-    //? the limit of Jan 1st 2020 and today
-    if (jan1st2020 < inputDate && inputDate < today) {
-      return validationStatus.Valid;
-    } else {
-      return validationStatus.Invalid;
-    }
-  } else {
-    return validationStatus.Invalid;
-  }
-};
-
-//? Validates the form's cost numeric input field
-const costValidation = (
-  cost: string,
-): validationStatus.Invalid | validationStatus.Valid => {
-  if (+cost >= 1) {
-    return validationStatus.Valid;
-  } else {
-    return validationStatus.Invalid;
-  }
-};
-
-//? Given a current value, initial value and a validation function, return
-//? what is the state of validation of the input once the respective field
-//? loses focus
-function validateInput(
-  value: string,
-  initialState: string,
-  pattern: (
-    valueToValidate: string,
-  ) => validationStatus.Invalid | validationStatus.Valid,
-): validationStatus {
-  //? If the field is at initial state, reset validation
-  if (value === initialState) {
-    return validationStatus.Unchanged;
-  } //? If the field is not empty, check if a validation RegEx pattern was provided
-  else {
-    return pattern(value);
-  }
-}
 //* Date formatted as YYYY-MM-DD
 const [timezonelessDate, timezoneDateGap] = new Date().toISOString().split("T");
 //? How data is initially instantiated
@@ -148,10 +75,10 @@ export default function AddNewExpenseForm(
       }));
       validationErrors++;
     } else if (
-      validateInput(
+      patternValidation(
         formValues.description,
         defaultFormValues.description,
-        descriptionValidation,
+        validateExpenseDescription,
       ) ===
         validationStatus.Invalid
     ) {
@@ -163,10 +90,10 @@ export default function AddNewExpenseForm(
     }
     //? If the cost is invalid, increase errors counter
     if (
-      validateInput(
+      patternValidation(
         formValues.cost.toString(),
         defaultFormValues.cost.toString(),
-        costValidation,
+        validateOneOrGreater,
       ) === validationStatus.Invalid
     ) {
       validationErrors++;
@@ -187,10 +114,10 @@ export default function AddNewExpenseForm(
         date: validationStatus.Invalid,
       }));
     } else if (
-      validateInput(
+      patternValidation(
         formValues.date,
         defaultFormValues.date,
-        dateValidation,
+        validateExpenseDate,
       ) === validationStatus.Invalid
     ) {
       validationErrors++;
@@ -244,10 +171,10 @@ export default function AddNewExpenseForm(
             }));
           }}
           validationFunction={() => {
-            const result = validateInput(
+            const result = patternValidation(
               formValues.description,
               defaultFormValues.description,
-              descriptionValidation,
+              validateExpenseDescription,
             );
             updateValidation((currentValidation) => ({
               ...currentValidation,
@@ -272,10 +199,10 @@ export default function AddNewExpenseForm(
             }));
           }}
           validationFunction={() => {
-            const result = validateInput(
+            const result = patternValidation(
               formValues.cost.toString(),
               defaultFormValues.cost.toString(),
-              costValidation,
+              validateOneOrGreater,
             );
             updateValidation((currentValidation) => ({
               ...currentValidation,
@@ -302,10 +229,10 @@ export default function AddNewExpenseForm(
             }));
           }}
           validationFunction={() => {
-            const result = validateInput(
+            const result = patternValidation(
               formValues.date,
               defaultFormValues.date,
-              dateValidation,
+              validateExpenseDate,
             );
             updateValidation((currentValidation) => ({
               ...currentValidation,

--- a/islands/RetirementCalculationForm.tsx
+++ b/islands/RetirementCalculationForm.tsx
@@ -11,7 +11,7 @@ import { validateAge as validateCurrentAge } from "../services/form-validation/v
 import { validateRetiringAge } from "../services/form-validation/validateRetirementAge.ts";
 import { validateCompensation } from "../services/form-validation/validateCompensation.ts";
 import { validateYearlyInvestment } from "../services/form-validation/validateInvestment.ts";
-import { validateReturns } from "../services/form-validation/validateReturns.ts";
+import { validateOneOrGreater } from "../services/form-validation/validateOneOrGreater.ts";
 import { validateZeroOrGreater } from "../services/form-validation/validateZeroOrGreater.ts";
 
 //? Base state data
@@ -73,7 +73,7 @@ export default function RetirementCalculatorForm(
       patternValidation(
         formValues.returns,
         baseRetirementStats.returns,
-        validateReturns,
+        validateOneOrGreater,
       ),
       patternValidation(
         formValues.starterSavings,
@@ -266,7 +266,7 @@ export default function RetirementCalculatorForm(
           const result = patternValidation(
             formValues.returns,
             baseRetirementStats.returns,
-            validateReturns,
+            validateOneOrGreater,
           );
           updateValidation((currentValidation) => ({
             ...currentValidation,

--- a/services/form-validation/validateAreaCode.ts
+++ b/services/form-validation/validateAreaCode.ts
@@ -2,9 +2,9 @@
 import { validationStatus } from "../../types/misc/validationStatus.ts";
 
 //? Validates the form's area code input field
-export const validateAreaCode = (
+export function validateAreaCode(
   areaCode: string,
-): validationStatus.Invalid | validationStatus.Valid => {
+): validationStatus.Invalid | validationStatus.Valid {
   //? Instantiate Area Code as a string length and if it's a valid number
   const areaCodeStringLength = areaCode.length;
   const isAreaCodeAnInvalidNumber = isNaN(Number(areaCode));
@@ -17,4 +17,4 @@ export const validateAreaCode = (
   } else {
     return validationStatus.Valid;
   }
-};
+}

--- a/services/form-validation/validateExpenseDate.ts
+++ b/services/form-validation/validateExpenseDate.ts
@@ -1,0 +1,32 @@
+//? Types for typecasting
+import { validationStatus } from "../../types/misc/validationStatus.ts";
+
+//? Validates the form's date input field
+export function validateExpenseDate(
+  date: string,
+): validationStatus.Invalid | validationStatus.Valid {
+  //? This RegEx looks for a string of 6 to 20 alphabet characters + space
+  //? and dash, but will fail validation if two consecutive spaces/dashes
+  //? are provided
+  const regularExpression = "^\\d{4}-\\d{2}-\\d{2}$";
+  //? Creates a RegEx with the expression above
+  const validation = new RegExp(regularExpression);
+  //? Validates the input against the RegEx, returning
+  //? validationStatus.Invalid if not in the proper format
+  if (validation.test(date)) {
+    //! Should we limit expenses to past expenses,
+    //! rather than allowing to calculate future needs?
+    const today = new Date().getTime();
+    const jan1st2020 = new Date(2020, 1, 1).getTime();
+    const inputDate = new Date(date).getTime();
+    //? If the format is correct, check if the date is within
+    //? the limit of Jan 1st 2020 and today
+    if (jan1st2020 < inputDate && inputDate < today) {
+      return validationStatus.Valid;
+    } else {
+      return validationStatus.Invalid;
+    }
+  } else {
+    return validationStatus.Invalid;
+  }
+}

--- a/services/form-validation/validateExpenseDescription.ts
+++ b/services/form-validation/validateExpenseDescription.ts
@@ -1,0 +1,21 @@
+//? Types for typecasting
+import { validationStatus } from "../../types/misc/validationStatus.ts";
+
+//? Validates the expense description input field
+export function validateExpenseDescription(
+  description: string,
+): validationStatus.Invalid | validationStatus.Valid {
+  //? This RegEx looks for a string of 3 to 40 alphabet characters + space
+  //? and dash, but will fail validation if two consecutive spaces/dashes
+  //? are provided
+  const regularExpression = "^(?!.*[ -]{2}).{3,}$";
+  //? Creates a RegEx with the expression above
+  const validation = new RegExp(regularExpression);
+  //? Validates the input against the RegEx, returning 1 for
+  //? valid and -1 for invalid input
+  if (validation.test(description)) {
+    return validationStatus.Valid;
+  } else {
+    return validationStatus.Invalid;
+  }
+}

--- a/services/form-validation/validateOneOrGreater.ts
+++ b/services/form-validation/validateOneOrGreater.ts
@@ -2,10 +2,10 @@
 import { validationStatus } from "../../types/misc/validationStatus.ts";
 
 //? Validates the form's returns numeric input field
-export function validateReturns(
-  investment: string,
+export function validateOneOrGreater(
+  numberAsString: string,
 ): validationStatus.Invalid | validationStatus.Valid {
-  if (Number(investment) >= 1) {
+  if (Number(numberAsString) >= 1) {
     return validationStatus.Valid;
   } else {
     return validationStatus.Invalid;

--- a/services/form-validation/validatePhoneNumber.ts
+++ b/services/form-validation/validatePhoneNumber.ts
@@ -2,9 +2,9 @@
 import { validationStatus } from "../../types/misc/validationStatus.ts";
 
 //? Validates the form's phone number input field
-export const validatePhoneNumber = (
+export function validatePhoneNumber(
   areaCode: string,
-): validationStatus.Invalid | validationStatus.Valid => {
+): validationStatus.Invalid | validationStatus.Valid {
   //? Instantiate Area Code as a string length and if it's a valid number
   const areaCodeStringLength = areaCode.length;
   const isAreaCodeAnInvalidNumber = isNaN(Number(areaCode));
@@ -18,4 +18,4 @@ export const validatePhoneNumber = (
   } else {
     return validationStatus.Valid;
   }
-};
+}


### PR DESCRIPTION
There were some leftover validation functions forgotten at `/tools/expenses-tracker`. Those were now moved to `/services/form-validation` with the rest.

Closes #84.