### PR TITLE
chore: updated text in /work and /projects

### DIFF
--- a/components/projects/ProjectsGrid.tsx
+++ b/components/projects/ProjectsGrid.tsx
@@ -9,7 +9,7 @@ const projects: ProjectDisplayProperties[] = [
   {
     projectLink: "/projects/expenses-tracker",
     projectTitle:
-      "Expenses tracker that allow filtering by year and provides simple bar charts for each month's totals",
+      "Expenses tracker that allow filtering by year and provides simple bar charts for each month's totals.",
     projectImageLink:
       "https://cdn.discordapp.com/attachments/576538316296421399/1120271217954406420/image.png",
     projectName: "Expenses tracker",
@@ -18,10 +18,19 @@ const projects: ProjectDisplayProperties[] = [
   {
     projectLink: "/projects/food-order",
     projectTitle:
-      "Mock of a food order app. Comes with a built-in cart system that allows the user to manage their items",
+      "Mock of a food order app. Comes with a built-in cart system that allows the user to manage their items.",
     projectImageLink:
       "https://media.discordapp.net/attachments/576538316296421399/1120279085952794634/image.png",
     projectName: "Food order",
+  },
+  //* Stimulus Check Form
+  {
+    projectLink: "/projects/stimulus-check",
+    projectTitle:
+      "Mock form required to request a stimulus check from the USA government during the pandemic.",
+    projectImageLink:
+      "https://cdn.discordapp.com/attachments/576538316296421399/1125175916729995335/image.png",
+    projectName: "Stimulus Check request",
   },
 ];
 

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -15,28 +15,28 @@ import * as $9 from "./routes/projects/food-order/checkout.tsx";
 import * as $10 from "./routes/projects/food-order/index.tsx";
 import * as $11 from "./routes/projects/food-order/success.tsx";
 import * as $12 from "./routes/projects/index.tsx";
-import * as $13 from "./routes/tools/highlighted-text/[text].tsx";
-import * as $14 from "./routes/tools/index.tsx";
-import * as $15 from "./routes/tools/retirement-calculator.tsx";
-import * as $16 from "./routes/tools/syntax-highlight.tsx";
-import * as $17 from "./routes/tools/whatsapp-message-link-generator.tsx";
-import * as $18 from "./routes/toys/index.tsx";
-import * as $19 from "./routes/toys/insanity.tsx";
-import * as $20 from "./routes/toys/spinners.tsx";
-import * as $21 from "./routes/what-is-this.tsx";
-import * as $22 from "./routes/work/form.tsx";
+import * as $13 from "./routes/projects/stimulus-check.tsx";
+import * as $14 from "./routes/tools/highlighted-text/[text].tsx";
+import * as $15 from "./routes/tools/index.tsx";
+import * as $16 from "./routes/tools/retirement-calculator.tsx";
+import * as $17 from "./routes/tools/syntax-highlight.tsx";
+import * as $18 from "./routes/tools/whatsapp-message-link-generator.tsx";
+import * as $19 from "./routes/toys/index.tsx";
+import * as $20 from "./routes/toys/insanity.tsx";
+import * as $21 from "./routes/toys/spinners.tsx";
+import * as $22 from "./routes/what-is-this.tsx";
 import * as $23 from "./routes/work/index.tsx";
 import * as $$0 from "./islands/UI/DigitalTimer.tsx";
 import * as $$1 from "./islands/UI/Modal.tsx";
 import * as $$2 from "./islands/misc/Collapsible.tsx";
 import * as $$3 from "./islands/misc/CopyTextAreaToClipboard.tsx";
-import * as $$4 from "./islands/misc/FormWithValidation.tsx";
-import * as $$5 from "./islands/misc/ThemeSwitcher.tsx";
-import * as $$6 from "./islands/projects/AddNewExpense.tsx";
-import * as $$7 from "./islands/projects/ExpensesTracker.tsx";
-import * as $$8 from "./islands/projects/ExpensesYearSelect.tsx";
-import * as $$9 from "./islands/projects/FoodOrder.tsx";
-import * as $$10 from "./islands/projects/FoodOrderCheckout.tsx";
+import * as $$4 from "./islands/misc/ThemeSwitcher.tsx";
+import * as $$5 from "./islands/projects/AddNewExpense.tsx";
+import * as $$6 from "./islands/projects/ExpensesTracker.tsx";
+import * as $$7 from "./islands/projects/ExpensesYearSelect.tsx";
+import * as $$8 from "./islands/projects/FoodOrder.tsx";
+import * as $$9 from "./islands/projects/FoodOrderCheckout.tsx";
+import * as $$10 from "./islands/projects/FormWithValidation.tsx";
 import * as $$11 from "./islands/tools/HighlightedCode.tsx";
 import * as $$12 from "./islands/tools/RetirementCalculationForm.tsx";
 import * as $$13 from "./islands/tools/RetirementCalculator.tsx";
@@ -58,16 +58,16 @@ const manifest = {
     "./routes/projects/food-order/index.tsx": $10,
     "./routes/projects/food-order/success.tsx": $11,
     "./routes/projects/index.tsx": $12,
-    "./routes/tools/highlighted-text/[text].tsx": $13,
-    "./routes/tools/index.tsx": $14,
-    "./routes/tools/retirement-calculator.tsx": $15,
-    "./routes/tools/syntax-highlight.tsx": $16,
-    "./routes/tools/whatsapp-message-link-generator.tsx": $17,
-    "./routes/toys/index.tsx": $18,
-    "./routes/toys/insanity.tsx": $19,
-    "./routes/toys/spinners.tsx": $20,
-    "./routes/what-is-this.tsx": $21,
-    "./routes/work/form.tsx": $22,
+    "./routes/projects/stimulus-check.tsx": $13,
+    "./routes/tools/highlighted-text/[text].tsx": $14,
+    "./routes/tools/index.tsx": $15,
+    "./routes/tools/retirement-calculator.tsx": $16,
+    "./routes/tools/syntax-highlight.tsx": $17,
+    "./routes/tools/whatsapp-message-link-generator.tsx": $18,
+    "./routes/toys/index.tsx": $19,
+    "./routes/toys/insanity.tsx": $20,
+    "./routes/toys/spinners.tsx": $21,
+    "./routes/what-is-this.tsx": $22,
     "./routes/work/index.tsx": $23,
   },
   islands: {
@@ -75,13 +75,13 @@ const manifest = {
     "./islands/UI/Modal.tsx": $$1,
     "./islands/misc/Collapsible.tsx": $$2,
     "./islands/misc/CopyTextAreaToClipboard.tsx": $$3,
-    "./islands/misc/FormWithValidation.tsx": $$4,
-    "./islands/misc/ThemeSwitcher.tsx": $$5,
-    "./islands/projects/AddNewExpense.tsx": $$6,
-    "./islands/projects/ExpensesTracker.tsx": $$7,
-    "./islands/projects/ExpensesYearSelect.tsx": $$8,
-    "./islands/projects/FoodOrder.tsx": $$9,
-    "./islands/projects/FoodOrderCheckout.tsx": $$10,
+    "./islands/misc/ThemeSwitcher.tsx": $$4,
+    "./islands/projects/AddNewExpense.tsx": $$5,
+    "./islands/projects/ExpensesTracker.tsx": $$6,
+    "./islands/projects/ExpensesYearSelect.tsx": $$7,
+    "./islands/projects/FoodOrder.tsx": $$8,
+    "./islands/projects/FoodOrderCheckout.tsx": $$9,
+    "./islands/projects/FormWithValidation.tsx": $$10,
     "./islands/tools/HighlightedCode.tsx": $$11,
     "./islands/tools/RetirementCalculationForm.tsx": $$12,
     "./islands/tools/RetirementCalculator.tsx": $$13,

--- a/islands/projects/FormWithValidation.tsx
+++ b/islands/projects/FormWithValidation.tsx
@@ -30,12 +30,9 @@ const textAreaPlaceholder = 'Data will be displayed here as you click "Send".' +
   "\n\nSome key insights for when building this:" +
   "\n- When using other websites, it's very annoying when you tap into a " +
   "field and tap out (without typing anything) and the field gives you a " +
-  "validation error. This form doesn't have that problem, it only " +
-  "attempts to validate the value if a value was actually provided and " +
-  "will reset if the value gets removed." +
-  "\n- Regexes are very powerful. I use them to validate login/signup" +
-  " on Trophy Place, the form above and probably too many places that" +
-  " could probably just use a simple deep equality check.";
+  "validation error. This form doesn't have that problem." +
+  "\n- Regexes are amazing! I use them to validate login/signup" +
+  " on Trophy Place, this form and everywhere else I can sneak them into.";
 
 //? Assign default form values and validation to avoid duplicating them everywhere
 const selectDropdownOptions = [

--- a/routes/projects/index.tsx
+++ b/routes/projects/index.tsx
@@ -28,15 +28,17 @@ export default function Home() {
           <ProjectsGrid />
           {/* Summary - React course */}
           <p class="my-2 text-justify">
-            These are the projects I completed while going through the{" "}
+            These are the projects I built inspired by the{" "}
             <GradientLink
-              content=" React - The Complete Guide"
+              content="React - The Complete Guide"
               link="https://www.udemy.com/course/react-the-complete-guide-incl-redux/"
               newTab={true}
               title="React couse, by Academind"
               customRel="noopener noreferrer"
             />{" "}
-            course from Academind.
+            course from Academind. It uses the features taught, but not a single
+            resource file. Everything was adapted to feel like it belong to my
+            website.
           </p>
           {/* Was already experienced with React */}
           <p class="my-2 text-justify">
@@ -54,12 +56,6 @@ export default function Home() {
             </em>{" "}
             if I don't make myself go through a full fledged course.
           </p>
-          {/* Adapted projects to my layout */}
-          <p class="my-2 text-justify">
-            Considering that, instead of creating a new repository for every
-            required project, I've just adapted everything to be used here,
-            inside Deno, Fresh and Preact.
-          </p>
           {/* I wanted problems */}
           <p class="my-2 text-justify">
             That way, not only I practice what I need to, but I'm also forcing
@@ -70,17 +66,20 @@ export default function Home() {
           </p>
           {/* Setting expectations */}
           <p class="my-2 text-justify">
-            Every project page includes a toggleable summary of what I learned
-            when completing the project. Overall, I don't think it was that
-            useful for me because I had already learned the large bulk of React
-            features previously by building websites for my freelance clients.
-            While it was nice to learn about why{" "}
+            Most projects includes a toggleable summary of what I learned when
+            completing the project. While it was nice to learn about why{" "}
             <span class="shl-inline">Fragments</span> exist, what is{" "}
             <span class="shl-inline">React.createElement()</span>,{" "}
             <span class="shl-inline">Portals</span> and{" "}
-            <span class="shl-inline">Context</span>, almost none of my clients
-            jobs would benefit by any of those, so it was mostly nice-to-know
-            course for me.
+            <span class="shl-inline">Context</span>, it was mostly nice-to-know
+            course for me. Check{" "}
+            <GradientLink
+              content="tools"
+              link="/tools"
+              title="The things I've built alone"
+            />{" "}
+            if you are curious to know about the things I've built zero
+            guidance.
           </p>
         </article>
       </Base>

--- a/routes/projects/stimulus-check.tsx
+++ b/routes/projects/stimulus-check.tsx
@@ -7,7 +7,7 @@ import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 //? Navigation Buttons to go back to the previous page or to the next article
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? Stylized and functional Form Island
-import FormWithValidation from "../../islands/misc/FormWithValidation.tsx";
+import FormWithValidation from "../../islands/projects/FormWithValidation.tsx";
 
 export default function Home() {
   return (
@@ -21,7 +21,7 @@ export default function Home() {
       {/* Base page layout with theme switching and footer outside of accent box */}
       <Base>
         <NavigationButtons
-          back={{ title: "Return to the works page", link: "/work" }}
+          back={{ title: "Return to projects", link: "/projects" }}
         />
         <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
           {/* Title header */}

--- a/routes/work/index.tsx
+++ b/routes/work/index.tsx
@@ -24,6 +24,11 @@ export default function Home() {
         <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
           {/* Title header */}
           <StyledHeader title="Past and Current work" />
+          <img
+            src="https://images-ext-2.discordapp.net/external/MrGU7E1Vw1ks2LSlDu4fiYOrT8wgVB4fCfoxRii6SrE/%3Fsize%3D4096/https/cdn.discordapp.com/avatars/555126737038737408/a61db2e4c1f0a92cacee54f7b1aea624.png?width=554&height=554"
+            alt="Yura's latest avatar"
+            class="my-4 mx-auto h-40 w-40"
+          />
           <p class="my-2 text-justify">
             I am the creator of{" "}
             <GradientLink
@@ -32,15 +37,18 @@ export default function Home() {
               link="https://discordapp.com/invite/j55v7pD"
               title="My Discord bot's support server."
             />, a PSN-related Discord bot, based on PSNProfiles.com data
-            (2018-2023). I've also{" "}
-            <GradientLink
-              content="blogged"
-              newTab={true}
-              link="https://github.com/TheYuriG/blog_lessons/tree/master/discord_create_channels"
-              title="My Medium post about how to create various things in Discord.JS v14."
-            />{" "}
-            about Discord.JS in the past, it has an amazing API.
+            (2018-2023). I maintained it and updated it weekly until they
+            blocked all third-party requests to the website.
           </p>
+          <iframe
+            class="my-4"
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/V0en08tuceY"
+            title="YouTube video player"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          >
+          </iframe>
           <p class="my-2 text-justify">
             I've created{" "}
             <GradientLink
@@ -66,9 +74,14 @@ export default function Home() {
             />{" "}
             (2020).
           </p>
+          <img
+            src="https://media.discordapp.net/attachments/576538316296421399/1125169376157519963/image.png?width=832&height=671"
+            alt="Yura's port to mobile/desktop"
+            class="my-4 mx-auto w-full"
+          />
           <p class="my-2 text-justify">
             In the following year, I started porting Yura's functionality from
-            Discord to a{"  "}
+            Discord to a{" "}
             <GradientLink
               content="mobile/desktop app"
               newTab={true}
@@ -80,42 +93,19 @@ export default function Home() {
             Eventually I shelved that project (2021).
           </p>
           <p class="my-2 text-justify">
-            After freelancing for design agencies for a while, in 2022 I decided
-            to eventually move out of freelancing and try to get a remote job in
-            a tech company. Using Wix/SquareSpace/Framer templates to build
-            websites was really wearing me off, since we were just building
-            contract websites as fast as possible only to start the next. Just
-            felt like the lack of testing, UX and post-launch care for the
-            product wasn't like how WebDev was meant to be.
+            I've been working as a contractor for design agencies since early
+            2022, but using Wix/SquareSpace/Framer templates to build websites
+            is really wearing me off, since we were just building contract
+            websites as fast as possible only to start the next and repeat it
+            all over again. It just doesn't feel like WebDev is meant to be.
           </p>
+          <img
+            src="https://media.discordapp.net/attachments/576538316296421399/1125171715916443678/image.png?width=920&height=670"
+            alt="Trophy Place games page"
+            class="my-4 mx-auto w-full"
+          />
           <p class="my-2 text-justify">
-            I wasn't feeling like I was making any progress in becoming a
-            serious full-stack developer, so I've bought some{" "}
-            <GradientLink
-              content="Udemy courses"
-              newTab={true}
-              link="https://www.udemy.com/certificate/UC-c14620b0-6803-48a3-a7ab-5211825cec51/"
-              customRel="noopener noreferrer"
-              title="My Node.JS backend certificate"
-            />{" "}
-            and actually become a more interesting potential employee.
-          </p>
-          <p class="my-2 text-justify">
-            That got me to land some interviews, I even made some{" "}
-            <GradientLink
-              content="take-home assignments"
-              newTab={true}
-              link="https://github.com/TheYuriG/fullstackTodoApp"
-              customRel="noopener noreferrer"
-              title="A React Native assignment"
-            />{" "}
-            and experienced React Native for the first time (not wildly
-            different from Flutter), but didn't really land anything other than
-            more freelance work and some temporary contracts.
-          </p>
-          <p class="my-2 text-justify">
-            Since I wasn't having much luck getting professionally into tech, in
-            2023 I focused on fleshing out older projects I had, eventually
+            I've been focusing on fleshing out older projects I had, eventually
             starting{" "}
             <GradientLink
               content="Trophy Place"
@@ -123,27 +113,19 @@ export default function Home() {
               link="https://my.trophy.place/"
               title="More than just a passion project, Trophy Place will eventually become the defacto website for trophy hunting on PSN."
             />. My partner took over the frontend and I take care of the
-            backend, which is currently written with Node.JS and Express, but I
-            want to eventually rewrite it with Deno and Oak instead. Currently
-            Trophy Place, this website and freelancing are my daily routine.
+            backend, which is currently written with Node.JS and Express, but
+            will be rewritten it with Deno and Oak.
           </p>
           <p class="my-2 text-justify">
-            This website has been specially useful into getting me to learn how
-            to build things from scratch, like these:
+            Currently, Trophy Place, this website you are currently visiting,
+            studying and my agency contract jobs are my daily{" "}
+            <GradientLink
+              content="coding routine"
+              newTab={true}
+              link="https://github.com/TheYuriG"
+              title="My GitHub profile page."
+            />.
           </p>
-          <ol
-            start={1}
-            class="self-start list-[lower-greek]"
-          >
-            <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
-              <GradientLink
-                content="Form (with validation)"
-                title="A simple mock data form."
-                link="/work/form"
-                newTab={false}
-              />
-            </li>
-          </ol>
         </article>
       </Base>
     </>


### PR DESCRIPTION
Went over the text in those pages a bit, cleaned it up.

Additionally, this PR also does the following:
- Adds images and videos to `/work`.
- Moves the Stimulus Check form from `/work` to `/projects`, despite not being exactly a project.

Closes #90. Closes #89.