### PR TITLE
Ports medium blog post to /blog

### DIFF
--- a/assets/PullRequestIcon.tsx
+++ b/assets/PullRequestIcon.tsx
@@ -1,0 +1,20 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/misc/IconProperties.ts";
+
+//? Renders a Pull Request Icon with fill, stroke and stroke-width
+export function PullRequestIcon(
+  { iconHeight, iconWidth, iconFillColor }: IconProperties,
+) {
+  return (
+    <svg
+      class="custom-tr-fi group-hover:fill-[var(--accent-color)]"
+      xmlns="http://www.w3.org/2000/svg"
+      height={iconHeight}
+      width={iconWidth}
+      fill={iconFillColor ?? "var(--neutral-color)"}
+      viewBox="0 0 512 512"
+    >
+      <path d="M305.8 2.1C314.4 5.9 320 14.5 320 24V64h16c70.7 0 128 57.3 128 128V358.7c28.3 12.3 48 40.5 48 73.3c0 44.2-35.8 80-80 80s-80-35.8-80-80c0-32.8 19.7-61 48-73.3V192c0-35.3-28.7-64-64-64H320v40c0 9.5-5.6 18.1-14.2 21.9s-18.8 2.3-25.8-4.1l-80-72c-5.1-4.6-7.9-11-7.9-17.8s2.9-13.3 7.9-17.8l80-72c7-6.3 17.2-7.9 25.8-4.1zM104 80A24 24 0 1 0 56 80a24 24 0 1 0 48 0zm8 73.3V358.7c28.3 12.3 48 40.5 48 73.3c0 44.2-35.8 80-80 80s-80-35.8-80-80c0-32.8 19.7-61 48-73.3V153.3C19.7 141 0 112.8 0 80C0 35.8 35.8 0 80 0s80 35.8 80 80c0 32.8-19.7 61-48 73.3zM104 432a24 24 0 1 0 -48 0 24 24 0 1 0 48 0zm328 24a24 24 0 1 0 0-48 24 24 0 1 0 0 48z" />
+    </svg>
+  );
+}

--- a/components/UI/GreekList.tsx
+++ b/components/UI/GreekList.tsx
@@ -7,7 +7,7 @@ export function GreekList({ items }: { items: Array<string | JSX.Element> }) {
     //? Ordered list using greek alphabet characters for counting
     <ol
       start={1}
-      class="self-start list-[lower-greek]"
+      class="self-start list-[lower-greek] my-4"
     >
       {items.map((item) => (
         <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">

--- a/components/UI/GreekList.tsx
+++ b/components/UI/GreekList.tsx
@@ -1,0 +1,19 @@
+//? Import JSX so we can inject children elements
+import { JSX } from "preact";
+
+//? Dynamically display a list of lowercase greek numerals
+export function GreekList({ items }: { items: Array<string | JSX.Element> }) {
+  return (
+    //? Ordered list using greek alphabet characters for counting
+    <ol
+      start={1}
+      class="self-start list-[lower-greek]"
+    >
+      {items.map((item) => (
+        <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
+          {item}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/components/blog/BlogPostSummary.tsx
+++ b/components/blog/BlogPostSummary.tsx
@@ -9,7 +9,7 @@ export function BlogPostSummary(summary: BlogPostSummaryProperties) {
     // What a Post Summary looks like
     <article class="my-4 w-full">
       {/* Post link */}
-      <a href={"/blog" + summary.link}>
+      <a href={summary.link}>
         {/* Centered heading */}
         <StyledSubHeader title={summary.title} />
       </a>

--- a/components/misc/ViewOnGithub.tsx
+++ b/components/misc/ViewOnGithub.tsx
@@ -1,0 +1,23 @@
+//? Add a Pull Request icon before the text to be displayed
+import { PullRequestIcon } from "../../assets/PullRequestIcon.tsx";
+
+//? Render a Gradient Link that has
+export function ViewOnGitHub({ githubLink }: { githubLink: string }) {
+  return (
+    <a
+      class="flex space-x-2 self-start items-center mb-4 custom-underline-gradient hover:custom-tx-ac group"
+      href={githubLink}
+      title="Link to this file on GitHub"
+      target="_self"
+      rel="noopener noreferrer"
+    >
+      <PullRequestIcon
+        iconHeight="1em"
+        iconWidth="1em"
+      />
+      <span>
+        View/Download file
+      </span>
+    </a>
+  );
+}

--- a/components/tools/WhatsappLinksList.tsx
+++ b/components/tools/WhatsappLinksList.tsx
@@ -2,34 +2,27 @@
 import { WhatsappLinkData } from "../../types/whatsapp-link-generator/whatsapp-link-data.ts";
 //? Create gradient links to all numbers provided
 import { GradientLink } from "../UI/GradientLink.tsx";
+//? Create a greek list of contents
+import { GreekList } from "../UI/GreekList.tsx";
 
 //? Dynamically display a list of links to messaging one or more numbers on Whatsapp
 export function WhatsappLinksList(
   { whatsappDataList }: { whatsappDataList: WhatsappLinkData[] },
 ) {
-  return (
-    //? Ordered list using greek alphabet characters for counting
-    <ol
-      start={1}
-      class="self-start list-[lower-greek]"
-    >
-      {/* Display a gradient link for every string received */}
-      {whatsappDataList.map((
-        { areaCode, countryCode, messageText, phoneNumber },
-      ) => (
-        <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
-          <GradientLink
-            newTab={true}
-            content={`+${countryCode} (${areaCode}) ${phoneNumber}`}
-            link={`https://wa.me/${countryCode}${areaCode}${phoneNumber}${
-              messageText !== ""
-                ? `?text=${encodeURIComponent(messageText)}`
-                : ""
-            }`}
-            customRel="nofollow noreferrer"
-          />
-        </li>
-      ))}
-    </ol>
-  );
+  //? Instantiate all links
+  const gradientWhatsappLinks = whatsappDataList.map((
+    { areaCode, countryCode, messageText, phoneNumber },
+  ) => (
+    <GradientLink
+      newTab={true}
+      content={`+${countryCode} (${areaCode}) ${phoneNumber}`}
+      link={`https://wa.me/${countryCode}${areaCode}${phoneNumber}${
+        messageText !== "" ? `?text=${encodeURIComponent(messageText)}` : ""
+      }`}
+      customRel="nofollow noreferrer"
+    />
+  ));
+
+  //? Render all links
+  return <GreekList items={gradientWhatsappLinks} />;
 }

--- a/data/blog/how-create-categories-discord-v14.ts
+++ b/data/blog/how-create-categories-discord-v14.ts
@@ -1,0 +1,11 @@
+//? Import required properties for a blog post
+import BlogPostSummaryProperties from "../../types/BlogPostSummaryProperties.ts";
+
+//? Export object with blog post summary data
+export const createCategoryPost: BlogPostSummaryProperties = {
+  title: "How to create Categories in Discord.JS V14",
+  shortSummary:
+    "A guide on how to create Categories in Discord V14. Categories help organizing your Text and Voice Channels per topic, improving the user experience",
+  date: 1675551637744,
+  link: "/blog/how-create-categories-discord-v14",
+};

--- a/data/blog/how-create-roles-discord-v14.ts
+++ b/data/blog/how-create-roles-discord-v14.ts
@@ -1,0 +1,11 @@
+//? Import required properties for a blog post
+import BlogPostSummaryProperties from "../../types/BlogPostSummaryProperties.ts";
+
+//? Export object with blog post summary data
+export const createRolesPost: BlogPostSummaryProperties = {
+  title: "How to create Roles in Discord.JS V14",
+  shortSummary:
+    "A guide on how to create Roles in Discord V14. Roles help organizing your server members by interest and/or function",
+  date: 1675612799744,
+  link: "/blog/how-create-roles-discord-v14",
+};

--- a/data/blog/how-create-text-channels-discord-v14.ts
+++ b/data/blog/how-create-text-channels-discord-v14.ts
@@ -1,0 +1,11 @@
+//? Import required properties for a blog post
+import BlogPostSummaryProperties from "../../types/BlogPostSummaryProperties.ts";
+
+//? Export object with blog post summary data
+export const createChannelPost: BlogPostSummaryProperties = {
+  title: "How to create Text Channels and Threads in Discord.JS V14",
+  shortSummary:
+    "A guide on how to create text channels and threads programatically in Discord V14",
+  date: 1675351637744,
+  link: "/blog/how-create-text-channels-discord-v14",
+};

--- a/data/blog/how-create-text-channels-discord-v14.ts
+++ b/data/blog/how-create-text-channels-discord-v14.ts
@@ -2,7 +2,7 @@
 import BlogPostSummaryProperties from "../../types/BlogPostSummaryProperties.ts";
 
 //? Export object with blog post summary data
-export const createChannelPost: BlogPostSummaryProperties = {
+export const createTextChannelPost: BlogPostSummaryProperties = {
   title: "How to create Text Channels and Threads in Discord.JS V14",
   shortSummary:
     "A guide on how to create text channels and threads programatically in Discord V14",

--- a/data/blog/how-create-theme-switcher-deno-fresh.ts
+++ b/data/blog/how-create-theme-switcher-deno-fresh.ts
@@ -1,0 +1,11 @@
+//? Import required properties for a blog post
+import BlogPostSummaryProperties from "../../types/BlogPostSummaryProperties.ts";
+
+//? Export object with blog post summary data
+export const createFreshThemeSwitcher: BlogPostSummaryProperties = {
+  title: "How to Create a Theme Switcher with Fresh",
+  shortSummary:
+    "A guide on how to create your own Theme Switcher using Deno and Fresh",
+  date: 1684849328672,
+  link: "/blog/how-create-theme-switcher-deno-fresh",
+};

--- a/data/blog/how-create-voice-channels-discord-v14.ts
+++ b/data/blog/how-create-voice-channels-discord-v14.ts
@@ -1,0 +1,11 @@
+//? Import required properties for a blog post
+import BlogPostSummaryProperties from "../../types/BlogPostSummaryProperties.ts";
+
+//? Export object with blog post summary data
+export const createVoiceChannelPost: BlogPostSummaryProperties = {
+  title: "How to create Voice Channels in Discord.JS V14",
+  shortSummary:
+    "A guide on how to create voice channels dynamically in Discord V14",
+  date: 1675381637744,
+  link: "/blog/how-create-voice-channels-discord-v14",
+};

--- a/data/blog/stopping-theme-flickering-deno-fresh.ts
+++ b/data/blog/stopping-theme-flickering-deno-fresh.ts
@@ -1,0 +1,11 @@
+//? Import required properties for a blog post
+import BlogPostSummaryProperties from "../../types/BlogPostSummaryProperties.ts";
+
+//? Export object with blog post summary data
+export const stopThemeFlickering: BlogPostSummaryProperties = {
+  title: "How to stop Theme flickering in Fresh",
+  shortSummary:
+    "A guide on how to make your Theme Switcher stop flickering when the page loads",
+  date: 1684951466007,
+  link: "/blog/stopping-theme-flickering-deno-fresh",
+};

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -5,30 +5,31 @@
 import * as $0 from "./routes/_404.tsx";
 import * as $1 from "./routes/_500.tsx";
 import * as $2 from "./routes/blog/how-create-categories-discord-v14.tsx";
-import * as $3 from "./routes/blog/how-create-text-channels-discord-v14.tsx";
-import * as $4 from "./routes/blog/how-create-theme-switcher-deno-fresh.tsx";
-import * as $5 from "./routes/blog/how-create-voice-channels-discord-v14.tsx";
-import * as $6 from "./routes/blog/index.tsx";
-import * as $7 from "./routes/blog/stopping-theme-flickering-deno-fresh.tsx";
-import * as $8 from "./routes/certificates.tsx";
-import * as $9 from "./routes/index.tsx";
-import * as $10 from "./routes/me.tsx";
-import * as $11 from "./routes/projects/expenses-tracker.tsx";
-import * as $12 from "./routes/projects/food-order/checkout.tsx";
-import * as $13 from "./routes/projects/food-order/index.tsx";
-import * as $14 from "./routes/projects/food-order/success.tsx";
-import * as $15 from "./routes/projects/index.tsx";
-import * as $16 from "./routes/projects/stimulus-check.tsx";
-import * as $17 from "./routes/tools/highlighted-text/[text].tsx";
-import * as $18 from "./routes/tools/index.tsx";
-import * as $19 from "./routes/tools/retirement-calculator.tsx";
-import * as $20 from "./routes/tools/syntax-highlight.tsx";
-import * as $21 from "./routes/tools/whatsapp-message-link-generator.tsx";
-import * as $22 from "./routes/toys/index.tsx";
-import * as $23 from "./routes/toys/insanity.tsx";
-import * as $24 from "./routes/toys/spinners.tsx";
-import * as $25 from "./routes/what-is-this.tsx";
-import * as $26 from "./routes/work/index.tsx";
+import * as $3 from "./routes/blog/how-create-roles-discord-v14.tsx";
+import * as $4 from "./routes/blog/how-create-text-channels-discord-v14.tsx";
+import * as $5 from "./routes/blog/how-create-theme-switcher-deno-fresh.tsx";
+import * as $6 from "./routes/blog/how-create-voice-channels-discord-v14.tsx";
+import * as $7 from "./routes/blog/index.tsx";
+import * as $8 from "./routes/blog/stopping-theme-flickering-deno-fresh.tsx";
+import * as $9 from "./routes/certificates.tsx";
+import * as $10 from "./routes/index.tsx";
+import * as $11 from "./routes/me.tsx";
+import * as $12 from "./routes/projects/expenses-tracker.tsx";
+import * as $13 from "./routes/projects/food-order/checkout.tsx";
+import * as $14 from "./routes/projects/food-order/index.tsx";
+import * as $15 from "./routes/projects/food-order/success.tsx";
+import * as $16 from "./routes/projects/index.tsx";
+import * as $17 from "./routes/projects/stimulus-check.tsx";
+import * as $18 from "./routes/tools/highlighted-text/[text].tsx";
+import * as $19 from "./routes/tools/index.tsx";
+import * as $20 from "./routes/tools/retirement-calculator.tsx";
+import * as $21 from "./routes/tools/syntax-highlight.tsx";
+import * as $22 from "./routes/tools/whatsapp-message-link-generator.tsx";
+import * as $23 from "./routes/toys/index.tsx";
+import * as $24 from "./routes/toys/insanity.tsx";
+import * as $25 from "./routes/toys/spinners.tsx";
+import * as $26 from "./routes/what-is-this.tsx";
+import * as $27 from "./routes/work/index.tsx";
 import * as $$0 from "./islands/UI/DigitalTimer.tsx";
 import * as $$1 from "./islands/UI/Modal.tsx";
 import * as $$2 from "./islands/misc/Collapsible.tsx";
@@ -51,30 +52,31 @@ const manifest = {
     "./routes/_404.tsx": $0,
     "./routes/_500.tsx": $1,
     "./routes/blog/how-create-categories-discord-v14.tsx": $2,
-    "./routes/blog/how-create-text-channels-discord-v14.tsx": $3,
-    "./routes/blog/how-create-theme-switcher-deno-fresh.tsx": $4,
-    "./routes/blog/how-create-voice-channels-discord-v14.tsx": $5,
-    "./routes/blog/index.tsx": $6,
-    "./routes/blog/stopping-theme-flickering-deno-fresh.tsx": $7,
-    "./routes/certificates.tsx": $8,
-    "./routes/index.tsx": $9,
-    "./routes/me.tsx": $10,
-    "./routes/projects/expenses-tracker.tsx": $11,
-    "./routes/projects/food-order/checkout.tsx": $12,
-    "./routes/projects/food-order/index.tsx": $13,
-    "./routes/projects/food-order/success.tsx": $14,
-    "./routes/projects/index.tsx": $15,
-    "./routes/projects/stimulus-check.tsx": $16,
-    "./routes/tools/highlighted-text/[text].tsx": $17,
-    "./routes/tools/index.tsx": $18,
-    "./routes/tools/retirement-calculator.tsx": $19,
-    "./routes/tools/syntax-highlight.tsx": $20,
-    "./routes/tools/whatsapp-message-link-generator.tsx": $21,
-    "./routes/toys/index.tsx": $22,
-    "./routes/toys/insanity.tsx": $23,
-    "./routes/toys/spinners.tsx": $24,
-    "./routes/what-is-this.tsx": $25,
-    "./routes/work/index.tsx": $26,
+    "./routes/blog/how-create-roles-discord-v14.tsx": $3,
+    "./routes/blog/how-create-text-channels-discord-v14.tsx": $4,
+    "./routes/blog/how-create-theme-switcher-deno-fresh.tsx": $5,
+    "./routes/blog/how-create-voice-channels-discord-v14.tsx": $6,
+    "./routes/blog/index.tsx": $7,
+    "./routes/blog/stopping-theme-flickering-deno-fresh.tsx": $8,
+    "./routes/certificates.tsx": $9,
+    "./routes/index.tsx": $10,
+    "./routes/me.tsx": $11,
+    "./routes/projects/expenses-tracker.tsx": $12,
+    "./routes/projects/food-order/checkout.tsx": $13,
+    "./routes/projects/food-order/index.tsx": $14,
+    "./routes/projects/food-order/success.tsx": $15,
+    "./routes/projects/index.tsx": $16,
+    "./routes/projects/stimulus-check.tsx": $17,
+    "./routes/tools/highlighted-text/[text].tsx": $18,
+    "./routes/tools/index.tsx": $19,
+    "./routes/tools/retirement-calculator.tsx": $20,
+    "./routes/tools/syntax-highlight.tsx": $21,
+    "./routes/tools/whatsapp-message-link-generator.tsx": $22,
+    "./routes/toys/index.tsx": $23,
+    "./routes/toys/insanity.tsx": $24,
+    "./routes/toys/spinners.tsx": $25,
+    "./routes/what-is-this.tsx": $26,
+    "./routes/work/index.tsx": $27,
   },
   islands: {
     "./islands/UI/DigitalTimer.tsx": $$0,

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -4,28 +4,29 @@
 
 import * as $0 from "./routes/_404.tsx";
 import * as $1 from "./routes/_500.tsx";
-import * as $2 from "./routes/blog/how-create-theme-switcher-deno-fresh.tsx";
-import * as $3 from "./routes/blog/index.tsx";
-import * as $4 from "./routes/blog/stopping-theme-flickering-deno-fresh.tsx";
-import * as $5 from "./routes/certificates.tsx";
-import * as $6 from "./routes/index.tsx";
-import * as $7 from "./routes/me.tsx";
-import * as $8 from "./routes/projects/expenses-tracker.tsx";
-import * as $9 from "./routes/projects/food-order/checkout.tsx";
-import * as $10 from "./routes/projects/food-order/index.tsx";
-import * as $11 from "./routes/projects/food-order/success.tsx";
-import * as $12 from "./routes/projects/index.tsx";
-import * as $13 from "./routes/projects/stimulus-check.tsx";
-import * as $14 from "./routes/tools/highlighted-text/[text].tsx";
-import * as $15 from "./routes/tools/index.tsx";
-import * as $16 from "./routes/tools/retirement-calculator.tsx";
-import * as $17 from "./routes/tools/syntax-highlight.tsx";
-import * as $18 from "./routes/tools/whatsapp-message-link-generator.tsx";
-import * as $19 from "./routes/toys/index.tsx";
-import * as $20 from "./routes/toys/insanity.tsx";
-import * as $21 from "./routes/toys/spinners.tsx";
-import * as $22 from "./routes/what-is-this.tsx";
-import * as $23 from "./routes/work/index.tsx";
+import * as $2 from "./routes/blog/how-create-channels-discord-v14.tsx";
+import * as $3 from "./routes/blog/how-create-theme-switcher-deno-fresh.tsx";
+import * as $4 from "./routes/blog/index.tsx";
+import * as $5 from "./routes/blog/stopping-theme-flickering-deno-fresh.tsx";
+import * as $6 from "./routes/certificates.tsx";
+import * as $7 from "./routes/index.tsx";
+import * as $8 from "./routes/me.tsx";
+import * as $9 from "./routes/projects/expenses-tracker.tsx";
+import * as $10 from "./routes/projects/food-order/checkout.tsx";
+import * as $11 from "./routes/projects/food-order/index.tsx";
+import * as $12 from "./routes/projects/food-order/success.tsx";
+import * as $13 from "./routes/projects/index.tsx";
+import * as $14 from "./routes/projects/stimulus-check.tsx";
+import * as $15 from "./routes/tools/highlighted-text/[text].tsx";
+import * as $16 from "./routes/tools/index.tsx";
+import * as $17 from "./routes/tools/retirement-calculator.tsx";
+import * as $18 from "./routes/tools/syntax-highlight.tsx";
+import * as $19 from "./routes/tools/whatsapp-message-link-generator.tsx";
+import * as $20 from "./routes/toys/index.tsx";
+import * as $21 from "./routes/toys/insanity.tsx";
+import * as $22 from "./routes/toys/spinners.tsx";
+import * as $23 from "./routes/what-is-this.tsx";
+import * as $24 from "./routes/work/index.tsx";
 import * as $$0 from "./islands/UI/DigitalTimer.tsx";
 import * as $$1 from "./islands/UI/Modal.tsx";
 import * as $$2 from "./islands/misc/Collapsible.tsx";
@@ -47,28 +48,29 @@ const manifest = {
   routes: {
     "./routes/_404.tsx": $0,
     "./routes/_500.tsx": $1,
-    "./routes/blog/how-create-theme-switcher-deno-fresh.tsx": $2,
-    "./routes/blog/index.tsx": $3,
-    "./routes/blog/stopping-theme-flickering-deno-fresh.tsx": $4,
-    "./routes/certificates.tsx": $5,
-    "./routes/index.tsx": $6,
-    "./routes/me.tsx": $7,
-    "./routes/projects/expenses-tracker.tsx": $8,
-    "./routes/projects/food-order/checkout.tsx": $9,
-    "./routes/projects/food-order/index.tsx": $10,
-    "./routes/projects/food-order/success.tsx": $11,
-    "./routes/projects/index.tsx": $12,
-    "./routes/projects/stimulus-check.tsx": $13,
-    "./routes/tools/highlighted-text/[text].tsx": $14,
-    "./routes/tools/index.tsx": $15,
-    "./routes/tools/retirement-calculator.tsx": $16,
-    "./routes/tools/syntax-highlight.tsx": $17,
-    "./routes/tools/whatsapp-message-link-generator.tsx": $18,
-    "./routes/toys/index.tsx": $19,
-    "./routes/toys/insanity.tsx": $20,
-    "./routes/toys/spinners.tsx": $21,
-    "./routes/what-is-this.tsx": $22,
-    "./routes/work/index.tsx": $23,
+    "./routes/blog/how-create-channels-discord-v14.tsx": $2,
+    "./routes/blog/how-create-theme-switcher-deno-fresh.tsx": $3,
+    "./routes/blog/index.tsx": $4,
+    "./routes/blog/stopping-theme-flickering-deno-fresh.tsx": $5,
+    "./routes/certificates.tsx": $6,
+    "./routes/index.tsx": $7,
+    "./routes/me.tsx": $8,
+    "./routes/projects/expenses-tracker.tsx": $9,
+    "./routes/projects/food-order/checkout.tsx": $10,
+    "./routes/projects/food-order/index.tsx": $11,
+    "./routes/projects/food-order/success.tsx": $12,
+    "./routes/projects/index.tsx": $13,
+    "./routes/projects/stimulus-check.tsx": $14,
+    "./routes/tools/highlighted-text/[text].tsx": $15,
+    "./routes/tools/index.tsx": $16,
+    "./routes/tools/retirement-calculator.tsx": $17,
+    "./routes/tools/syntax-highlight.tsx": $18,
+    "./routes/tools/whatsapp-message-link-generator.tsx": $19,
+    "./routes/toys/index.tsx": $20,
+    "./routes/toys/insanity.tsx": $21,
+    "./routes/toys/spinners.tsx": $22,
+    "./routes/what-is-this.tsx": $23,
+    "./routes/work/index.tsx": $24,
   },
   islands: {
     "./islands/UI/DigitalTimer.tsx": $$0,

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -4,30 +4,31 @@
 
 import * as $0 from "./routes/_404.tsx";
 import * as $1 from "./routes/_500.tsx";
-import * as $2 from "./routes/blog/how-create-text-channels-discord-v14.tsx";
-import * as $3 from "./routes/blog/how-create-theme-switcher-deno-fresh.tsx";
-import * as $4 from "./routes/blog/how-create-voice-channels-discord-v14.tsx";
-import * as $5 from "./routes/blog/index.tsx";
-import * as $6 from "./routes/blog/stopping-theme-flickering-deno-fresh.tsx";
-import * as $7 from "./routes/certificates.tsx";
-import * as $8 from "./routes/index.tsx";
-import * as $9 from "./routes/me.tsx";
-import * as $10 from "./routes/projects/expenses-tracker.tsx";
-import * as $11 from "./routes/projects/food-order/checkout.tsx";
-import * as $12 from "./routes/projects/food-order/index.tsx";
-import * as $13 from "./routes/projects/food-order/success.tsx";
-import * as $14 from "./routes/projects/index.tsx";
-import * as $15 from "./routes/projects/stimulus-check.tsx";
-import * as $16 from "./routes/tools/highlighted-text/[text].tsx";
-import * as $17 from "./routes/tools/index.tsx";
-import * as $18 from "./routes/tools/retirement-calculator.tsx";
-import * as $19 from "./routes/tools/syntax-highlight.tsx";
-import * as $20 from "./routes/tools/whatsapp-message-link-generator.tsx";
-import * as $21 from "./routes/toys/index.tsx";
-import * as $22 from "./routes/toys/insanity.tsx";
-import * as $23 from "./routes/toys/spinners.tsx";
-import * as $24 from "./routes/what-is-this.tsx";
-import * as $25 from "./routes/work/index.tsx";
+import * as $2 from "./routes/blog/how-create-categories-discord-v14.tsx";
+import * as $3 from "./routes/blog/how-create-text-channels-discord-v14.tsx";
+import * as $4 from "./routes/blog/how-create-theme-switcher-deno-fresh.tsx";
+import * as $5 from "./routes/blog/how-create-voice-channels-discord-v14.tsx";
+import * as $6 from "./routes/blog/index.tsx";
+import * as $7 from "./routes/blog/stopping-theme-flickering-deno-fresh.tsx";
+import * as $8 from "./routes/certificates.tsx";
+import * as $9 from "./routes/index.tsx";
+import * as $10 from "./routes/me.tsx";
+import * as $11 from "./routes/projects/expenses-tracker.tsx";
+import * as $12 from "./routes/projects/food-order/checkout.tsx";
+import * as $13 from "./routes/projects/food-order/index.tsx";
+import * as $14 from "./routes/projects/food-order/success.tsx";
+import * as $15 from "./routes/projects/index.tsx";
+import * as $16 from "./routes/projects/stimulus-check.tsx";
+import * as $17 from "./routes/tools/highlighted-text/[text].tsx";
+import * as $18 from "./routes/tools/index.tsx";
+import * as $19 from "./routes/tools/retirement-calculator.tsx";
+import * as $20 from "./routes/tools/syntax-highlight.tsx";
+import * as $21 from "./routes/tools/whatsapp-message-link-generator.tsx";
+import * as $22 from "./routes/toys/index.tsx";
+import * as $23 from "./routes/toys/insanity.tsx";
+import * as $24 from "./routes/toys/spinners.tsx";
+import * as $25 from "./routes/what-is-this.tsx";
+import * as $26 from "./routes/work/index.tsx";
 import * as $$0 from "./islands/UI/DigitalTimer.tsx";
 import * as $$1 from "./islands/UI/Modal.tsx";
 import * as $$2 from "./islands/misc/Collapsible.tsx";
@@ -49,30 +50,31 @@ const manifest = {
   routes: {
     "./routes/_404.tsx": $0,
     "./routes/_500.tsx": $1,
-    "./routes/blog/how-create-text-channels-discord-v14.tsx": $2,
-    "./routes/blog/how-create-theme-switcher-deno-fresh.tsx": $3,
-    "./routes/blog/how-create-voice-channels-discord-v14.tsx": $4,
-    "./routes/blog/index.tsx": $5,
-    "./routes/blog/stopping-theme-flickering-deno-fresh.tsx": $6,
-    "./routes/certificates.tsx": $7,
-    "./routes/index.tsx": $8,
-    "./routes/me.tsx": $9,
-    "./routes/projects/expenses-tracker.tsx": $10,
-    "./routes/projects/food-order/checkout.tsx": $11,
-    "./routes/projects/food-order/index.tsx": $12,
-    "./routes/projects/food-order/success.tsx": $13,
-    "./routes/projects/index.tsx": $14,
-    "./routes/projects/stimulus-check.tsx": $15,
-    "./routes/tools/highlighted-text/[text].tsx": $16,
-    "./routes/tools/index.tsx": $17,
-    "./routes/tools/retirement-calculator.tsx": $18,
-    "./routes/tools/syntax-highlight.tsx": $19,
-    "./routes/tools/whatsapp-message-link-generator.tsx": $20,
-    "./routes/toys/index.tsx": $21,
-    "./routes/toys/insanity.tsx": $22,
-    "./routes/toys/spinners.tsx": $23,
-    "./routes/what-is-this.tsx": $24,
-    "./routes/work/index.tsx": $25,
+    "./routes/blog/how-create-categories-discord-v14.tsx": $2,
+    "./routes/blog/how-create-text-channels-discord-v14.tsx": $3,
+    "./routes/blog/how-create-theme-switcher-deno-fresh.tsx": $4,
+    "./routes/blog/how-create-voice-channels-discord-v14.tsx": $5,
+    "./routes/blog/index.tsx": $6,
+    "./routes/blog/stopping-theme-flickering-deno-fresh.tsx": $7,
+    "./routes/certificates.tsx": $8,
+    "./routes/index.tsx": $9,
+    "./routes/me.tsx": $10,
+    "./routes/projects/expenses-tracker.tsx": $11,
+    "./routes/projects/food-order/checkout.tsx": $12,
+    "./routes/projects/food-order/index.tsx": $13,
+    "./routes/projects/food-order/success.tsx": $14,
+    "./routes/projects/index.tsx": $15,
+    "./routes/projects/stimulus-check.tsx": $16,
+    "./routes/tools/highlighted-text/[text].tsx": $17,
+    "./routes/tools/index.tsx": $18,
+    "./routes/tools/retirement-calculator.tsx": $19,
+    "./routes/tools/syntax-highlight.tsx": $20,
+    "./routes/tools/whatsapp-message-link-generator.tsx": $21,
+    "./routes/toys/index.tsx": $22,
+    "./routes/toys/insanity.tsx": $23,
+    "./routes/toys/spinners.tsx": $24,
+    "./routes/what-is-this.tsx": $25,
+    "./routes/work/index.tsx": $26,
   },
   islands: {
     "./islands/UI/DigitalTimer.tsx": $$0,

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -4,29 +4,30 @@
 
 import * as $0 from "./routes/_404.tsx";
 import * as $1 from "./routes/_500.tsx";
-import * as $2 from "./routes/blog/how-create-channels-discord-v14.tsx";
+import * as $2 from "./routes/blog/how-create-text-channels-discord-v14.tsx";
 import * as $3 from "./routes/blog/how-create-theme-switcher-deno-fresh.tsx";
-import * as $4 from "./routes/blog/index.tsx";
-import * as $5 from "./routes/blog/stopping-theme-flickering-deno-fresh.tsx";
-import * as $6 from "./routes/certificates.tsx";
-import * as $7 from "./routes/index.tsx";
-import * as $8 from "./routes/me.tsx";
-import * as $9 from "./routes/projects/expenses-tracker.tsx";
-import * as $10 from "./routes/projects/food-order/checkout.tsx";
-import * as $11 from "./routes/projects/food-order/index.tsx";
-import * as $12 from "./routes/projects/food-order/success.tsx";
-import * as $13 from "./routes/projects/index.tsx";
-import * as $14 from "./routes/projects/stimulus-check.tsx";
-import * as $15 from "./routes/tools/highlighted-text/[text].tsx";
-import * as $16 from "./routes/tools/index.tsx";
-import * as $17 from "./routes/tools/retirement-calculator.tsx";
-import * as $18 from "./routes/tools/syntax-highlight.tsx";
-import * as $19 from "./routes/tools/whatsapp-message-link-generator.tsx";
-import * as $20 from "./routes/toys/index.tsx";
-import * as $21 from "./routes/toys/insanity.tsx";
-import * as $22 from "./routes/toys/spinners.tsx";
-import * as $23 from "./routes/what-is-this.tsx";
-import * as $24 from "./routes/work/index.tsx";
+import * as $4 from "./routes/blog/how-create-voice-channels-discord-v14.tsx";
+import * as $5 from "./routes/blog/index.tsx";
+import * as $6 from "./routes/blog/stopping-theme-flickering-deno-fresh.tsx";
+import * as $7 from "./routes/certificates.tsx";
+import * as $8 from "./routes/index.tsx";
+import * as $9 from "./routes/me.tsx";
+import * as $10 from "./routes/projects/expenses-tracker.tsx";
+import * as $11 from "./routes/projects/food-order/checkout.tsx";
+import * as $12 from "./routes/projects/food-order/index.tsx";
+import * as $13 from "./routes/projects/food-order/success.tsx";
+import * as $14 from "./routes/projects/index.tsx";
+import * as $15 from "./routes/projects/stimulus-check.tsx";
+import * as $16 from "./routes/tools/highlighted-text/[text].tsx";
+import * as $17 from "./routes/tools/index.tsx";
+import * as $18 from "./routes/tools/retirement-calculator.tsx";
+import * as $19 from "./routes/tools/syntax-highlight.tsx";
+import * as $20 from "./routes/tools/whatsapp-message-link-generator.tsx";
+import * as $21 from "./routes/toys/index.tsx";
+import * as $22 from "./routes/toys/insanity.tsx";
+import * as $23 from "./routes/toys/spinners.tsx";
+import * as $24 from "./routes/what-is-this.tsx";
+import * as $25 from "./routes/work/index.tsx";
 import * as $$0 from "./islands/UI/DigitalTimer.tsx";
 import * as $$1 from "./islands/UI/Modal.tsx";
 import * as $$2 from "./islands/misc/Collapsible.tsx";
@@ -48,29 +49,30 @@ const manifest = {
   routes: {
     "./routes/_404.tsx": $0,
     "./routes/_500.tsx": $1,
-    "./routes/blog/how-create-channels-discord-v14.tsx": $2,
+    "./routes/blog/how-create-text-channels-discord-v14.tsx": $2,
     "./routes/blog/how-create-theme-switcher-deno-fresh.tsx": $3,
-    "./routes/blog/index.tsx": $4,
-    "./routes/blog/stopping-theme-flickering-deno-fresh.tsx": $5,
-    "./routes/certificates.tsx": $6,
-    "./routes/index.tsx": $7,
-    "./routes/me.tsx": $8,
-    "./routes/projects/expenses-tracker.tsx": $9,
-    "./routes/projects/food-order/checkout.tsx": $10,
-    "./routes/projects/food-order/index.tsx": $11,
-    "./routes/projects/food-order/success.tsx": $12,
-    "./routes/projects/index.tsx": $13,
-    "./routes/projects/stimulus-check.tsx": $14,
-    "./routes/tools/highlighted-text/[text].tsx": $15,
-    "./routes/tools/index.tsx": $16,
-    "./routes/tools/retirement-calculator.tsx": $17,
-    "./routes/tools/syntax-highlight.tsx": $18,
-    "./routes/tools/whatsapp-message-link-generator.tsx": $19,
-    "./routes/toys/index.tsx": $20,
-    "./routes/toys/insanity.tsx": $21,
-    "./routes/toys/spinners.tsx": $22,
-    "./routes/what-is-this.tsx": $23,
-    "./routes/work/index.tsx": $24,
+    "./routes/blog/how-create-voice-channels-discord-v14.tsx": $4,
+    "./routes/blog/index.tsx": $5,
+    "./routes/blog/stopping-theme-flickering-deno-fresh.tsx": $6,
+    "./routes/certificates.tsx": $7,
+    "./routes/index.tsx": $8,
+    "./routes/me.tsx": $9,
+    "./routes/projects/expenses-tracker.tsx": $10,
+    "./routes/projects/food-order/checkout.tsx": $11,
+    "./routes/projects/food-order/index.tsx": $12,
+    "./routes/projects/food-order/success.tsx": $13,
+    "./routes/projects/index.tsx": $14,
+    "./routes/projects/stimulus-check.tsx": $15,
+    "./routes/tools/highlighted-text/[text].tsx": $16,
+    "./routes/tools/index.tsx": $17,
+    "./routes/tools/retirement-calculator.tsx": $18,
+    "./routes/tools/syntax-highlight.tsx": $19,
+    "./routes/tools/whatsapp-message-link-generator.tsx": $20,
+    "./routes/toys/index.tsx": $21,
+    "./routes/toys/insanity.tsx": $22,
+    "./routes/toys/spinners.tsx": $23,
+    "./routes/what-is-this.tsx": $24,
+    "./routes/work/index.tsx": $25,
   },
   islands: {
     "./islands/UI/DigitalTimer.tsx": $$0,

--- a/routes/blog/how-create-categories-discord-v14.tsx
+++ b/routes/blog/how-create-categories-discord-v14.tsx
@@ -9,6 +9,8 @@ import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? A HTML Link component to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+//? Display a link to view the source code on GitHub
+import { ViewOnGitHub } from "../../components/misc/ViewOnGithub.tsx";
 //? Import post summary
 import { createVoiceChannelPost as previousPost } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
 import { createCategoryPost as postSummary } from "../../data/blog/how-create-categories-discord-v14.ts";
@@ -279,24 +281,18 @@ export default function Home() {
             </span>
           </div>
           {/* Code link */}
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createcategory.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createcategory.js" />
           <p class="my-2 text-justify">
-            As you probably noticed if you paid attention to the{" "}
+            You might have noticed if you went through the{" "}
             <GradientLink
               link={createTextChannelPost.link}
               title={createTextChannelPost.title}
               content="Create a Text Channel with Dynamic Names"
               newTab={false}
             />{" "}
-            lesson, not much was changed. We have renamed our variable, updated
-            the command and the option name, and changed the type of{" "}
+            lesson that very little was changed. We have renamed our variable,
+            updated the command and the option name, and changed the type of
+            {" "}
             <GradientLink
               link="https://discord.js.org/#/docs/discord.js/main/class/GuildChannel"
               title="GuildChannel (D.JS Docs)"
@@ -645,14 +641,7 @@ export default function Home() {
             </span>
           </div>
           {/* Code link */}
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createcategorywithnestedchannels.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createcategorywithnestedchannels.js" />
           <p class="my-2 text-justify">
             You should be fairly familiar with what's happening here by this
             point if you have been following along. We are requiring the user to

--- a/routes/blog/how-create-categories-discord-v14.tsx
+++ b/routes/blog/how-create-categories-discord-v14.tsx
@@ -1,0 +1,799 @@
+//? Head component with all Meta tags pre-set
+import { CustomHead } from "../../components/base/CustomHead.tsx";
+//? Lateral text with theme switcher
+import { Base } from "../../components/base/Base.tsx";
+//? Default styled headers
+import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
+import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
+//? Navigation Buttons to go back to the previous page or to the next page (optional)
+import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
+//? A HTML Link component to pre-format links and reduce boiletplate
+import { GradientLink } from "../../components/UI/GradientLink.tsx";
+//? Import post summary
+import { createVoiceChannelPost as previousPost } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
+import { createCategoryPost as postSummary } from "../../data/blog/how-create-categories-discord-v14.ts";
+import { createTextChannelPost } from "../../data/blog/how-create-text-channels-discord-v14.ts";
+
+export default function Home() {
+  return (
+    <>
+      <CustomHead
+        title={postSummary.title}
+        description={postSummary.shortSummary}
+        link={"https://www.theyurig.com" + postSummary.link}
+      >
+      </CustomHead>
+      {/* Base page layout with theme switching and footer outside of accent box */}
+      <Base>
+        {/* Back button */}
+        <NavigationButtons
+          back={{ title: previousPost.title, link: previousPost.link }}
+        />
+        <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
+          {/* Title header */}
+          <StyledHeader title={postSummary.title} />
+          {/* Post creation date */}
+          <p class="text-sm mb-2 w-full text-center">
+            {new Date(postSummary.date).toLocaleString()}
+          </p>
+          {/* Medium alternative */}
+          <p class="mb-4 self-start text-xs">
+            This is the third (of four) parts of the Discord.JS V14 tutorial
+            that I've published. You can read the{" "}
+            <GradientLink
+              link={previousPost.link}
+              title={previousPost.title}
+              content="second part"
+              customRel="prev"
+              newTab={false}
+            />{" "}
+            here. You can also read the full version of this tutorial on{" "}
+            <GradientLink
+              link="https://medium.com/@yuri03042/how-to-create-categories-text-channels-threads-voice-channels-and-roles-in-discord-js-v14-1f2664546433"
+              title="Medium version alternative"
+              content="Medium"
+              customRel="noopener noreferrer"
+            />{" "}
+            if you prefer.
+          </p>
+          {/* Introduction */}
+          <p class="my-2 text-justify">
+            As mentioned in the previous lessons,{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Categories"
+              customRel="noopener noreferrer"
+            />{" "}
+            are the parents of some{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildChannel"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />. Not all{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildChannel"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            belong to a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />{" "}
+            (the ones that don't, are referred as "stray Channels").
+          </p>
+          <p class="my-2 text-justify">
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Categories"
+              customRel="noopener noreferrer"
+            />{" "}
+            exist for primarily two reasons: Organizing{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildChannel"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            within a certain topic and quickly syncing the permissions of all
+            {" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildChannel"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            within it. They also are very simple to create, even simpler than
+            {" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            or{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text Channels"
+              customRel="noopener noreferrer"
+            />, since the number of configuration options for them is limited.
+          </p>
+          <p class="my-2 text-justify">
+            Let's modify the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            file a bit and then talk about the differences between them and{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Categories"
+              customRel="noopener noreferrer"
+            />:
+          </p>
+
+          {/* Creating category code block */}
+          <div class="shl-block">
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // initial code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addStringOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+  `}option{`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "categoryname"
+            </span>){" "}
+            <span class="shl-cmnt">
+              // option names need to always be lowercase and have no spaces
+            </span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              "Choose the name to give to the category"
+            </span>){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMinLength</span>(<span class="shl-num">
+              1
+            </span>){" "}
+            <span class="shl-cmnt">// A Category needs to be named</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMaxLength</span>(<span class="shl-num">
+              25
+            </span>){" "}
+            <span class="shl-cmnt">
+              // Discord will cut-off names past the ~27 characters (for
+              Categories),
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // so that's a good hard limit to set. You can manually increase
+              this if you wish
+            </span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setRequired</span>(<span class="shl-bool">
+              true
+            </span>){`
+`});{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-kwd">const</span> chosenCategoryName{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getString</span>(<span class="shl-str">
+              "categoryname"
+            </span>);{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">
+              .
+            </span>guild<span class="shl-oper">
+              .
+            </span>channels<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+  `}name<span class="shl-oper">:</span>{" "}
+            chosenCategoryName<span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The name given to the Channel by the user
+            </span>
+            {`
+  `}type<span class="shl-oper">:</span>{" "}
+            <span class="shl-class">ChannelType</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">GuildCategory</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The type of the Channel created.{`
+`}
+            </span>&#125;);{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // rest of the code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+          </div>
+          {/* Code link */}
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createcategory.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
+          <p class="my-2 text-justify">
+            As you probably noticed if you paid attention to the{" "}
+            <GradientLink
+              link={createTextChannelPost.link}
+              title={createTextChannelPost.title}
+              content="Create a Text Channel with Dynamic Names"
+              newTab={false}
+            />{" "}
+            lesson, not much was changed. We have renamed our variable, updated
+            the command and the option name, and changed the type of{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildChannel"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            being created to{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="GuildCategory"
+              customRel="noopener noreferrer"
+            />. Simple, right? But there is not much use in having empty{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Categories"
+              customRel="noopener noreferrer"
+            />, so let's populate our newly created{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />{" "}
+            with some{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildChannel"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            now.
+          </p>
+
+          <StyledSubHeader title="Creating a Category that nests other types of channels" />
+          <p class="my-2 text-justify">
+            We have seen how to create{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text"
+              customRel="noopener noreferrer"
+            />{" "}
+            and{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            that can be nested in their existing parent{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Categories"
+              customRel="noopener noreferrer"
+            />{" "}
+            (when there is one), but now we are going to create a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />{" "}
+            and immediately nest newly created{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            and{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            within. As you can probably guess, we won't need to change a lot of
+            our existing code, but we gonna reuse code from a few of our files
+            to accomplish this.
+          </p>
+
+          {/* Category with nested channels code block */}
+          <div class="shl-block">
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // initial code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-cmnt">
+              // Text Channel name{`
+`}
+            </span>
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addStringOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+  `}option{`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "textchannelname"
+            </span>){" "}
+            <span class="shl-cmnt">
+              // option names need to always be lowercase and have no spaces
+            </span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              "Choose the name to give to the text channel"
+            </span>){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMinLength</span>(<span class="shl-num">
+              1
+            </span>){" "}
+            <span class="shl-cmnt">// A Text Channel needs to be named</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMaxLength</span>(<span class="shl-num">
+              25
+            </span>){" "}
+            <span class="shl-cmnt">
+              // Discord will cut-off names past the 25 characters,
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // so that's a good hard limit to set. You can manually increase
+              this if you wish
+            </span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setRequired</span>(<span class="shl-bool">
+              true
+            </span>){`
+`});{`
+`}
+            <span class="shl-cmnt">
+              // Voice Channel name{`
+`}
+            </span>
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addStringOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+  `}option{`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "voicechannelname"
+            </span>){" "}
+            <span class="shl-cmnt">
+              // option names need to always be lowercase and have no spaces
+            </span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              "Choose the name to give to the voice channel"
+            </span>){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMinLength</span>(<span class="shl-num">
+              1
+            </span>){" "}
+            <span class="shl-cmnt">// A Voice Channel needs to be named</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMaxLength</span>(<span class="shl-num">
+              25
+            </span>){" "}
+            <span class="shl-cmnt">
+              // Discord will cut-off names past the 25 characters,
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // so that's a good hard limit to set. You can manually increase
+              this if you wish
+            </span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setRequired</span>(<span class="shl-bool">
+              true
+            </span>){`
+`});{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-kwd">const</span> chosenTextChannelName{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getString</span>(<span class="shl-str">
+              "textchannelname"
+            </span>);{`
+`}
+            <span class="shl-kwd">const</span> chosenVoiceChannelName{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getString</span>({`
+  `}
+            <span class="shl-str">"voicechannelname"</span>
+            <span class="shl-oper">,</span>
+            {`
+`});{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-cmnt">
+              // Now create the Category in the server.{`
+`}
+            </span>
+            <span class="shl-kwd">const</span> newlyCreatedCategory{" "}
+            <span class="shl-oper">=</span> <span class="shl-kwd">await</span>
+            {" "}
+            interaction<span class="shl-oper">
+              .
+            </span>guild<span class="shl-oper">
+              .
+            </span>channels<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+  `}name<span class="shl-oper">:</span>{" "}
+            chosenCategoryName<span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The name given to the Channel by the user
+            </span>
+            {`
+  `}type<span class="shl-oper">:</span>{" "}
+            <span class="shl-class">ChannelType</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">GuildCategory</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The type of the Channel created.{`
+`}
+            </span>&#125;);{`
+
+`}
+            <span class="shl-cmnt">
+              // Now we create the Text Channel within the Category we just
+              created{`
+`}
+            </span>
+            <span class="shl-kwd">await</span>{" "}
+            newlyCreatedCategory<span class="shl-oper">
+              .
+            </span>children<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+  `}name<span class="shl-oper">:</span>{" "}
+            chosenTextChannelName<span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The name given to the Channel by the user
+            </span>
+            {`
+  `}type<span class="shl-oper">:</span>{" "}
+            <span class="shl-class">ChannelType</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">GuildText</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">// The type of the Channel created.</span>
+            {`
+  `}
+            <span class="shl-cmnt">
+              // Since "text" is the default Channel created, this could be
+              ommitted{`
+`}
+            </span>&#125;);{`
+
+`}
+            <span class="shl-cmnt">
+              // Lastly we create the Voice Channel within the same Category{`
+`}
+            </span>
+            <span class="shl-kwd">await</span>{" "}
+            newlyCreatedCategory<span class="shl-oper">
+              .
+            </span>children<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+  `}name<span class="shl-oper">:</span>{" "}
+            chosenVoiceChannelName<span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The name given to the Channel by the user
+            </span>
+            {`
+  `}type<span class="shl-oper">:</span>{" "}
+            <span class="shl-class">ChannelType</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">GuildVoice</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The type of the Channel created.{`
+`}
+            </span>&#125;);{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // rest of the code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+          </div>
+          {/* Code link */}
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createcategorywithnestedchannels.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
+          <p class="my-2 text-justify">
+            You should be fairly familiar with what's happening here by this
+            point if you have been following along. We are requiring the user to
+            provide us a name for the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            and the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channel"
+              customRel="noopener noreferrer"
+            />, we are then fetching that input and using it to create them
+            nested within the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />{" "}
+            we created. There are only two points that I think it's important to
+            go through in more detail:
+          </p>
+          {/* line 65 quote */}
+          <q className="custom-quote italic self-start">
+            const newlyCreatedCategory = await
+            interaction.guild.channels.create(&#123; (<GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcategorywithnestedchannels.js#L65"
+              title="view source"
+              content="line 65"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            We are now fetching the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />{" "}
+            and storing it to a constant, so it can be used to nest the newly
+            created{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text"
+              customRel="noopener noreferrer"
+            />{" "}
+            and{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channels"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+          {/* lines 74 and 81 quote */}
+          <q className="custom-quote italic self-start">
+            await newlyCreatedCategory.children.create(&#123; (lines{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcategorywithnestedchannels.js#L74"
+              title="view source"
+              content="74"
+              customRel="noopener noreferrer"
+            />{" "}
+            and{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcategorywithnestedchannels.js#L81"
+              title="view source"
+              content="81"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            Since we now have a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />, we don't need to transverse through the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CommandInteraction"
+              title="CommandInteraction (D.JS Docs)"
+              content="interaction"
+              customRel="noopener noreferrer"
+            />, then the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Guild"
+              title="Guild (D.JS Docs)"
+              content="guild"
+              customRel="noopener noreferrer"
+            />, and then the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildChannelManager"
+              title="GuildChannelManager (D.JS Docs)"
+              content="guild channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            to create our{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildChannel"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />, we can just use the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />'s{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannelChildManager"
+              title="CategoryChannelChildManager (D.JS Docs)"
+              content="children"
+              customRel="noopener noreferrer"
+            />{" "}
+            and nest our{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildChannel"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            inside that.
+          </p>
+
+          {/* Next post: Roles */}
+          <p class="mt-4 text-justify self-start">
+            Next post: Creating Roles in Discord.JS V14
+          </p>
+          {/* Post author */}
+          <footer class="mt-auto w-full text-right text-sm">
+            Written with 💞 by TheYuriG
+          </footer>
+        </article>
+      </Base>
+    </>
+  );
+}

--- a/routes/blog/how-create-categories-discord-v14.tsx
+++ b/routes/blog/how-create-categories-discord-v14.tsx
@@ -12,6 +12,7 @@ import { GradientLink } from "../../components/UI/GradientLink.tsx";
 //? Import post summary
 import { createVoiceChannelPost as previousPost } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
 import { createCategoryPost as postSummary } from "../../data/blog/how-create-categories-discord-v14.ts";
+import { createRolesPost as nextPost } from "../../data/blog/how-create-roles-discord-v14.ts";
 import { createTextChannelPost } from "../../data/blog/how-create-text-channels-discord-v14.ts";
 
 export default function Home() {
@@ -28,6 +29,7 @@ export default function Home() {
         {/* Back button */}
         <NavigationButtons
           back={{ title: previousPost.title, link: previousPost.link }}
+          next={{ title: nextPost.title, link: nextPost.link }}
         />
         <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
           {/* Title header */}
@@ -786,7 +788,14 @@ export default function Home() {
 
           {/* Next post: Roles */}
           <p class="mt-4 text-justify self-start">
-            Next post: Creating Roles in Discord.JS V14
+            Next post:{" "}
+            <GradientLink
+              link={nextPost.link}
+              title={nextPost.title}
+              content={nextPost.title}
+              customRel="next"
+              newTab={false}
+            />.
           </p>
           {/* Post author */}
           <footer class="mt-auto w-full text-right text-sm">

--- a/routes/blog/how-create-categories-discord-v14.tsx
+++ b/routes/blog/how-create-categories-discord-v14.tsx
@@ -681,7 +681,7 @@ export default function Home() {
             go through in more detail:
           </p>
           {/* line 65 quote */}
-          <q className="custom-quote italic self-start">
+          <q class="custom-quote italic self-start">
             const newlyCreatedCategory = await
             interaction.guild.channels.create(&#123; (<GradientLink
               link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcategorywithnestedchannels.js#L65"
@@ -715,7 +715,7 @@ export default function Home() {
             />.
           </p>
           {/* lines 74 and 81 quote */}
-          <q className="custom-quote italic self-start">
+          <q class="custom-quote italic self-start">
             await newlyCreatedCategory.children.create(&#123; (lines{" "}
             <GradientLink
               link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcategorywithnestedchannels.js#L74"

--- a/routes/blog/how-create-roles-discord-v14.tsx
+++ b/routes/blog/how-create-roles-discord-v14.tsx
@@ -1,0 +1,1698 @@
+//? Head component with all Meta tags pre-set
+import { CustomHead } from "../../components/base/CustomHead.tsx";
+//? Lateral text with theme switcher
+import { Base } from "../../components/base/Base.tsx";
+//? Default styled headers
+import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
+import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
+//? Navigation Buttons to go back to the previous page or to the next page (optional)
+import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
+//? A HTML Link component to pre-format links and reduce boiletplate
+import { GradientLink } from "../../components/UI/GradientLink.tsx";
+//? Import post summary
+import { createCategoryPost as previousPost } from "../../data/blog/how-create-categories-discord-v14.ts";
+import { createRolesPost as postSummary } from "../../data/blog/how-create-roles-discord-v14.ts";
+
+export default function Home() {
+  return (
+    <>
+      <CustomHead
+        title={postSummary.title}
+        description={postSummary.shortSummary}
+        link={"https://www.theyurig.com" + postSummary.link}
+      >
+      </CustomHead>
+      {/* Base page layout with theme switching and footer outside of accent box */}
+      <Base>
+        {/* Back button */}
+        <NavigationButtons
+          back={{ title: previousPost.title, link: previousPost.link }}
+        />
+        <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
+          {/* Title header */}
+          <StyledHeader title={postSummary.title} />
+          {/* Post creation date */}
+          <p class="text-sm mb-2 w-full text-center">
+            {new Date(postSummary.date).toLocaleString()}
+          </p>
+          {/* Medium alternative */}
+          <p class="mb-4 self-start text-xs">
+            This is the fourth and last part of the Discord.JS V14 tutorial that
+            I've published. You can read the{" "}
+            <GradientLink
+              link={previousPost.link}
+              title={previousPost.title}
+              content="third part"
+              customRel="prev"
+              newTab={false}
+            />{" "}
+            here. You can also read the full version of this tutorial on{" "}
+            <GradientLink
+              link="https://medium.com/@yuri03042/how-to-create-categories-text-channels-threads-voice-channels-and-roles-in-discord-js-v14-1f2664546433"
+              title="Medium version alternative"
+              content="Medium"
+              customRel="noopener noreferrer"
+            />{" "}
+            if you prefer.
+          </p>
+
+          {/* Introduction */}
+          <p class="my-2 text-justify">
+            Creating{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Roles"
+              customRel="noopener noreferrer"
+            />, like{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/ThreadChannel"
+              title="ThreadChannel (D.JS Docs)"
+              content="Threads"
+              customRel="noopener noreferrer"
+            />, does not care about the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/BaseChannel"
+              title="BaseChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            or its{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Categories"
+              customRel="noopener noreferrer"
+            />.{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Roles"
+              customRel="noopener noreferrer"
+            />{" "}
+            also have many interesting properties that we can modify, like
+            color. Let's tweak a little the code we used for creating a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/BaseChannel"
+              title="BaseChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+
+          {/* Create dynamic name role code block */}
+          <div class="shl-block">
+            <span class="shl-cmnt">
+              // Importing SlashCommandBuilder is required for every slash
+              command{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // We import PermissionFlagsBits so we can restrict this command
+              usage{`
+`}
+            </span>
+            <span class="shl-kwd">const</span> &#123;{" "}
+            <span class="shl-class">SlashCommandBuilder</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-class">PermissionFlagsBits</span> &#125;{" "}
+            <span class="shl-oper">=</span>{" "}
+            <span class="shl-func">require</span>(<span class="shl-str">
+              "discord.js"
+            </span>);{`
+`}module<span class="shl-oper">.</span>exports <span class="shl-oper">=</span>
+            {" "}
+            &#123;{`
+  `}data<span class="shl-oper">:</span> <span class="shl-kwd">new</span>{" "}
+            <span class="shl-class">SlashCommandBuilder</span>(){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "createrole"
+            </span>){" "}
+            <span class="shl-cmnt">// Command name matching file name</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              "Creates a new role"
+            </span>){`
+    `}
+            <span class="shl-cmnt">// Role name</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addStringOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+      `}option{`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "rolename"
+            </span>){" "}
+            <span class="shl-cmnt">
+              // option names need to always be lowercase and have no spaces
+            </span>
+            {`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              "Choose the name to give to the role"
+            </span>){`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMinLength</span>(<span class="shl-num">
+              1
+            </span>) <span class="shl-cmnt">// A role needs to be named</span>
+            {`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMaxLength</span>(<span class="shl-num">
+              100
+            </span>){" "}
+            <span class="shl-cmnt">
+              // Hard limit set by Discord for role names
+            </span>
+            {`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setRequired</span>(<span class="shl-bool">
+              true
+            </span>){`
+    `}){`
+    `}
+            <span class="shl-cmnt">
+              // You will usually only want users that can create new Channels
+              to
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // be able to use this command and this is what this line does.
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // Feel free to remove it if you want to allow any users to
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">// create new Channels</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">
+              setDefaultMemberPermissions
+            </span>(<span class="shl-class">PermissionFlagsBits</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">ManageChannels</span>){`
+    `}
+            <span class="shl-cmnt">
+              // It's impossible to create roles inside DMs, so
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // it's in your best interest in disabling this command through
+              DMs
+            </span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">
+              setDMPermission
+            </span>(<span class="shl-bool">false</span>)<span class="shl-oper">
+              ,
+            </span>
+            {`
+  `}
+            <span class="shl-kwd">async</span>{" "}
+            <span class="shl-func">execute</span>(interaction) &#123;{`
+    `}
+            <span class="shl-cmnt">
+              // Before executing any other code, we need to acknowledge the
+              interaction.
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // Discord only gives us 3 seconds to acknowledge an interaction
+              before
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // the interaction gets voided and can't be used anymore.
+            </span>
+            {`
+    `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">reply</span>(&#123;{`
+      `}content<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">
+              "Fetched all input and working on your request!"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+    `}&#125;);{`
+
+    `}
+            <span class="shl-cmnt">
+              // After acknowledging the interaction, we retrieve the string
+              sent by the user
+            </span>
+            {`
+    `}
+            <span class="shl-kwd">const</span> chosenRoleName{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getString</span>(<span class="shl-str">
+              "rolename"
+            </span>);{`
+    `}
+            <span class="shl-cmnt">
+              // Do note that the string passed to the method .getString() needs
+              to
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // match EXACTLY the name of the option provided (line 12 in this
+              file).
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // If it's not a perfect match, this will always return null
+            </span>
+            {`
+
+    `}
+            <span class="shl-kwd">try</span> &#123;{`
+      `}
+            <span class="shl-cmnt">// Create the role</span>
+            {`
+      `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">
+              .
+            </span>guild<span class="shl-oper">
+              .
+            </span>roles<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+        `}name<span class="shl-oper">:</span>{" "}
+            chosenRoleName<span class="shl-oper">,</span>
+            {`
+      `}&#125;);{`
+
+      `}
+            <span class="shl-cmnt">
+              // Inform the user about the role creation being successful
+            </span>
+            {`
+      `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">editReply</span>(&#123;{`
+        `}content<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">"Your role was created successfully!"</span>
+            <span class="shl-oper">,</span>
+            {`
+      `}&#125;);{`
+      `}
+            <span class="shl-kwd">return</span>;{`
+    `}&#125; <span class="shl-kwd">catch</span> (error) &#123;{`
+      `}
+            <span class="shl-cmnt">
+              // If an error occurred and we were not able to create the Channel
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // the bot is most likely received the "Missing Permissions"
+              error.
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">// Log the error to the console</span>
+            {`
+      `}console<span class="shl-oper">.</span>
+            <span class="shl-func">log</span>(error);{`
+      `}
+            <span class="shl-cmnt">
+              // Also inform the user that an error occurred and give them
+              feedback
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // about how to avoid this error if they want to try again
+            </span>
+            {`
+      `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">editReply</span>(&#123;{`
+        `}content<span class="shl-oper">:</span>
+            {`
+          `}
+            <span class="shl-str">
+              "Your role could not be created! Please check if the bot has the
+              necessary permissions!"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+      `}&#125;);{`
+      `}
+            <span class="shl-kwd">return</span>;{`
+    `}&#125;{`
+  `}&#125;<span class="shl-oper">,</span>
+            {`
+`}&#125;;{`
+`}
+          </div>
+          {/* Code link */}
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createrole.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
+          {/* line 65 quote */}
+          <q class="custom-quote italic self-start">
+            await interaction.guild.roles.create(&#123;
+          </q>
+          <p class="my-2 text-justify">
+            To create a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />, you need to access the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/RoleManager"
+              title="RoleManager (D.JS Docs)"
+              content="roles"
+              customRel="noopener noreferrer"
+            />{" "}
+            of a server and then create a new{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            there. Creating a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            can take some additional{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/RoleCreateOptions"
+              title="RoleCreateOptions (D.JS Docs)"
+              content="configuration"
+              customRel="noopener noreferrer"
+            />, but all settings are optional (a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            with no configuration will be called "new role" and have no color).
+            As in previous lessons, we create a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            that has a name provided by the user and, after that{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            is created, we edit the initial message with a success message
+            (<GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createrole.js#L46"
+              title="view source"
+              content="line 46"
+              customRel="noopener noreferrer"
+            />).
+          </p>
+          <p class="my-2 text-justify">
+            Now that we know how to create a role, how about we learn how to
+            create a colored role?
+          </p>
+
+          <StyledSubHeader title="Creating a colored role" />
+          <p class="my-2 text-justify">
+            Discord{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Roles"
+              customRel="noopener noreferrer"
+            />{" "}
+            can have any color you want. Discord even provides us with some
+            colors they have standardized. We will both offer to use Discord's
+            standard color selection, while also allowing users to customize
+            exactly the color they want for the role, using hex codes for RGB
+            colors.
+          </p>
+
+          {/* Creating colored role code block */}
+          <div class="shl-block">
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // initial code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-cmnt">
+              // Role color options using Discord's defaults{`
+`}
+            </span>
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addStringOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+  `}option{`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              'rolecolor'
+            </span>){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              'Select a color for your role (using Discord defaults)'
+            </span>){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addChoices</span>({`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Aqua'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x1abc9c'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Green'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x57f287'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Blue'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x3498db'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Yellow'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0xfee75c'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'LuminousVividPink'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0xe91e63'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Fuchsia'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0xeb459e'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Gold'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0xf1c40f'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Orange'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0xe67e22'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Red'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0xed4245'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Grey'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x95a5a6'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Navy'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x34495e'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'DarkAqua'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x11806a'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'DarkGreen'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x1f8b4c'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'DarkBlue'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x206694'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'DarkPurple'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x71368a'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'DarkVividPink'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0xad1457'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'DarkGold'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0xc27c0e'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'DarkOrange'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0xa84300'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'DarkRed'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x992d22'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'DarkerGrey'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x7f8c8d'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'LightGrey'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0xbcc0c0'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'DarkNavy'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x2c3e50'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Blurple'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x5865f2'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'Greyple'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x99aab5'</span>{" "}
+            &#125;<span class="shl-oper">,</span>
+            {`
+      `}&#123; name<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">'DarkButNotBlack'</span>
+            <span class="shl-oper">,</span> value<span class="shl-oper">:</span>
+            {" "}
+            <span class="shl-str">'0x2c2f33'</span> &#125;{`
+    `}){`
+  `}){`
+`}
+            <span class="shl-cmnt">
+              // Role color options using a hex code or integer{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // relevant link for hex codes:
+              https://www.rapidtables.com/web/color/RGB_Color.html{`
+`}
+            </span>
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addStringOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+  `}option{`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              'customrolecolor'
+            </span>){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>({`
+      `}
+            <span class="shl-str">
+              'Select a custom color for your role (hex code only. overrides
+              "rolecolor")'
+            </span>
+            {`
+    `}){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMinLength</span>(<span class="shl-num">
+              8
+            </span>){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMaxLength</span>(<span class="shl-num">
+              8
+            </span>){`
+  `}){`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-kwd">const</span> chosenRoleName{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getString</span>(<span class="shl-str">
+              'rolename'
+            </span>);{`
+`}
+            <span class="shl-kwd">const</span> chosenRoleColor{" "}
+            <span class="shl-oper">=</span>
+            {`
+  `}interaction<span class="shl-oper">.</span>options<span class="shl-oper">
+              .
+            </span>
+            <span class="shl-func">getString</span>(<span class="shl-str">
+              'customrolecolor'
+            </span>) <span class="shl-oper">??</span>
+            {`
+  `}interaction<span class="shl-oper">.</span>options<span class="shl-oper">
+              .
+            </span>
+            <span class="shl-func">getString</span>(<span class="shl-str">
+              'rolecolor'
+            </span>) <span class="shl-oper">??</span>
+            {`
+  `}
+            <span class="shl-num">undefined</span>;{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}name<span class="shl-oper">:</span>{" "}
+            chosenRoleName<span class="shl-oper">,</span>
+            {`
+`}color<span class="shl-oper">:</span>{" "}
+            chosenRoleColor<span class="shl-oper">,</span>
+            {`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // rest of the code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+          </div>
+          {/* Code link */}
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createcoloredrole.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
+
+          <p class="my-2 text-justify self-start">
+            Once again, let's go through each bit of code individually.
+          </p>
+          {/* line 20 quote */}
+          <q class="custom-quote italic self-start">
+            .setName('rolecolor') (<GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcoloredrole.js#L20"
+              title="view source"
+              content="line 20"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            The first of the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/RoleCreateOptions"
+              title="RoleCreateOptions (D.JS Docs)"
+              content="options"
+              customRel="noopener noreferrer"
+            />{" "}
+            we added is <span class="shl-inline">rolecolor</span>. This{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/RoleCreateOptions"
+              title="RoleCreateOptions (D.JS Docs)"
+              content="option"
+              customRel="noopener noreferrer"
+            />{" "}
+            has 25 choices with colors that were standardized by Discord on
+            their{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role?scrollTo=color"
+              title="color property (D.JS Docs)"
+              content="role color"
+              customRel="noopener noreferrer"
+            />{" "}
+            selection and their brand color palette. This is the easiest way for
+            users to pick a color without needing to find a specific hex code.
+          </p>
+          {/* line 54 quote */}
+          <q class="custom-quote italic self-start">
+            .setName('customrolecolor') (<GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcoloredrole.js#L54"
+              title="view source"
+              content="line 54"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            The second{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/RoleCreateOptions"
+              title="RoleCreateOptions (D.JS Docs)"
+              content="option"
+              customRel="noopener noreferrer"
+            />{" "}
+            we added is{" "}
+            <span class="shl-inline">customrolecolor</span>. This allows users
+            to create a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            with ANY color they want, by using a hex code. There are various
+            websites that can be used to get a hex code from a color. The one
+            I've been using for years is{" "}
+            <GradientLink
+              link="https://www.rapidtables.com/web/color/RGB_Color.html"
+              title="RapidTables, a website to pick color codes (Website)"
+              content="RapidTables"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+          {/* lines 58 and 59 quote */}
+          <q class="custom-quote italic self-start">
+            .setMinLength(8) .setMaxLength(8) (lines{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcoloredrole.js#L58"
+              title="view source"
+              content="58"
+              customRel="noopener noreferrer"
+            />{" "}
+            and{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcoloredrole.js#L59"
+              title="view source"
+              content="59"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            You might have noticed that we have those strict limiters in place.
+            This is because every RGB hex code has exactly 8 digits, the first
+            two being <span class="shl-inline">0x</span>{" "}
+            which identifies that the following digits are a hexadecimal number.
+            The next two digits are responsible for the Red, the 5th and 6th
+            digits are responsible for the Green and the last 2 digits are
+            responsible for the Blue.
+          </p>
+          {/* lines 79 to 82 quote */}
+          <q class="custom-quote italic self-start">
+            const chosenRoleColor =
+            interaction.options.getString('customrolecolor') ??
+            interaction.options.getString('rolecolor') ?? undefined; (lines{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcoloredrole.js#L79"
+              title="view source"
+              content="79"
+              customRel="noopener noreferrer"
+            />{" "}
+            to{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcoloredrole.js#L82"
+              title="view source"
+              content="82"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            If you noticed that we mention that{" "}
+            <span class="shl-inline">customrolecolor</span> overrides{" "}
+            <span class="shl-inline">rolecolor</span> on{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcoloredrole.js#L56"
+              title="view source"
+              content="line 56"
+              customRel="noopener noreferrer"
+            />, this is the reason why. Since a single{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            can't have two colors, we need to prioritize one of the inputs over
+            the other and since it takes more effort to find a custom RGB hex
+            code, we will assume that the user would rather use that color
+            instead, in case they picked a{" "}
+            <span class="shl-inline">rolecolor</span>{" "}
+            by mistake (or intentionally, since some users enjoy trying to break
+            things just because they can). Here we use the{" "}
+            <GradientLink
+              link="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing"
+              title="Nullish Coalescence (MDN Docs)"
+              content="Javascript Nullish Coalescence"
+              customRel="noopener noreferrer"
+            />{" "}
+            operator <span class="shl-inline">??</span>{" "}
+            to check if the user provided any custom value. If they didn't, then
+            we check if they picked one of Discord's standard colors. If they
+            also didn't, then we set the color as{" "}
+            <span class="shl-inline">undefined</span>, so a colorless{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            can be created as the default fallback.
+          </p>
+          {/* line 91 quote */}
+          <q class="custom-quote italic self-start">
+            color: chosenRoleColor, (<GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createcoloredrole.js#L91"
+              title="view source"
+              content="line 91"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            Finally, we use either the{" "}
+            <span class="shl-inline">customrolecolor</span> or the{" "}
+            <span class="shl-inline">rolecolor</span> or{" "}
+            <span class="shl-inline">undefined</span>{" "}
+            to set the color (or no color) for the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            we will be creating.
+          </p>
+          <p class="my-2 text-justify">
+            Now we have a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            and it can have a color, but what's the use of a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            that no one possesses? Let's grant this{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            to some{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildMember"
+              title="GuildMember (D.JS Docs)"
+              content="Members"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+
+          <StyledSubHeader title="Creating a role and then granting it to members" />
+          <p class="my-2 text-justify">
+            Granting a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            to a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildMemberManager?scrollTo=addRole"
+              title="GuildMemberManager (D.JS Docs)"
+              content="Member"
+              customRel="noopener noreferrer"
+            />{" "}
+            is very simple, you just need to access their{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Roles"
+              customRel="noopener noreferrer"
+            />{" "}
+            and then add the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />. Let's take a look at what that code would look like.
+          </p>
+
+          {/* Granting role code block */}
+          <div class="shl-block">
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // initial code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-cmnt">
+              // Member that should get the role{`
+`}
+            </span>a<span class="shl-oper">.</span>
+            <span class="shl-func">addMemberOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+  `}option{`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "membertoreceiverole"
+            </span>){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              "The user you want to give the newly created role to"
+            </span>){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setRequired</span>(<span class="shl-bool">
+              true
+            </span>){`
+`});{`
+`}
+            <span class="shl-cmnt">
+              // Grant role to the member using the command{`
+`}
+            </span>a<span class="shl-oper">.</span>
+            <span class="shl-func">addBooleanOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+  `}option{`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "grantroletocommanduser"
+            </span>){" "}
+            <span class="shl-cmnt">
+              // option names need to always be lowercase and have no spaces
+            </span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              "Choose you should be granted the role after creation"
+            </span>){`
+`});{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-kwd">const</span> chosenRoleColor{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getString</span>(<span class="shl-str">
+              "customrolecolor"
+            </span>) <span class="shl-oper">??</span>
+            {`
+  `}interaction<span class="shl-oper">.</span>options<span class="shl-oper">
+              .
+            </span>
+            <span class="shl-func">getString</span>(<span class="shl-str">
+              "rolecolor"
+            </span>) <span class="shl-oper">??</span>
+            {`
+  `}
+            <span class="shl-num">undefined</span>;{`
+`}
+            <span class="shl-kwd">const</span> memberNeedingRole{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getMember</span>(<span class="shl-str">
+              "membertoreceiverole"
+            </span>);{`
+`}
+            <span class="shl-kwd">const</span> grantRoleToSelf{" "}
+            <span class="shl-oper">=</span>
+            {`
+  `}interaction<span class="shl-oper">.</span>options<span class="shl-oper">
+              .
+            </span>
+            <span class="shl-func">getBoolean</span>(<span class="shl-str">
+              "grantroletocommanduser"
+            </span>) <span class="shl-oper">??</span>{" "}
+            <span class="shl-bool">false</span>;{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-cmnt">
+              // Check if the user selected "True" to the option to grant role
+              to self{`
+`}
+            </span>
+            <span class="shl-kwd">if</span> (grantRoleToSelf{" "}
+            <span class="shl-oper">==</span>{" "}
+            <span class="shl-bool">true</span>) &#123;{`
+  `}
+            <span class="shl-cmnt">
+              // If they did, navigate their properties until their roles and
+            </span>
+            {`
+  `}
+            <span class="shl-cmnt">// add the newly created role to them</span>
+            {`
+  `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">
+              .
+            </span>member<span class="shl-oper">
+              .
+            </span>roles<span class="shl-oper">.</span>
+            <span class="shl-func">
+              add
+            </span>(coloredRole)<span class="shl-oper">.</span>
+            <span class="shl-kwd">catch</span>((e){" "}
+            <span class="shl-kwd">=&gt;</span> &#123;{`
+    `}
+            <span class="shl-cmnt">
+              // If it fails, send a followUp message with the error
+            </span>
+            {`
+    `}interaction<span class="shl-oper">.</span>
+            <span class="shl-func">followUp</span>(&#123;{`
+      `}content<span class="shl-oper">:</span>
+            {`
+        `}
+            <span class="shl-str">
+              "Failed to give you the new role. Do you have any roles with
+              higher priority than me?"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+      `}ephemeral<span class="shl-oper">:</span>{" "}
+            <span class="shl-bool">true</span>
+            <span class="shl-oper">,</span>
+            {`
+    `}&#125;);{`
+  `}&#125;);{`
+`}&#125;{`
+
+`}
+            <span class="shl-cmnt">
+              // Check if a guild member was provided to receive the role{`
+`}
+            </span>
+            <span class="shl-kwd">if</span> (memberNeedingRole{" "}
+            <span class="shl-oper">!=</span>{" "}
+            <span class="shl-num">null</span>) &#123;{`
+  `}
+            <span class="shl-cmnt">
+              // Check if the command user requested to get the role
+            </span>
+            {`
+  `}
+            <span class="shl-cmnt">
+              // and also provided their own member to receive the role
+            </span>
+            {`
+  `}
+            <span class="shl-kwd">if</span> ({`
+    `}interaction<span class="shl-oper">.</span>member<span class="shl-oper">
+              .
+            </span>id <span class="shl-oper">===</span>{" "}
+            memberNeedingRole<span class="shl-oper">.</span>id{" "}
+            <span class="shl-oper">&amp;&amp;</span> grantRoleToSelf{" "}
+            <span class="shl-oper">==</span> <span class="shl-bool">true</span>
+            {`
+  `}) &#123;{`
+    `}
+            <span class="shl-cmnt">
+              // If they did, give them an ephemeral error message
+            </span>
+            {`
+    `}interaction<span class="shl-oper">.</span>
+            <span class="shl-func">followUp</span>(&#123;{`
+      `}content<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">"You were already granted the role!"</span>
+            <span class="shl-oper">,</span>
+            {`
+      `}ephemeral<span class="shl-oper">:</span>{" "}
+            <span class="shl-bool">true</span>
+            <span class="shl-oper">,</span>
+            {`
+    `}&#125;);{`
+  `}&#125;{`
+
+  `}
+            <span class="shl-cmnt">
+              // Check if the command user provided a different member
+            </span>
+            {`
+  `}
+            <span class="shl-cmnt">// than themselves to receive the role</span>
+            {`
+  `}
+            <span class="shl-kwd">if</span> ({`
+    `}interaction<span class="shl-oper">.</span>member<span class="shl-oper">
+              .
+            </span>id <span class="shl-oper">!==</span>{" "}
+            memberNeedingRole<span class="shl-oper">.</span>id{" "}
+            <span class="shl-oper">||</span> grantRoleToSelf{" "}
+            <span class="shl-oper">==</span> <span class="shl-bool">false</span>
+            {`
+  `}) &#123;{`
+    `}
+            <span class="shl-cmnt">
+              // If they did, navigate their properties until their roles and
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">// add the newly created role to them</span>
+            {`
+    `}
+            <span class="shl-kwd">await</span>{" "}
+            memberNeedingRole<span class="shl-oper">
+              .
+            </span>roles<span class="shl-oper">.</span>
+            <span class="shl-func">
+              add
+            </span>(coloredRole)<span class="shl-oper">.</span>
+            <span class="shl-kwd">catch</span>((e){" "}
+            <span class="shl-kwd">=&gt;</span> &#123;{`
+      `}
+            <span class="shl-cmnt">
+              // If it fails, send a followUp message with the error
+            </span>
+            {`
+      `}interaction<span class="shl-oper">.</span>
+            <span class="shl-func">followUp</span>(&#123;{`
+        `}content<span class="shl-oper">:</span>
+            {`
+          `}
+            <span class="shl-str">
+              "Failed to give the new role to the member. Do they have any roles
+              with higher priority than me?"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+      `}&#125;);{`
+    `}&#125;);{`
+  `}&#125;{`
+`}&#125;{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // rest of the code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+          </div>
+          {/* Code link */}
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createandgrantrole.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
+
+          <p class="my-2 text-justify self-start">
+            Let's break down this code into smaller chunks again.
+          </p>
+          {/* lines 61 and 62 quote */}
+          <q class="custom-quote italic self-start">
+            const chosenRoleColor =
+            interaction.options.getString('customrolecolor') ??
+            interaction.options.getString('rolecolor') ?? undefined; (lines{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createandgrantrole.js#L61"
+              title="view source"
+              content="61"
+              customRel="noopener noreferrer"
+            />{" "}
+            to{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createandgrantrole.js#L62"
+              title="view source"
+              content="62"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            This{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/RoleCreateOptions"
+              title="RoleCreateOptions (D.JS Docs)"
+              content="option"
+              customRel="noopener noreferrer"
+            />{" "}
+            allows the user to select a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildMember"
+              title="GuildMember (D.JS Docs)"
+              content="Member"
+              customRel="noopener noreferrer"
+            />{" "}
+            that will receive the role, once it has been created. This will not
+            ping them or notify them in any way.
+          </p>
+          {/* lines 68 to 69 quote */}
+          <q class="custom-quote italic self-start">
+            const chosenRoleColor =
+            interaction.options.getString('customrolecolor') ??
+            interaction.options.getString('rolecolor') ?? undefined; (lines{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createandgrantrole.js#L68"
+              title="view source"
+              content="68"
+              customRel="noopener noreferrer"
+            />{" "}
+            to{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createandgrantrole.js#L69"
+              title="view source"
+              content="69"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            This{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/RoleCreateOptions"
+              title="RoleCreateOptions (D.JS Docs)"
+              content="option"
+              customRel="noopener noreferrer"
+            />{" "}
+            was added to allow the person using the command to get the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            added to them after being created if they select true when using the
+            command.
+          </p>
+          {/* lines 96 to 97 quote */}
+          <q class="custom-quote italic self-start">
+            const chosenRoleColor =
+            interaction.options.getString('customrolecolor') ??
+            interaction.options.getString('rolecolor') ?? undefined; (lines{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createandgrantrole.js#L96"
+              title="view source"
+              content="96"
+              customRel="noopener noreferrer"
+            />{" "}
+            to{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createandgrantrole.js#L97"
+              title="view source"
+              content="97"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            Fetches the user input from the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/RoleCreateOptions"
+              title="RoleCreateOptions (D.JS Docs)"
+              content="options"
+              customRel="noopener noreferrer"
+            />{" "}
+            mentioned above. Note how{" "}
+            <span class="shl-inline">grantRoleToSelf</span>{" "}
+            will default to false if the user doesn't select an{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/RoleCreateOptions"
+              title="RoleCreateOptions (D.JS Docs)"
+              content="option"
+              customRel="noopener noreferrer"
+            />. This means that the only way for the user to be granted the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            they have created is by manually selecting{" "}
+            <span class="shl-inline">true</span> when using the command.
+          </p>
+          {/* line 110 quote */}
+          <q class="custom-quote italic self-start">
+            if (grantRoleToSelf == true) &#123; (
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createandgrantrole.js#L110"
+              title="view source"
+              content="line 110"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            Checks if the user requested to give themselves the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            after creation and, if they did, attempt to give it to them. This,
+            just like giving a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            to any{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildMember"
+              title="GuildMember (D.JS Docs)"
+              content="Member"
+              customRel="noopener noreferrer"
+            />, is prone to fail if the bot doesn't have permission to{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildMemberManager"
+              title="GuildMemberManager (D.JS Docs)"
+              content="Manage Members"
+              customRel="noopener noreferrer"
+            />{" "}
+            or if the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildMember"
+              title="GuildMember (D.JS Docs)"
+              content="Member"
+              customRel="noopener noreferrer"
+            />{" "}
+            that we are trying to give the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            already has another{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            that has higher priority than the all of bot's{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Roles"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+          {/* line 124 quote */}
+          <q class="custom-quote italic self-start">
+            if (memberNeedingRole != null) &#123; (
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createandgrantrole.js#L124"
+              title="view source"
+              content="line 124"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify self-start">
+            Check if the user provided us with a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildMember"
+              title="GuildMember (D.JS Docs)"
+              content="Member"
+              customRel="noopener noreferrer"
+            />{" "}
+            to give the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+          {/* line 127 quote */}
+          <q class="custom-quote italic self-start">
+            if (interaction.member.id === memberNeedingRole.id &&
+            grantRoleToSelf == true) &#123; (
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createandgrantrole.js#L127"
+              title="view source"
+              content="line 127"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            Check if the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildMember"
+              title="GuildMember (D.JS Docs)"
+              content="Member"
+              customRel="noopener noreferrer"
+            />{" "}
+            provided is the same person as the user that triggered the command
+            and if they have previously asked to receive the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />. This will only give them an error message if they asked for the
+            {" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            twice, otherwise, it will just give them the role.
+          </p>
+          {/* line 137 quote */}
+          <q class="custom-quote italic self-start">
+            if (interaction.member.id !== memberNeedingRole.id ||
+            grantRoleToSelf == false) &#123; (
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createandgrantrole.js#L137"
+              title="view source"
+              content="line 137"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            If the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildMember"
+              title="GuildMember (D.JS Docs)"
+              content="Member"
+              customRel="noopener noreferrer"
+            />{" "}
+            provided is different than the user triggering the command or if a
+            {" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildMember"
+              title="GuildMember (D.JS Docs)"
+              content="Member"
+              customRel="noopener noreferrer"
+            />{" "}
+            was provided and the user didn't request to have the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            added to themselves with the other{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/RoleCreateOptions"
+              title="RoleCreateOptions (D.JS Docs)"
+              content="option"
+              customRel="noopener noreferrer"
+            />, grant the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/GuildMember"
+              title="GuildMember (D.JS Docs)"
+              content="Member"
+              customRel="noopener noreferrer"
+            />{" "}
+            to have the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+          <p class="my-2 text-justify">
+            That was quite a bit of code we added and with that, we have also
+            covered an edge case where users can try to give themselves the same
+            {" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Role"
+              customRel="noopener noreferrer"
+            />{" "}
+            twice.{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/Role"
+              title="Role (D.JS Docs)"
+              content="Roles"
+              customRel="noopener noreferrer"
+            />{" "}
+            are very complex entities and there is a lot more that can be done
+            with them, like setting up additional permissions and updating them
+            post-creation, but that's a lesson for another day.
+          </p>
+
+          {/* Post author */}
+          <footer class="mt-auto w-full text-right text-sm">
+            Written with 💞 by TheYuriG
+          </footer>
+        </article>
+      </Base>
+    </>
+  );
+}

--- a/routes/blog/how-create-roles-discord-v14.tsx
+++ b/routes/blog/how-create-roles-discord-v14.tsx
@@ -9,6 +9,8 @@ import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? A HTML Link component to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+//? Display a link to view the source code on GitHub
+import { ViewOnGitHub } from "../../components/misc/ViewOnGithub.tsx";
 //? Import post summary
 import { createCategoryPost as previousPost } from "../../data/blog/how-create-categories-discord-v14.ts";
 import { createRolesPost as postSummary } from "../../data/blog/how-create-roles-discord-v14.ts";
@@ -375,14 +377,7 @@ export default function Home() {
 `}
           </div>
           {/* Code link */}
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createrole.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createrole.js" />
           {/* line 65 quote */}
           <q class="custom-quote italic self-start">
             await interaction.guild.roles.create(&#123;
@@ -797,15 +792,7 @@ export default function Home() {
             <span class="shl-cmnt">// ...</span>
           </div>
           {/* Code link */}
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createcoloredrole.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
-
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createcoloredrole.js" />
           <p class="my-2 text-justify self-start">
             Once again, let's go through each bit of code individually.
           </p>
@@ -1349,14 +1336,7 @@ export default function Home() {
             </span>
           </div>
           {/* Code link */}
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createandgrantrole.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createandgrantrole.js" />
 
           <p class="my-2 text-justify self-start">
             Let's break down this code into smaller chunks again.

--- a/routes/blog/how-create-text-channels-discord-v14.tsx
+++ b/routes/blog/how-create-text-channels-discord-v14.tsx
@@ -12,7 +12,8 @@ import { GradientLink } from "../../components/UI/GradientLink.tsx";
 //? Create a greek list of contents
 import { GreekList } from "../../components/UI/GreekList.tsx";
 //? Import post summary
-import { createChannelPost as postSummary } from "../../data/blog/how-create-text-channels-discord-v14.ts";
+import { createTextChannelPost as postSummary } from "../../data/blog/how-create-text-channels-discord-v14.ts";
+import { createVoiceChannelPost as nextPost } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
 
 export default function Home() {
   return (
@@ -28,6 +29,7 @@ export default function Home() {
         {/* Back button */}
         <NavigationButtons
           back={{ title: "Browse more blog posts", link: "/blog" }}
+          next={{ title: nextPost.title, link: nextPost.link }}
         />
         <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
           {/* Title header */}
@@ -37,8 +39,10 @@ export default function Home() {
             {new Date(postSummary.date).toLocaleString()}
           </p>
           {/* Medium alternative */}
-          <p class="mb-4 self-start text-sm">
-            You can also read the full version of this tutorial on{" "}
+          <p class="mb-4 self-start text-xs">
+            This is the first (of four) parts of the Discord.JS V14 tutorial
+            that I've published. You can also read the full version of this
+            tutorial on{" "}
             <GradientLink
               link="https://medium.com/@yuri03042/how-to-create-categories-text-channels-threads-voice-channels-and-roles-in-discord-js-v14-1f2664546433"
               title="Medium version alternative"
@@ -1737,7 +1741,13 @@ export default function Home() {
 
           {/* Next post: voice channels */}
           <p class="mt-4 text-justify self-start">
-            Next post: Creating Voice Channels in Discord.JS V14
+            Next post:{" "}
+            <GradientLink
+              content={nextPost.title}
+              link={nextPost.link}
+              customRel="next"
+              newTab={false}
+            />.
           </p>
           {/* Post author */}
           <footer class="mt-auto w-full text-right text-sm">

--- a/routes/blog/how-create-text-channels-discord-v14.tsx
+++ b/routes/blog/how-create-text-channels-discord-v14.tsx
@@ -1,0 +1,1750 @@
+//? Head component with all Meta tags pre-set
+import { CustomHead } from "../../components/base/CustomHead.tsx";
+//? Lateral text with theme switcher
+import { Base } from "../../components/base/Base.tsx";
+//? Default styled headers
+import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
+import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
+//? Navigation Buttons to go back to the previous page or to the next page (optional)
+import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
+//? A HTML Link component to pre-format links and reduce boiletplate
+import { GradientLink } from "../../components/UI/GradientLink.tsx";
+//? Create a greek list of contents
+import { GreekList } from "../../components/UI/GreekList.tsx";
+//? Import post summary
+import { createChannelPost as postSummary } from "../../data/blog/how-create-text-channels-discord-v14.ts";
+
+export default function Home() {
+  return (
+    <>
+      <CustomHead
+        title={postSummary.title}
+        description={postSummary.shortSummary}
+        link={"https://www.theyurig.com" + postSummary.link}
+      >
+      </CustomHead>
+      {/* Base page layout with theme switching and footer outside of accent box */}
+      <Base>
+        {/* Back button */}
+        <NavigationButtons
+          back={{ title: "Browse more blog posts", link: "/blog" }}
+        />
+        <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
+          {/* Title header */}
+          <StyledHeader title={postSummary.title} />
+          {/* Post creation date */}
+          <p class="text-sm mb-2 w-full text-center">
+            {new Date(postSummary.date).toLocaleString()}
+          </p>
+          {/* Medium alternative */}
+          <p class="mb-4 self-start text-sm">
+            You can also read the full version of this tutorial on{" "}
+            <GradientLink
+              link="https://medium.com/@yuri03042/how-to-create-categories-text-channels-threads-voice-channels-and-roles-in-discord-js-v14-1f2664546433"
+              title="Medium version alternative"
+              content="Medium"
+              customRel="noopener noreferrer"
+            />{" "}
+            if you prefer.
+          </p>
+          {/* Introduction */}
+          <p class="my-2 text-justify">
+            Navigating through{" "}
+            <GradientLink
+              link="https://discordjs.guide/#before-you-begin"
+              title="Guide to starting with Discord.JS"
+              content="Discord.JS' guide"
+              customRel="noopener noreferrer"
+            />{" "}
+            and{" "}
+            <GradientLink
+              link="https://discordjs.guide/#before-you-begin"
+              title="Discord.JS documentation"
+              content="Discord.JS' guide"
+              customRel="noopener noreferrer"
+            />{"  "}
+            can be confusing if you are new to programming, as many bot creators
+            will also be learning how to code to create their bot (it was my
+            first project too, back in 2018!). This post aims to simplify the
+            learning process to make different types of{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            from a slash command interaction. Before anything else, it's
+            essential to share links to relevant resources used in this blog
+            post:
+          </p>
+          {/* Relevant links */}
+          <GreekList
+            items={[
+              <GradientLink
+                link="https://discord.com/invite/djs"
+                title="Discord.JS' Discord support server"
+                content="Discord.JS' support server"
+                customRel="noopener noreferrer"
+              />,
+              <GradientLink
+                link="https://discordjs.guide/#before-you-begin"
+                title="Guide to starting with Discord.JS"
+                content="Discord.JS' guide (currently at v14)"
+                customRel="noopener noreferrer"
+              />,
+              <GradientLink
+                link="https://discord.js.org/#/docs/discord.js/main/general/welcome"
+                title="Discord.JS documentation"
+                content="Discord.JS' documentation (currently at v14)"
+                customRel="noopener noreferrer"
+              />,
+            ]}
+          />
+          {/* Remember: questions */}
+          <p class="my-2 text-justify">
+            Remember that if you have any questions,{" "}
+            <strong>Google your issue first</strong>, and, if you can't find the
+            solution, join the{" "}
+            <GradientLink
+              link="https://discord.com/invite/djs"
+              title="Discord.JS' Discord support server"
+              content="support server"
+              customRel="noopener noreferrer"
+            />{" "}
+            and ask for help in the proper v14 help channel.
+          </p>
+          {/* First: prior setup */}
+          <p class="my-2 text-justify">
+            First, this guide assumes you already have a{" "}
+            <GradientLink
+              link="https://discordjs.guide/preparations/setting-up-a-bot-application.html"
+              title="Setting up a bot application (D.JS Guide)"
+              content="bot set up"
+              customRel="noopener noreferrer"
+            />
+            , use{" "}
+            <GradientLink
+              link="https://discordjs.guide/creating-your-bot/slash-commands.html"
+              title="Slash commands (D.JS Guide)"
+              content="slash command interactions"
+              customRel="noopener noreferrer"
+            />
+            , you have a{" "}
+            <GradientLink
+              link="https://discordjs.guide/creating-your-bot/command-handling.html"
+              title="Command handler (D.JS Guide)"
+              content="command handler"
+              customRel="noopener noreferrer"
+            />{" "}
+            set up and the command you are using was already deployed. You will
+            need to update the code on your own if you are still using{" "}
+            <span class="shl-inline">
+              messageCreate
+            </span>{" "}
+            events instead.
+          </p>
+          {/* Second: Savascript */}
+          <p class="my-2 text-justify">
+            Second, this guide assumes you are using Javascript over Typescript.
+            Feel free to use the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/general/welcome"
+              title="Welcome (D.JS Docs)"
+              content="documentation website"
+              customRel="noopener noreferrer"
+            />{" "}
+            if you need assistance defining your types.
+          </p>
+          {/* Third: check GitHub */}
+          <p class="my-2 text-justify">
+            Third, all code for the topics in these lessons will be available on
+            this{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/tree/master/discord_create_channels/commands"
+              title="All code is available on GitHub"
+              content="GitHub repository"
+              customRel="noopener noreferrer"
+            />
+            . The code written is very verbose on purpose, as this guide aims to
+            help even the newest programmer to update their bot. You will see
+            values being checked for{" "}
+            <span class="shl-inline">
+              true
+            </span>{" "}
+            and then for{" "}
+            <span class="shl-inline">
+              false
+            </span>{" "}
+            right after. This is intended because I want to make the code
+            examples extremely clear and easy to understand for newer
+            programmers. If you choose to copy my files and you are more
+            experienced in writing Javascript, feel free to update the code and
+            remove those additional checks.
+          </p>
+          {/* Fourth: depth, contribution */}
+          <p class="my-2 text-justify">
+            Last, but not least, this article will briefly touch on the creation
+            of certain Discord features, but will not dive deep into topics like
+            "editing an existing channel" or "setting permissions for channels".
+            These topics can be used to write new guides in the future if the
+            interest is there.
+          </p>
+
+          <StyledSubHeader title="Creating your first Text Channel" />
+          {/* First text channel: starting */}
+          <p class="my-2 text-justify">
+            Let's start with your basic file. We will not have{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/CommandInteractionOption"
+              title="CommandInteractionOption (D.JS Docs)"
+              content="options"
+              customRel="noopener noreferrer"
+            />{" "}
+            added as I'm not assuming how configurable you want the commands to
+            be, but you can (and we will) add more{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/CommandInteractionOption"
+              title="CommandInteractionOption (D.JS Docs)"
+              content="options"
+              customRel="noopener noreferrer"
+            />{" "}
+            later.
+          </p>
+
+          {/* Create text channel code block */}
+          <div class="shl-block">
+            <span class="shl-cmnt">
+              // Importing SlashCommandBuilder is required for every slash
+              command{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // We import PermissionFlagsBits so we can restrict this command
+              usage{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // We also import ChannelType to define what kind of Channel we
+              are creating{`
+`}
+            </span>
+            <span class="shl-kwd">const</span> &#123;{" "}
+            <span class="shl-class">SlashCommandBuilder</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-class">PermissionFlagsBits</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-class">ChannelType</span> &#125;{" "}
+            <span class="shl-oper">=</span>{" "}
+            <span class="shl-func">require</span>({`
+  `}
+            <span class="shl-str">"discord.js"</span>
+            <span class="shl-oper">,</span>
+            {`
+`});{`
+`}module<span class="shl-oper">.</span>exports <span class="shl-oper">=</span>
+            {" "}
+            &#123;{`
+  `}data<span class="shl-oper">:</span> <span class="shl-kwd">new</span>{" "}
+            <span class="shl-class">SlashCommandBuilder</span>(){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "createnewchannel"
+            </span>){" "}
+            <span class="shl-cmnt">// Command name matching file name</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              'Ths command creates a text channel called "new"'
+            </span>){`
+    `}
+            <span class="shl-cmnt">
+              // You will usually only want users that can create new Channels
+              to
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // be able to use this command and this is what this line does.
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // Feel free to remove it if you want to allow any users to
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">// create new Channels</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">
+              setDefaultMemberPermissions
+            </span>(<span class="shl-class">PermissionFlagsBits</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">ManageChannels</span>){`
+    `}
+            <span class="shl-cmnt">
+              // It's impossible to create normal Text Channels inside DMs, so
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // it's in your best interest in disabling this command through
+              DMs
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // as well. Threads, however, can be created in DMs, but we will
+              see
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">// more about them later in this post</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">
+              setDMPermission
+            </span>(<span class="shl-bool">false</span>)<span class="shl-oper">
+              ,
+            </span>
+            {`
+  `}
+            <span class="shl-kwd">async</span>{" "}
+            <span class="shl-func">execute</span>(interaction) &#123;{`
+    `}
+            <span class="shl-cmnt">
+              // Before executing any other code, we need to acknowledge the
+              interaction.
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // Discord only gives us 3 seconds to acknowledge an interaction
+              before
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // the interaction gets voided and can't be used anymore.
+            </span>
+            {`
+    `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">reply</span>(&#123;{`
+      `}content<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">
+              "Fetched all input and working on your request!"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+    `}&#125;);{`
+
+    `}
+            <span class="shl-kwd">try</span> &#123;{`
+      `}
+            <span class="shl-cmnt">
+              // Now create the Channel in the server.
+            </span>
+            {`
+      `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">
+              .
+            </span>guild<span class="shl-oper">
+              .
+            </span>channels<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+        `}name<span class="shl-oper">:</span> <span class="shl-str">"new"</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">// The name given to the Channel</span>
+            {`
+        `}type<span class="shl-oper">:</span>{" "}
+            <span class="shl-class">ChannelType</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">GuildText</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">// The type of the Channel created.</span>
+            {`
+        `}
+            <span class="shl-cmnt">
+              // Since "text" is the default Channel created, this could be
+              ommitted
+            </span>
+            {`
+      `}&#125;);{`
+      `}
+            <span class="shl-cmnt">
+              // Notice how we are creating a Channel in the list of Channels
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // of the server. This will cause the Channel to spawn at the top
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // of the Channels list, without belonging to any Categories (more
+              on that later)
+            </span>
+            {`
+
+      `}
+            <span class="shl-cmnt">
+              // If we managed to create the Channel, edit the initial response
+              with
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">// a success message</span>
+            {`
+      `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">editReply</span>(&#123;{`
+        `}content<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">
+              "Your channel was successfully created!"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+      `}&#125;);{`
+    `}&#125; <span class="shl-kwd">catch</span> (error) &#123;{`
+      `}
+            <span class="shl-cmnt">
+              // If an error occurred and we were not able to create the Channel
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // the bot is most likely received the "Missing Permissions"
+              error.
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">// Log the error to the console</span>
+            {`
+      `}console<span class="shl-oper">.</span>
+            <span class="shl-func">log</span>(error);{`
+      `}
+            <span class="shl-cmnt">
+              // Also inform the user that an error occurred and give them
+              feedback
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // about how to avoid this error if they want to try again
+            </span>
+            {`
+      `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">editReply</span>(&#123;{`
+        `}content<span class="shl-oper">:</span>
+            {`
+          `}
+            <span class="shl-str">
+              "Your channel could not be created! Please check if the bot has
+              the necessary permissions!"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+      `}&#125;);{`
+    `}&#125;{`
+  `}&#125;<span class="shl-oper">,</span>
+            {`
+`}&#125;;
+          </div>
+          {/* Code link */}
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createnewchannel.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
+          {/* Deploying and refreshing */}
+          <p class="my-2 text-justify">
+            <GradientLink
+              link="https://discordjs.guide/creating-your-bot/command-deployment.html#command-registration"
+              title="Registering commands (D.JS Guide)"
+              content="Deploying this command"
+              customRel="noopener noreferrer"
+            />
+            , refreshing your client, and triggering the command will always
+            create a new{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            called "new". But that's not very versatile, is it? Let's tweak the
+            code a bit so we can choose what name we want to give the{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            now.
+          </p>
+
+          <StyledSubHeader title="Creating a Text Channel with a dynamic name" />
+          <p class="my-2 text-justify">
+            To be able to set the name from the command itself, we need to tweak
+            the code a little, add{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/typedef/CommandInteractionOption"
+              title="CommandInteractionOption (D.JS Docs)"
+              content="options"
+              customRel="noopener noreferrer"
+            />{" "}
+            to the command, and then retrieve the name provided by the user in
+            our file.
+          </p>
+
+          {/* Dynamic name text channel */}
+          <div class="shl-block">
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // initial code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-cmnt">
+              // Text Channel name{`
+`}
+            </span>
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addStringOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+	`}option{`
+		`}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              'channelname'
+            </span>){" "}
+            <span class="shl-cmnt">
+              // option names need to always be lowercase and have no spaces
+            </span>
+            {`
+		`}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              'Choose the name to give to the channel'
+            </span>){`
+		`}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMinLength</span>(<span class="shl-num">
+              1
+            </span>){" "}
+            <span class="shl-cmnt">// A Text Channel needs to be named</span>
+            {`
+		`}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMaxLength</span>(<span class="shl-num">
+              25
+            </span>){" "}
+            <span class="shl-cmnt">
+              // Discord will cut-off names past the 25 characters,
+            </span>
+            {`
+		`}
+            <span class="shl-cmnt">
+              // so that's a good hard limit to set. You can manually increase
+              this if you wish
+            </span>
+            {`
+		`}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setRequired</span>(<span class="shl-bool">
+              true
+            </span>){`
+`}){`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-kwd">const</span> chosenChannelName{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getString</span>(<span class="shl-str">
+              'channelname'
+            </span>);{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">
+              .
+            </span>guild<span class="shl-oper">
+              .
+            </span>channels<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+    `}name<span class="shl-oper">:</span>{" "}
+            chosenChannelName<span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The name given to the Channel by the user
+            </span>
+            {`
+    `}type<span class="shl-oper">:</span>{" "}
+            <span class="shl-class">ChannelType</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">GuildText</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">// The type of the Channel created.</span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // Since "text" is the default Channel created, this could be
+              ommitted{`
+`}
+            </span>&#125;);{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // rest of the code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+          </div>
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createchannel.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
+          <p class="my-2 text-justify">
+            A small note here:{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="Discord blog post"
+              content="Discord has a visual limit of around 25
+            characters"
+              customRel="noopener noreferrer"
+            />{" "}
+            for channels on the sidebar, but they don't define an actual hard
+            limit for{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            names and expect users to have common sense. If you choose to
+            override the 25-character limit in{" "}
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createchannel.js#L15"
+              title="view source"
+              content="line 15"
+              customRel="noopener noreferrer"
+            />, please ensure there is another limit in place to stop users from
+            creating absurdly long{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            names.{" "}
+            <GradientLink
+              link="https://www.collinsdictionary.com/dictionary/english/give-someone-enough-rope-to-hang-himself-or-herself"
+              title="Don't allow your users to be the architect of their own destruction"
+              content="Avoid giving them enough rope to hang themselves"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+          <p class="my-2 text-justify">
+            After saving your file, reloading your bot, and{" "}
+            <GradientLink
+              link="https://discordjs.guide/creating-your-bot/command-deployment.html#command-registration"
+              title="Deploying commands (D.JS Guide)"
+              content="redeploying your
+            commands"
+              customRel="noopener noreferrer"
+            />, you now have a command that can quickly create a new{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text Channel"
+              customRel="noopener noreferrer"
+            />. Neat, huh? But we are still creating stray{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            at the top of the{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            list. Let's change that now.
+          </p>
+
+          {/* Create channel inside category section */}
+          <StyledSubHeader title="Create a Channel that is nested in the parent Category (when there is one)" />
+          <p class="my-2 text-justify">
+            More experienced Discord users won't be expecting the newly created
+            {" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            to appear on the top of the{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            list, but instead, to be within the same{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />{" "}
+            of the{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            they used the command in. We will now be tweaking our code to create
+            {" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            with that behavior whenever the server has{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Categories"
+              customRel="noopener noreferrer"
+            />{" "}
+            set up, but still, be able to create stray{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            if the command was used in a{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            that isn't nested in a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+
+          {/* Create channel inside category code block */}
+          <div class="shl-block">
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // initial code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+`}
+            <span class="shl-cmnt">
+              // Check if this Channel where the command was used is stray{`
+`}
+            </span>
+            <span class="shl-kwd">if</span>{" "}
+            (<span class="shl-oper">!</span>interaction<span class="shl-oper">
+              .
+            </span>channel<span class="shl-oper">.</span>parent) &#123;{`
+	`}
+            <span class="shl-cmnt">
+              // If the Channel where the command was used is stray,
+            </span>
+            {`
+	`}
+            <span class="shl-cmnt">
+              // create another stray Channel in the server.
+            </span>
+            {`
+	`}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">
+              .
+            </span>guild<span class="shl-oper">
+              .
+            </span>channels<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+		`}name<span class="shl-oper">:</span>{" "}
+            chosenChannelName<span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The name given to the Channel by the user
+            </span>
+            {`
+		`}type<span class="shl-oper">:</span>{" "}
+            <span class="shl-class">ChannelType</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">GuildText</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">// The type of the Channel created.</span>
+            {`
+		`}
+            <span class="shl-cmnt">
+              // Since "text" is the default Channel created, this could be
+              ommitted
+            </span>
+            {`
+	`}&#125;);{`
+	`}
+            <span class="shl-cmnt">
+              // Notice how we are creating a Channel in the list of Channels
+            </span>
+            {`
+	`}
+            <span class="shl-cmnt">
+              // of the server. This will cause the Channel to spawn at the top
+            </span>
+            {`
+	`}
+            <span class="shl-cmnt">
+              // of the Channels list, without belonging to any Categories (more
+              on that later)
+            </span>
+            {`
+
+	`}
+            <span class="shl-cmnt">
+              // If we managed to create the Channel, edit the initial response
+              with
+            </span>
+            {`
+	`}
+            <span class="shl-cmnt">// a success message</span>
+            {`
+	`}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">editReply</span>(&#123;{`
+		`}content<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">
+              'Your channel was successfully created!'
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+	`}&#125;);{`
+	`}
+            <span class="shl-kwd">return</span>;{`
+`}&#125;{`
+
+`}
+            <span class="shl-cmnt">
+              // Check if this Channel where the command was used belongs to a
+              Category{`
+`}
+            </span>
+            <span class="shl-kwd">if</span> (interaction<span class="shl-oper">
+              .
+            </span>channel<span class="shl-oper">.</span>parent) &#123;{`
+	`}
+            <span class="shl-cmnt">
+              // If the Channel where the command belongs to a Category,
+            </span>
+            {`
+	`}
+            <span class="shl-cmnt">
+              // create another Channel in the same Category.
+            </span>
+            {`
+	`}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">
+              .
+            </span>channel<span class="shl-oper">
+              .
+            </span>parent<span class="shl-oper">
+              .
+            </span>children<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+		`}name<span class="shl-oper">:</span>{" "}
+            chosenChannelName<span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The name given to the Channel by the user
+            </span>
+            {`
+		`}type<span class="shl-oper">:</span>{" "}
+            <span class="shl-class">ChannelType</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">GuildText</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">// The type of the Channel created.</span>
+            {`
+		`}
+            <span class="shl-cmnt">
+              // Since "text" is the default Channel created, this could be
+              ommitted
+            </span>
+            {`
+	`}&#125;);{`
+
+	`}
+            <span class="shl-cmnt">
+              // If we managed to create the Channel, edit the initial response
+              with
+            </span>
+            {`
+	`}
+            <span class="shl-cmnt">// a success message</span>
+            {`
+	`}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">editReply</span>(&#123;{`
+		`}content<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">
+              'Your channel was successfully created in the same category!'
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+	`}&#125;);{`
+	`}
+            <span class="shl-kwd">return</span>;{`
+`}&#125;{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // rest of the code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+          </div>
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createchannelincategory.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
+          <p class="my-2 text-justify self-start">
+            Let's go through this bit by bit.
+          </p>
+          {/* line 45 quote */}
+          <q
+            cite="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createchannelincategory.js#L45"
+            class="custom-quote italic self-start"
+          >
+            if (!interaction.channel.parent) &#123; (
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createchannelincategory.js#L45"
+              title="view source"
+              content="line 45"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            First, we are checking if the{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            where the command was used doesn't have a parent, which would mean
+            they are not nested within a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />. If this check succeeds, then this is a stray{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            and we can reuse our previous code to create another stray{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            . Do note that we end this if check with a{" "}
+            <span class="shl-inline">return</span>{" "}
+            statement. More on that is below.
+          </p>
+          {/* line 66 quote */}
+          <q
+            cite="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createchannelincategory.js#L66"
+            class="custom-quote italic self-start"
+          >
+            if (interaction.channel.parent) &#123; (
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createchannelincategory.js#L66"
+              title="view source"
+              content="line 66"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            Now we are checking if the{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            where the command was used does have a parent, meaning they are
+            nested in a{"  "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+          {/* line 69 quote */}
+          <q
+            cite="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createchannelincategory.js#L69"
+            class="custom-quote italic self-start"
+          >
+            await interaction.channel.parent.children.create(&#123; (
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createchannelincategory.js#L69"
+              title="view source"
+              content="line 69"
+              customRel="noopener noreferrer"
+            />)
+          </q>
+          <p class="my-2 text-justify">
+            Since the{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            where the command was used does have a parent, we need to create our
+            {" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            inside that same{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />. For that, we need to first access the children of that{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Category"
+              customRel="noopener noreferrer"
+            />{" "}
+            and then create our{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            within.
+          </p>
+          <p class="my-2 text-justify">
+            Now that we are handling both cases for stray{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            and nested{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channels"
+              customRel="noopener noreferrer"
+            />, let's switch gears for a moment and talk about{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/ThreadChannel"
+              title="ThreadChannel (D.JS Docs)"
+              content="Thread"
+              customRel="noopener noreferrer"
+            />{" "}
+            before we proceed to Voice Channels, Categories, and Roles.
+          </p>
+
+          {/* Create thread section */}
+          <StyledSubHeader title="Create a Thread with a dynamic name" />
+          <p class="my-2 text-justify">
+            Starting a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/ThreadChannel"
+              title="ThreadChannel (D.JS Docs)"
+              content="Thread"
+              customRel="noopener noreferrer"
+            />{" "}
+            is about as simple as creating a{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />, all you need is either a message or a{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            that will host the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/ThreadChannel"
+              title="ThreadChannel (D.JS Docs)"
+              content="Thread"
+              customRel="noopener noreferrer"
+            />. Because{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/ThreadChannel"
+              title="ThreadChannel (D.JS Docs)"
+              content="Threads"
+              customRel="noopener noreferrer"
+            />{" "}
+            live inside a{" "}
+            <GradientLink
+              link="https://discord.com/moderation/208-channel-categories-and-names"
+              title="GuildChannel (D.JS Docs)"
+              content="Channel"
+              customRel="noopener noreferrer"
+            />, regardless of using a message as a starting point or not, you
+            don't need to care for{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/CategoryChannel"
+              title="CategoryChannel (D.JS Docs)"
+              content="Categories"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+
+          {/* Create Thread code block */}
+          <div class="shl-block">
+            <span class="shl-cmnt">
+              // Importing SlashCommandBuilder is required for every slash
+              command{`
+`}
+            </span>
+            <span class="shl-kwd">const</span> &#123;{" "}
+            <span class="shl-class">SlashCommandBuilder</span> &#125;{" "}
+            <span class="shl-oper">=</span>{" "}
+            <span class="shl-func">require</span>(<span class="shl-str">
+              "discord.js"
+            </span>);{`
+`}module<span class="shl-oper">.</span>exports <span class="shl-oper">=</span>
+            {" "}
+            &#123;{`
+  `}data<span class="shl-oper">:</span> <span class="shl-kwd">new</span>{" "}
+            <span class="shl-class">SlashCommandBuilder</span>(){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "createthread"
+            </span>){" "}
+            <span class="shl-cmnt">// Command name matching file name</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              "Creates a new thread"
+            </span>){`
+    `}
+            <span class="shl-cmnt">// Thread name</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addStringOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+      `}option{`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "threadname"
+            </span>){" "}
+            <span class="shl-cmnt">
+              // option names need to always be lowercase and have no spaces
+            </span>
+            {`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              "Choose the name to give to the thread"
+            </span>){`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setRequired</span>(<span class="shl-bool">
+              true
+            </span>){`
+    `}){`
+    `}
+            <span class="shl-cmnt">// Thread starts from message</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addBooleanOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+      `}option{`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "messageparent"
+            </span>){" "}
+            <span class="shl-cmnt">
+              // option names need to always be lowercase and have no spaces
+            </span>
+            {`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>({`
+          `}
+            <span class="shl-str">
+              "Choose if this thread should be use the initial message as
+              parent"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+        `}){`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setRequired</span>(<span class="shl-bool">
+              true
+            </span>){`
+    `})<span class="shl-oper">,</span>
+            {`
+  `}
+            <span class="shl-kwd">async</span>{" "}
+            <span class="shl-func">execute</span>(interaction) &#123;{`
+    `}
+            <span class="shl-cmnt">
+              // Before executing any other code, we need to acknowledge the
+              interaction.
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // Discord only gives us 3 seconds to acknowledge an interaction
+              before
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // the interaction gets voided and can't be used anymore.
+            </span>
+            {`
+    `}
+            <span class="shl-kwd">const</span> interactionReplied{" "}
+            <span class="shl-oper">=</span> <span class="shl-kwd">await</span>
+            {" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">reply</span>(&#123;{`
+      `}content<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">
+              "Fetched all input and working on your request!"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+      `}fetchReply<span class="shl-oper">:</span>{" "}
+            <span class="shl-bool">true</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // notice how we are instantiating this reply to
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // a constant and passing `fetchReply: true` in the reply options
+            </span>
+            {`
+    `}&#125;);{`
+
+    `}
+            <span class="shl-cmnt">
+              // After acknowledging the interaction, we retrieve the string
+              sent by the user
+            </span>
+            {`
+    `}
+            <span class="shl-kwd">const</span> chosenThreadName{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getString</span>(<span class="shl-str">
+              "threadname"
+            </span>);{`
+    `}
+            <span class="shl-kwd">const</span> threadWithMessageAsParent{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getBoolean</span>({`
+      `}
+            <span class="shl-str">"messageparent"</span>
+            <span class="shl-oper">,</span>
+            {`
+    `});{`
+    `}
+            <span class="shl-cmnt">
+              // Do note that the string passed to the method .getString() and
+              .getBoolean()
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // needs to match EXACTLY the name of the options provided (line
+              10 and 17
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // in this file). If it's not a perfect match, these will always
+              return null
+            </span>
+            {`
+
+    `}
+            <span class="shl-kwd">try</span> &#123;{`
+      `}
+            <span class="shl-cmnt">
+              // Check if the current Channel the command was used is a Thread,
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // which would cause the creation of another Thread to fail.
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // Threads cannot be parents of other Threads!
+            </span>
+            {`
+      `}
+            <span class="shl-kwd">if</span> (interaction<span class="shl-oper">
+              .
+            </span>channel<span class="shl-oper">.</span>
+            <span class="shl-func">isThread</span>(){" "}
+            <span class="shl-oper">==</span>{" "}
+            <span class="shl-bool">true</span>) &#123;{`
+        `}
+            <span class="shl-cmnt">
+              // If the current Channel is a Thread, return a fail message
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">// and stop the command</span>
+            {`
+        `}
+            <span class="shl-kwd">await</span>{" "}
+            interactionReplied<span class="shl-oper">.</span>
+            <span class="shl-func">edit</span>(&#123;{`
+          `}content<span class="shl-oper">:</span>
+            {`
+            `}
+            <span class="shl-str">
+              `It's impossible to create a thread within another thread. Try
+              again inside a text channel!`
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+        `}&#125;);{`
+        `}
+            <span class="shl-kwd">return</span>;{" "}
+            <span class="shl-cmnt">
+              // Return statement here to stop all further code execution on
+              this file
+            </span>
+            {`
+      `}&#125;{`
+
+      `}
+            <span class="shl-cmnt">
+              // Check if the Channel where the command was used is not a Thread
+            </span>
+            {`
+      `}
+            <span class="shl-kwd">if</span> (interaction<span class="shl-oper">
+              .
+            </span>channel<span class="shl-oper">.</span>
+            <span class="shl-func">isThread</span>(){" "}
+            <span class="shl-oper">==</span>{" "}
+            <span class="shl-bool">false</span>) &#123;{`
+        `}
+            <span class="shl-cmnt">
+              // If the Channel isn't a Thread, check if the user
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">
+              // requested the initial message to be the parent of the Thread
+            </span>
+            {`
+        `}
+            <span class="shl-kwd">if</span> (threadWithMessageAsParent{" "}
+            <span class="shl-oper">==</span>{" "}
+            <span class="shl-bool">true</span>) &#123;{`
+          `}
+            <span class="shl-cmnt">
+              // If the initial message will be used as parent for the
+            </span>
+            {`
+          `}
+            <span class="shl-cmnt">
+              // Thread, check if the message already has a Thread
+            </span>
+            {`
+          `}
+            <span class="shl-kwd">if</span>{" "}
+            (interactionReplied<span class="shl-oper">.</span>hasThread{" "}
+            <span class="shl-oper">==</span>{" "}
+            <span class="shl-bool">true</span>) &#123;{`
+            `}
+            <span class="shl-cmnt">
+              // If the initial message already has a Thread,
+            </span>
+            {`
+            `}
+            <span class="shl-cmnt">
+              // return an error message to the user and stop the command
+            </span>
+            {`
+            `}interactionReplied<span class="shl-oper">.</span>
+            <span class="shl-func">edit</span>(&#123;{`
+              `}content<span class="shl-oper">:</span>
+            {`
+                `}
+            <span class="shl-str">
+              "It was not possible to create a thread in this message because it
+              already has one."
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+            `}&#125;);{`
+            `}
+            <span class="shl-kwd">return</span>;{" "}
+            <span class="shl-cmnt">
+              // Return statement here to stop all further code execution on
+              this file
+            </span>
+            {`
+          `}&#125;{`
+
+          `}
+            <span class="shl-cmnt">
+              // If the initial message will be used as parent for the
+            </span>
+            {`
+          `}
+            <span class="shl-cmnt">
+              // Thread, check if the message already doesn't have a Thread
+            </span>
+            {`
+          `}
+            <span class="shl-kwd">if</span>{" "}
+            (interactionReplied<span class="shl-oper">.</span>hasThread{" "}
+            <span class="shl-oper">==</span>{" "}
+            <span class="shl-bool">false</span>) &#123;{`
+            `}
+            <span class="shl-cmnt">
+              // If the initial message doesn't have a Thread,
+            </span>
+            {`
+            `}
+            <span class="shl-cmnt">// create one.</span>
+            {`
+            `}
+            <span class="shl-kwd">await</span>{" "}
+            interactionReplied<span class="shl-oper">.</span>
+            <span class="shl-func">startThread</span>(&#123;{`
+              `}name<span class="shl-oper">:</span>{" "}
+            chosenThreadName<span class="shl-oper">,</span>
+            {`
+            `}&#125;);{`
+            `}
+            <span class="shl-cmnt">
+              // We don't return here because we want
+            </span>
+            {`
+            `}
+            <span class="shl-cmnt">// to use the success message below</span>
+            {`
+          `}&#125;{`
+        `}&#125;{`
+
+        `}
+            <span class="shl-cmnt">
+              // If the initial message isn't meant to be the parent of
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">
+              // the Thread, create an orphaned Thread in this Channel
+            </span>
+            {`
+        `}
+            <span class="shl-kwd">if</span> (threadWithMessageAsParent{" "}
+            <span class="shl-oper">==</span>{" "}
+            <span class="shl-bool">false</span>) &#123;{`
+          `}
+            <span class="shl-cmnt">
+              // Create the orphaned Thread in the command Channel
+            </span>
+            {`
+          `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">
+              .
+            </span>channel<span class="shl-oper">
+              .
+            </span>threads<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+            `}name<span class="shl-oper">:</span>{" "}
+            chosenThreadName<span class="shl-oper">,</span>
+            {`
+          `}&#125;);{`
+          `}
+            <span class="shl-cmnt">
+              // We don't return here because we want
+            </span>
+            {`
+          `}
+            <span class="shl-cmnt">// to use the success message below</span>
+            {`
+        `}&#125;{`
+
+        `}
+            <span class="shl-cmnt">
+              // If we managed to create the Thread, orphaned or using the
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">
+              // initial message as parent, edit the initial response
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">// with a success message</span>
+            {`
+        `}
+            <span class="shl-kwd">await</span>{" "}
+            interactionReplied<span class="shl-oper">.</span>
+            <span class="shl-func">edit</span>(&#123;{`
+          `}content<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">"Your thread was successfully created!"</span>
+            <span class="shl-oper">,</span>
+            {`
+        `}&#125;);{`
+      `}&#125;{`
+    `}&#125; <span class="shl-kwd">catch</span> (error) &#123;{`
+      `}
+            <span class="shl-cmnt">
+              // If an error occurred and we were not able to create the Thread,
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // the bot is most likely received the "Missing Permissions"
+              error.
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">// Log the error to the console</span>
+            {`
+      `}console<span class="shl-oper">.</span>
+            <span class="shl-func">log</span>(error);{`
+      `}
+            <span class="shl-cmnt">
+              // Also inform the user that an error occurred and give them
+              feedback
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // about how to avoid this error if they want to try again
+            </span>
+            {`
+      `}
+            <span class="shl-kwd">await</span>{" "}
+            interactionReplied<span class="shl-oper">.</span>
+            <span class="shl-func">edit</span>(&#123;{`
+        `}content<span class="shl-oper">:</span>
+            {`
+          `}
+            <span class="shl-str">
+              "Your thread could not be created! Please check if the bot has the
+              necessary permissions!"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+      `}&#125;);{`
+      `}
+            <span class="shl-kwd">return</span>;{`
+    `}&#125;{`
+  `}&#125;<span class="shl-oper">,</span>
+            {`
+`}&#125;;{`
+`}
+          </div>
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createthread.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
+          <p class="my-2 text-justify self-start">
+            Alright, few key points with this code:
+          </p>
+          <GreekList
+            items={[
+              <p>
+                We are now storing the message sent as a reply to the
+                interaction in the constant{" "}
+                <span class="shl-inline">
+                  interactionReplied
+                </span>{" "}
+                (<GradientLink
+                  link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createthread.js#L25"
+                  title="view source"
+                  content="line 25"
+                  customRel="noopener noreferrer"
+                />
+                ). This is done so we can refer to that message later if the
+                user requested to use our message as a parent to the{" "}
+                <GradientLink
+                  link="https://discord.js.org/#/docs/discord.js/main/class/ThreadChannel"
+                  title="ThreadChannel (D.JS Docs)"
+                  content="Thread"
+                  customRel="noopener noreferrer"
+                />{" "}
+                we are going to create (<GradientLink
+                  link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createthread.js#L73"
+                  title="view source"
+                  content="line 73"
+                  customRel="noopener noreferrer"
+                />
+                ).
+              </p>,
+              <p>
+                We also handle the case that the user might not want to create a
+                {" "}
+                <GradientLink
+                  link="https://discord.js.org/#/docs/discord.js/main/class/ThreadChannel"
+                  title="ThreadChannel (D.JS Docs)"
+                  content="Thread"
+                  customRel="noopener noreferrer"
+                />{" "}
+                on the message itself, so an orphaned{"  "}
+                <GradientLink
+                  link="https://discord.js.org/#/docs/discord.js/main/class/ThreadChannel"
+                  title="ThreadChannel (D.JS Docs)"
+                  content="Thread"
+                  customRel="noopener noreferrer"
+                />{" "}
+                is created in the{" "}
+                <GradientLink
+                  link="https://discord.com/moderation/208-channel-categories-and-names"
+                  title="GuildChannel (D.JS Docs)"
+                  content="Channel"
+                  customRel="noopener noreferrer"
+                />{" "}
+                where the command was used instead.
+              </p>,
+            ]}
+          />
+
+          {/* Next post: voice channels */}
+          <p class="mt-4 text-justify self-start">
+            Next post: Creating Voice Channels in Discord.JS V14
+          </p>
+          {/* Post author */}
+          <footer class="mt-auto w-full text-right text-sm">
+            Written with 💞 by TheYuriG
+          </footer>
+        </article>
+      </Base>
+    </>
+  );
+}

--- a/routes/blog/how-create-text-channels-discord-v14.tsx
+++ b/routes/blog/how-create-text-channels-discord-v14.tsx
@@ -11,6 +11,8 @@ import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
 //? Create a greek list of contents
 import { GreekList } from "../../components/UI/GreekList.tsx";
+//? Display a link to view the source code on GitHub
+import { ViewOnGitHub } from "../../components/misc/ViewOnGithub.tsx";
 //? Import post summary
 import { createTextChannelPost as postSummary } from "../../data/blog/how-create-text-channels-discord-v14.ts";
 import { createVoiceChannelPost as nextPost } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
@@ -466,14 +468,7 @@ export default function Home() {
 `}&#125;;
           </div>
           {/* Code link */}
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createnewchannel.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createnewchannel.js" />
           {/* Deploying and refreshing */}
           <p class="my-2 text-justify">
             <GradientLink
@@ -653,14 +648,7 @@ export default function Home() {
             </span>
             <span class="shl-cmnt">// ...</span>
           </div>
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createchannel.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createchannel.js" />
           <p class="my-2 text-justify">
             A small note here:{" "}
             <GradientLink
@@ -988,14 +976,7 @@ export default function Home() {
             </span>
             <span class="shl-cmnt">// ...</span>
           </div>
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createchannelincategory.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createchannelincategory.js" />
           <p class="my-2 text-justify self-start">
             Let's go through this bit by bit.
           </p>
@@ -1670,14 +1651,7 @@ export default function Home() {
 `}&#125;;{`
 `}
           </div>
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createthread.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createthread.js" />
           <p class="my-2 text-justify self-start">
             Alright, few key points with this code:
           </p>

--- a/routes/blog/how-create-theme-switcher-deno-fresh.tsx
+++ b/routes/blog/how-create-theme-switcher-deno-fresh.tsx
@@ -11,6 +11,8 @@ import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
 //? Create a greek list of contents
 import { GreekList } from "../../components/UI/GreekList.tsx";
+//? Display a link to view the source code on GitHub
+import { ViewOnGitHub } from "../../components/misc/ViewOnGithub.tsx";
 //? Import posts
 import { createFreshThemeSwitcher as postSummary } from "../../data/blog/how-create-theme-switcher-deno-fresh.ts";
 import { stopThemeFlickering as nextPost } from "../../data/blog/stopping-theme-flickering-deno-fresh.ts";
@@ -293,14 +295,7 @@ export default function Home() {
 	`});{`
 `}&#125;
           </div>
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/deno_create_theme_switcher/islands/basicThemeSwitcher.tsx"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/deno_create_theme_switcher/islands/basicThemeSwitcher.tsx" />
           {/* Initial implementation explanation */}
           <p class="text-justify">
             This creates a radio input that has{" "}
@@ -390,14 +385,7 @@ export default function Home() {
 `}
             <span class="shl-oper">...</span>
           </div>
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/deno_create_theme_switcher/islands/updatedThemeSwitcher.tsx"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/deno_create_theme_switcher/islands/updatedThemeSwitcher.tsx" />
           {/* Second code block explanation */}
           <p class="my-2 text-justify">
             We have added a reference to the{" "}

--- a/routes/blog/how-create-theme-switcher-deno-fresh.tsx
+++ b/routes/blog/how-create-theme-switcher-deno-fresh.tsx
@@ -128,11 +128,11 @@ export default function Home() {
           </p>
           {/* Main content start */}
           <StyledSubHeader title="Creating A Theme Switcher" />
-          <p class="my-2 text-justify">
+          <p class="my-2 text-justify self-start">
             Let's create a very simple Theme Switcher:
           </p>
           {/* Code block with initial implementation */}
-          <div class="shl-block">
+          <div class="shl-block self-start">
             <span class="shl-cmnt">
               // /islands/ThemeSwitcher.tsx{`
 `}
@@ -315,7 +315,7 @@ export default function Home() {
             with the values for your theme.
           </p>
           {/* Improved implementation with localStorage */}
-          <div class="shl-block">
+          <div class="shl-block self-start">
             <span class="shl-cmnt">
               // /islands/ThemeSwitcher.tsx (updated){`
 `}
@@ -395,7 +395,7 @@ export default function Home() {
             </code>{" "}
             on the first render.
           </p>
-          <p class="text-justify">
+          <p class="text-justify self-start">
             What the{" "}
             <code class="shl-inline">
               useEffect()

--- a/routes/blog/how-create-theme-switcher-deno-fresh.tsx
+++ b/routes/blog/how-create-theme-switcher-deno-fresh.tsx
@@ -9,6 +9,8 @@ import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? A HTML Link component to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+//? Create a greek list of contents
+import { GreekList } from "../../components/UI/GreekList.tsx";
 
 const googleLightDarkImage =
   "https://web-dev.imgix.net/image/vS06HQ1YTsbMKSFTIPl2iogUQP73/skKcjSv1gMQRYk1AdEp7.png?auto=format&w=1600";
@@ -400,79 +402,75 @@ export default function Home() {
             </code>{" "}
             does, in order:
           </p>
-          <ol
-            start={1}
-            class="self-start list-[lower-greek]"
-          >
-            {/* Explanation part 1 */}
-            <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
-              Runs on start, checks if there is a theme saved (if not,{" "}
-              <code class="shl-inline">
-                savedTheme
-              </code>{" "}
-              will be{" "}
-              <code class="shl-inline">
-                null
-              </code>
-              ), and sets the current theme as the{" "}
-              <code class="shl-inline">
-                savedTheme
-              </code>
-              , if they are different, then stops (remember that{" "}
-              <code class="shl-inline">
-                useEffect()
-              </code>{" "}
-              is using the{" "}
-              <code class="shl-inline">
-                theme
-              </code>{" "}
-              as a dependency so not returning here would cause an infinite
-              loop!).
-            </li>
-            {/* Explanation part 2 */}
-            <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
-              After setting the{" "}
-              <code class="shl-inline">
-                theme
-              </code>{" "}
-              equal to{" "}
-              <code class="shl-inline">
-                localStorage
-              </code>'s{" "}
-              <code class="shl-inline">
-                savedTheme
-              </code>{" "}
-              is the same as the{" "}
-              <code class="shl-inline">
-                theme
-              </code>
-              , it will skip the first{" "}
-              <code class="shl-inline">
-                if
-              </code>{" "}
-              check and negate the{" "}
-              <code class="shl-inline">
-                isInitialMount
-              </code>{" "}
-              value and stop.
-            </li>
-            {/* Explanation part 3 */}
-            <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
-              (Optional) If the{" "}
-              <code class="shl-inline">
-                theme
-              </code>{" "}
-              is updated, it will skip both{" "}
-              <code class="shl-inline">
-                if
-              </code>{" "}
-              checks, save the theme to{" "}
-              <code class="shl-inline">
-                localStorage
-              </code>
-              , and applies it.
-            </li>
-          </ol>
+          <GreekList
+            items={[
+              <p>
+                Runs on start, checks if there is a theme saved (if not,{" "}
+                <code class="shl-inline">
+                  savedTheme
+                </code>{" "}
+                will be{" "}
+                <code class="shl-inline">
+                  null
+                </code>
+                ), and sets the current theme as the{" "}
+                <code class="shl-inline">
+                  savedTheme
+                </code>
+                , if they are different, then stops (remember that{" "}
+                <code class="shl-inline">
+                  useEffect()
+                </code>{" "}
+                is using the{" "}
+                <code class="shl-inline">
+                  theme
+                </code>{" "}
+                as a dependency so not returning here would cause an infinite
+                loop!).
+              </p>,
+              <p>
+                After setting the{" "}
+                <code class="shl-inline">
+                  theme
+                </code>{" "}
+                equal to{" "}
+                <code class="shl-inline">
+                  localStorage
+                </code>'s{" "}
+                <code class="shl-inline">
+                  savedTheme
+                </code>{" "}
+                is the same as the{" "}
+                <code class="shl-inline">
+                  theme
+                </code>
+                , it will skip the first{" "}
+                <code class="shl-inline">
+                  if
+                </code>{" "}
+                check and negate the{" "}
+                <code class="shl-inline">
+                  isInitialMount
+                </code>{" "}
+                value and stop.
+              </p>,
+              <p>
+                (Optional) If the{" "}
+                <code class="shl-inline">
+                  theme
+                </code>{" "}
+                is updated, it will skip both{" "}
+                <code class="shl-inline">
+                  if
+                </code>{" "}
+                checks, save the theme to{" "}
+                <code class="shl-inline">
+                  localStorage
+                </code>
+                , and applies it.
+              </p>,
+            ]}
+          />
           {/* Linking to repository version */}
           <p class="my-2 text-justify">
             This website uses an improved version of the same Theme Switcher

--- a/routes/blog/how-create-theme-switcher-deno-fresh.tsx
+++ b/routes/blog/how-create-theme-switcher-deno-fresh.tsx
@@ -290,6 +290,14 @@ export default function Home() {
 	`});{`
 `}&#125;
           </div>
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/deno_create_theme_switcher/islands/basicThemeSwitcher.tsx"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
           {/* Initial implementation explanation */}
           <p class="text-justify">
             This creates a radio input that has{" "}
@@ -379,6 +387,14 @@ export default function Home() {
 `}
             <span class="shl-oper">...</span>
           </div>
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/deno_create_theme_switcher/islands/updatedThemeSwitcher.tsx"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
           {/* Second code block explanation */}
           <p class="my-2 text-justify">
             We have added a reference to the{" "}

--- a/routes/blog/how-create-theme-switcher-deno-fresh.tsx
+++ b/routes/blog/how-create-theme-switcher-deno-fresh.tsx
@@ -11,6 +11,9 @@ import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
 //? Create a greek list of contents
 import { GreekList } from "../../components/UI/GreekList.tsx";
+//? Import posts
+import { createFreshThemeSwitcher as postSummary } from "../../data/blog/how-create-theme-switcher-deno-fresh.ts";
+import { stopThemeFlickering as nextPost } from "../../data/blog/stopping-theme-flickering-deno-fresh.ts";
 
 const googleLightDarkImage =
   "https://web-dev.imgix.net/image/vS06HQ1YTsbMKSFTIPl2iogUQP73/skKcjSv1gMQRYk1AdEp7.png?auto=format&w=1600";
@@ -19,10 +22,10 @@ export default function Home() {
   return (
     <>
       <CustomHead
-        title="How to Create a Theme Switcher with Fresh"
-        description="A guide on how to create your own Theme Switcher using Deno and Fresh"
+        title={postSummary.title}
+        description={postSummary.shortSummary}
         imageLink={googleLightDarkImage}
-        link="https://www.theyurig.com/blog/how-create-theme-switcher-deno-fresh"
+        link={"https://www.theyurig.com" + postSummary.link}
       >
       </CustomHead>
       {/* Base page layout with theme switching and footer outside of accent box */}
@@ -31,16 +34,16 @@ export default function Home() {
         <NavigationButtons
           back={{ title: "Browse more blog posts", link: "/blog" }}
           next={{
-            title: "Read next: Stop theme flickering",
-            link: "/blog/stopping-theme-flickering-deno-fresh",
+            title: nextPost.title,
+            link: nextPost.link,
           }}
         />
         <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
           {/* Title header */}
-          <StyledHeader title="How to Create a Theme Switcher with Fresh" />
+          <StyledHeader title={postSummary.title} />
           {/* Post creation date */}
           <p class="text-sm mb-2 w-full text-center">
-            {new Date(1684849328672).toLocaleString()}
+            {new Date(postSummary.date).toLocaleString()}
           </p>
           {/* Blog post opening image */}
           <img
@@ -506,8 +509,8 @@ export default function Home() {
             check for user preferences. Let's address those problems on those on
             the{" "}
             <GradientLink
-              link="/blog/stopping-theme-flickering-deno-fresh"
-              title="Part 2 of this blog post. Please click, it has really good information!"
+              link={nextPost.link}
+              title={nextPost.title}
               content="next blog post"
               newTab={false}
               customRel="next"

--- a/routes/blog/how-create-voice-channels-discord-v14.tsx
+++ b/routes/blog/how-create-voice-channels-discord-v14.tsx
@@ -9,6 +9,8 @@ import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? A HTML Link component to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+//? Display a link to view the source code on GitHub
+import { ViewOnGitHub } from "../../components/misc/ViewOnGithub.tsx";
 //? Import post summary
 import { createTextChannelPost as previousPost } from "../../data/blog/how-create-text-channels-discord-v14.ts";
 import { createVoiceChannelPost as postSummary } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
@@ -519,14 +521,7 @@ export default function Home() {
 `}
           </div>
           {/* Code link */}
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createvoicechannel.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createvoicechannel.js" />
           <p class="my-2 text-justify">
             A few tweaks were made, variables were renamed, comments were
             updated, and error messages were updated, but the process isn't much
@@ -734,14 +729,7 @@ export default function Home() {
             <span class="shl-cmnt">// ...</span>
           </div>
           {/* Code link */}
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createvoicewithuserlimit.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createvoicewithuserlimit.js" />
           {/* line 30 quote */}
           <p class="my-2 text-justify">
             There are a few key points that need to be talked about. The first

--- a/routes/blog/how-create-voice-channels-discord-v14.tsx
+++ b/routes/blog/how-create-voice-channels-discord-v14.tsx
@@ -10,8 +10,9 @@ import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? A HTML Link component to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
 //? Import post summary
-import { createVoiceChannelPost as postSummary } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
 import { createTextChannelPost as previousPost } from "../../data/blog/how-create-text-channels-discord-v14.ts";
+import { createVoiceChannelPost as postSummary } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
+import { createCategoryPost as nextPost } from "../../data/blog/how-create-categories-discord-v14.ts";
 
 export default function Home() {
   return (
@@ -27,6 +28,7 @@ export default function Home() {
         {/* Back button */}
         <NavigationButtons
           back={{ title: previousPost.title, link: previousPost.link }}
+          next={{ title: nextPost.title, link: nextPost.link }}
         />
         <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
           {/* Title header */}
@@ -826,7 +828,13 @@ export default function Home() {
 
           {/* Next post: Categories */}
           <p class="mt-4 text-justify self-start">
-            Next post: Creating Categories in Discord.JS V14
+            Next post:{" "}
+            <GradientLink
+              link={nextPost.link}
+              title={nextPost.title}
+              content={nextPost.title}
+              newTab={false}
+            />
           </p>
           {/* Post author */}
           <footer class="mt-auto w-full text-right text-sm">

--- a/routes/blog/how-create-voice-channels-discord-v14.tsx
+++ b/routes/blog/how-create-voice-channels-discord-v14.tsx
@@ -1,0 +1,839 @@
+//? Head component with all Meta tags pre-set
+import { CustomHead } from "../../components/base/CustomHead.tsx";
+//? Lateral text with theme switcher
+import { Base } from "../../components/base/Base.tsx";
+//? Default styled headers
+import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
+import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
+//? Navigation Buttons to go back to the previous page or to the next page (optional)
+import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
+//? A HTML Link component to pre-format links and reduce boiletplate
+import { GradientLink } from "../../components/UI/GradientLink.tsx";
+//? Import post summary
+import { createVoiceChannelPost as postSummary } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
+import { createTextChannelPost as previousPost } from "../../data/blog/how-create-text-channels-discord-v14.ts";
+
+export default function Home() {
+  return (
+    <>
+      <CustomHead
+        title={postSummary.title}
+        description={postSummary.shortSummary}
+        link={"https://www.theyurig.com" + postSummary.link}
+      >
+      </CustomHead>
+      {/* Base page layout with theme switching and footer outside of accent box */}
+      <Base>
+        {/* Back button */}
+        <NavigationButtons
+          back={{ title: previousPost.title, link: previousPost.link }}
+        />
+        <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
+          {/* Title header */}
+          <StyledHeader title={postSummary.title} />
+          {/* Post creation date */}
+          <p class="text-sm mb-2 w-full text-center">
+            {new Date(postSummary.date).toLocaleString()}
+          </p>
+          {/* Medium alternative */}
+          <p class="mb-4 self-start text-xs">
+            This is the second (of four) parts of the Discord.JS V14 tutorial
+            that I've published. You can read the{" "}
+            <GradientLink
+              link={previousPost.link}
+              title={previousPost.title}
+              content="first part"
+              customRel="prev"
+              newTab={false}
+            />{" "}
+            here. You can also read the full version of this tutorial on{" "}
+            <GradientLink
+              link="https://medium.com/@yuri03042/how-to-create-categories-text-channels-threads-voice-channels-and-roles-in-discord-js-v14-1f2664546433"
+              title="Medium version alternative"
+              content="Medium"
+              customRel="noopener noreferrer"
+            />{" "}
+            if you prefer.
+          </p>
+          {/* Introduction */}
+          <p class="my-2 text-justify">
+            Creating a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            isn't that much different than creating a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text Channel"
+              customRel="noopener noreferrer"
+            />.{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            won't get their names normalized to lowercase and have their spaces
+            replaced by dashes, so whatever you write will be what will be used.
+            Because of how similar{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice"
+              customRel="noopener noreferrer"
+            />{" "}
+            and{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            are, we can reuse most of the code we used for the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            and make small adjustments.
+          </p>
+
+          {/* Creating Voice Channel code block */}
+          <div class="shl-block">
+            <span class="shl-cmnt">
+              // Importing SlashCommandBuilder is required for every slash
+              command{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // We import PermissionFlagsBits so we can restrict this command
+              usage{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // We also import ChannelType to define what kind of Channel we
+              are creating{`
+`}
+            </span>
+            <span class="shl-kwd">const</span> &#123;{" "}
+            <span class="shl-class">SlashCommandBuilder</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-class">PermissionFlagsBits</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-class">ChannelType</span> &#125;{" "}
+            <span class="shl-oper">=</span>{" "}
+            <span class="shl-func">require</span>({`
+  `}
+            <span class="shl-str">"discord.js"</span>
+            <span class="shl-oper">,</span>
+            {`
+`});{`
+`}module<span class="shl-oper">.</span>exports <span class="shl-oper">=</span>
+            {" "}
+            &#123;{`
+  `}data<span class="shl-oper">:</span> <span class="shl-kwd">new</span>{" "}
+            <span class="shl-class">SlashCommandBuilder</span>(){`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "createvoicechannel"
+            </span>){" "}
+            <span class="shl-cmnt">// Command name matching file name</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              "Creates a new voice channel"
+            </span>){`
+    `}
+            <span class="shl-cmnt">// Voice Channel name</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addStringOption</span>((option){" "}
+            <span class="shl-kwd">=&gt;</span>
+            {`
+      `}option{`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              "voicechannelname"
+            </span>){" "}
+            <span class="shl-cmnt">
+              // option names need to always be lowercase and have no spaces
+            </span>
+            {`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>(<span class="shl-str">
+              "Choose the name to give to the voice channel"
+            </span>){`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMinLength</span>(<span class="shl-num">
+              1
+            </span>){" "}
+            <span class="shl-cmnt">// A Voice Channel needs to be named</span>
+            {`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMaxLength</span>(<span class="shl-num">
+              25
+            </span>){" "}
+            <span class="shl-cmnt">
+              // Discord will cut-off names past the 25 characters,
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">
+              // so that's a good hard limit to set. You can manually increase
+              this if you wish
+            </span>
+            {`
+        `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setRequired</span>(<span class="shl-bool">
+              true
+            </span>){`
+    `}){`
+    `}
+            <span class="shl-cmnt">
+              // You will usually only want users that can create new Channels
+              to
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // be able to use this command and this is what this line does.
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // Feel free to remove it if you want to allow any users to
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">// create new Channels</span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">
+              setDefaultMemberPermissions
+            </span>(<span class="shl-class">PermissionFlagsBits</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">ManageChannels</span>){`
+    `}
+            <span class="shl-cmnt">
+              // It's impossible to create Voice Channels inside DMs, so
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // it's in your best interest in disabling this command through
+              DMs
+            </span>
+            {`
+    `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">
+              setDMPermission
+            </span>(<span class="shl-bool">false</span>)<span class="shl-oper">
+              ,
+            </span>
+            {`
+  `}
+            <span class="shl-kwd">async</span>{" "}
+            <span class="shl-func">execute</span>(interaction) &#123;{`
+    `}
+            <span class="shl-cmnt">
+              // Before executing any other code, we need to acknowledge the
+              interaction.
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // Discord only gives us 3 seconds to acknowledge an interaction
+              before
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // the interaction gets voided and can't be used anymore.
+            </span>
+            {`
+    `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">reply</span>(&#123;{`
+      `}content<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">
+              "Fetched all input and working on your request!"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+    `}&#125;);{`
+
+    `}
+            <span class="shl-cmnt">
+              // After acknowledging the interaction, we retrieve the string
+              sent by the user
+            </span>
+            {`
+    `}
+            <span class="shl-kwd">const</span> chosenVoiceChannelName{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getString</span>({`
+      `}
+            <span class="shl-str">"voicechannelname"</span>
+            <span class="shl-oper">,</span>
+            {`
+    `});{`
+    `}
+            <span class="shl-cmnt">
+              // Do note that the string passed to the method .getString() needs
+              to
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // match EXACTLY the name of the option provided (line 12 in this
+              file).
+            </span>
+            {`
+    `}
+            <span class="shl-cmnt">
+              // If it's not a perfect match, this will always return null
+            </span>
+            {`
+
+    `}
+            <span class="shl-kwd">try</span> &#123;{`
+      `}
+            <span class="shl-cmnt">
+              // Check if this Channel where the command was used is stray
+            </span>
+            {`
+      `}
+            <span class="shl-kwd">if</span>{" "}
+            (<span class="shl-oper">!</span>interaction<span class="shl-oper">
+              .
+            </span>channel<span class="shl-oper">.</span>parent) &#123;{`
+        `}
+            <span class="shl-cmnt">
+              // If the Channel where the command was used is stray,
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">
+              // create another stray Voice Channel in the server.
+            </span>
+            {`
+        `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">
+              .
+            </span>guild<span class="shl-oper">
+              .
+            </span>channels<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+          `}name<span class="shl-oper">:</span>{" "}
+            chosenVoiceChannelName<span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The name given to the Channel by the user
+            </span>
+            {`
+          `}type<span class="shl-oper">:</span>{" "}
+            <span class="shl-class">ChannelType</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">GuildVoice</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">// The type of the Channel created.</span>
+            {`
+        `}&#125;);{`
+        `}
+            <span class="shl-cmnt">
+              // Notice how we are creating a Channel in the list of Channels
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">
+              // of the server. This will cause the Channel to spawn at the top
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">
+              // of the Channels list, without belonging to any Categories
+            </span>
+            {`
+
+        `}
+            <span class="shl-cmnt">
+              // If we managed to create the Channel, edit the initial response
+              with
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">// a success message</span>
+            {`
+        `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">editReply</span>(&#123;{`
+          `}content<span class="shl-oper">:</span>{" "}
+            <span class="shl-str">
+              "Your voice channel was successfully created!"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+        `}&#125;);{`
+        `}
+            <span class="shl-kwd">return</span>;{`
+      `}&#125;{`
+
+      `}
+            <span class="shl-cmnt">
+              // Check if this Channel where the command was used belongs to a
+              Category
+            </span>
+            {`
+      `}
+            <span class="shl-kwd">if</span> (interaction<span class="shl-oper">
+              .
+            </span>channel<span class="shl-oper">.</span>parent) &#123;{`
+        `}
+            <span class="shl-cmnt">
+              // If the Channel where the command belongs to a Category,
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">
+              // create another Channel in the same Category.
+            </span>
+            {`
+        `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">
+              .
+            </span>channel<span class="shl-oper">
+              .
+            </span>parent<span class="shl-oper">
+              .
+            </span>children<span class="shl-oper">.</span>
+            <span class="shl-func">create</span>(&#123;{`
+          `}name<span class="shl-oper">:</span>{" "}
+            chosenVoiceChannelName<span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The name given to the Channel by the user
+            </span>
+            {`
+          `}type<span class="shl-oper">:</span>{" "}
+            <span class="shl-class">ChannelType</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">GuildVoice</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">// The type of the Channel created.</span>
+            {`
+        `}&#125;);{`
+
+        `}
+            <span class="shl-cmnt">
+              // If we managed to create the Channel, edit the initial response
+              with
+            </span>
+            {`
+        `}
+            <span class="shl-cmnt">// a success message</span>
+            {`
+        `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">editReply</span>(&#123;{`
+          `}content<span class="shl-oper">:</span>
+            {`
+            `}
+            <span class="shl-str">
+              "Your voice channel was successfully created in the same
+              category!"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+        `}&#125;);{`
+        `}
+            <span class="shl-kwd">return</span>;{`
+      `}&#125;{`
+    `}&#125; <span class="shl-kwd">catch</span> (error) &#123;{`
+      `}
+            <span class="shl-cmnt">
+              // If an error occurred and we were not able to create the Channel
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // the bot is most likely received the "Missing Permissions"
+              error.
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">// Log the error to the console</span>
+            {`
+      `}console<span class="shl-oper">.</span>
+            <span class="shl-func">log</span>(error);{`
+      `}
+            <span class="shl-cmnt">
+              // Also inform the user that an error occurred and give them
+              feedback
+            </span>
+            {`
+      `}
+            <span class="shl-cmnt">
+              // about how to avoid this error if they want to try again
+            </span>
+            {`
+      `}
+            <span class="shl-kwd">await</span>{" "}
+            interaction<span class="shl-oper">.</span>
+            <span class="shl-func">editReply</span>(&#123;{`
+        `}content<span class="shl-oper">:</span>
+            {`
+          `}
+            <span class="shl-str">
+              "Your voice channel could not be created! Please check if the bot
+              has the necessary permissions!"
+            </span>
+            <span class="shl-oper">,</span>
+            {`
+      `}&#125;);{`
+    `}&#125;{`
+  `}&#125;<span class="shl-oper">,</span>
+            {`
+`}&#125;;{`
+`}
+          </div>
+          {/* Code link */}
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createvoicechannel.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
+          <p class="my-2 text-justify">
+            A few tweaks were made, variables were renamed, comments were
+            updated, and error messages were updated, but the process isn't much
+            different from creating a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text Channel"
+              customRel="noopener noreferrer"
+            />. One of the few features that{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            have over{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/TextChannel"
+              title="TextChannel (D.JS Docs)"
+              content="Text Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            is the ability to limit the number of users it can hold at once.
+            Let's take a look at how to do that now.
+          </p>
+
+          {/* Creating Voice Channel with member limit */}
+          <StyledSubHeader title="Create a Voice Channel that has a maximum number of concurrent users" />
+          <p class="my-2 text-justify">
+            One of the exclusive features that{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channels"
+              customRel="noopener noreferrer"
+            />{" "}
+            have over other Channels is the ability to{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel?scrollTo=userLimit"
+              title="userLimit property (D.JS Docs)"
+              content="limit"
+              customRel="noopener noreferrer"
+            />{" "}
+            the number of users that can use it at the same time. To set this
+            number, all you gotta do is pass in an integer for the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel?scrollTo=userLimit"
+              title="userLimit property (D.JS Docs)"
+              content="userLimit"
+              customRel="noopener noreferrer"
+            />{" "}
+            key when creating a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channel"
+              customRel="noopener noreferrer"
+            />.
+          </p>
+          {/* Voice Channel with member limit code block  */}
+          <div class="shl-block">
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // initial code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+  `}
+            <span class="shl-cmnt">
+              // Voice Channel limit of participants{`
+`}
+            </span>
+            <span class="shl-oper">.</span>
+            <span class="shl-func">addIntegerOption</span>({`
+    `}(option) <span class="shl-kwd">=&gt;</span>
+            {`
+        `}option{`
+            `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setName</span>(<span class="shl-str">
+              'voiceuserlimit'
+            </span>){" "}
+            <span class="shl-cmnt">
+              // option names need to always be lowercase and have no spaces
+            </span>
+            {`
+            `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setDescription</span>({`
+                `}
+            <span class="shl-str">
+              'Select the maximum number of concurrent users for the voice
+              channel'
+            </span>
+            {`
+            `}){`
+            `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setMinValue</span>(<span class="shl-num">
+              2
+            </span>){" "}
+            <span class="shl-cmnt">
+              // A voice Channel with less than 2 users will be useless
+            </span>
+            {`
+            `}
+            <span class="shl-cmnt">
+              // for nearly every case, so we will disable users from creating
+              voice
+            </span>
+            {`
+            `}
+            <span class="shl-cmnt">
+              // Channels that can take less than that
+            </span>
+            {`
+            `}
+            <span class="shl-oper">.</span>
+            <span class="shl-func">setRequired</span>(<span class="shl-bool">
+              false
+            </span>){`
+`}){`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+    `}
+            <span class="shl-cmnt">
+              // After acknowledging the interaction, we retrieve the input sent
+              by the user
+            </span>
+            {`
+    `}
+            <span class="shl-kwd">const</span> chosenVoiceChannelName{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getString</span>(<span class="shl-str">
+              'voicechannelname'
+            </span>);{`
+    `}
+            <span class="shl-kwd">const</span> voiceChannelUserLimit{" "}
+            <span class="shl-oper">=</span> interaction<span class="shl-oper">
+              .
+            </span>options<span class="shl-oper">.</span>
+            <span class="shl-func">getInteger</span>(<span class="shl-str">
+              'voiceuserlimit'
+            </span>) <span class="shl-oper">??</span>{" "}
+            <span class="shl-num">undefined</span>;{`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // code in between unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+            {`
+
+    `}name<span class="shl-oper">:</span>{" "}
+            chosenVoiceChannelName<span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">
+              // The name given to the Channel by the user
+            </span>
+            {`
+    `}type<span class="shl-oper">:</span>{" "}
+            <span class="shl-class">ChannelType</span>
+            <span class="shl-oper">.</span>
+            <span class="shl-class">GuildVoice</span>
+            <span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">// The type of the Channel created.</span>
+            {`
+    `}userLimit<span class="shl-oper">:</span>{" "}
+            voiceChannelUserLimit<span class="shl-oper">,</span>{" "}
+            <span class="shl-cmnt">// The max number of concurrent users</span>
+            {`
+
+`}
+            <span class="shl-cmnt">
+              // ...{`
+`}
+            </span>
+            <span class="shl-cmnt">
+              // rest of the code unchanged{`
+`}
+            </span>
+            <span class="shl-cmnt">// ...</span>
+          </div>
+          {/* Code link */}
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createvoicewithuserlimit.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
+          {/* line 30 quote */}
+          <p class="my-2 text-justify">
+            There are a few key points that need to be talked about. The first
+            of them is that we are not requiring the limit to be set
+            (<GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createvoicewithuserlimit.js#L30"
+              title="view source"
+              content="line 30"
+              customRel="noopener noreferrer"
+            />). This allows the user to set a limit if they want but also
+            allows the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            to be unlimited if they don't.
+          </p>
+          <q className="custom-quote italic self-start">
+            const voiceChannelUserLimit =
+            interaction.options.getInteger('voiceuserlimit') ?? undefined;
+          </q>
+          {/* line 49 quote */}
+          <p class="my-2 text-justify">
+            To avoid this causing an error when creating the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channel"
+              customRel="noopener noreferrer"
+            />, we check (<GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/4fc83cf7d08c20fc43cc0018d24db2eb9ff33ae1/discord_create_channels/commands/createvoicewithuserlimit.js#L49"
+              title="view source"
+              content="line 49"
+              customRel="noopener noreferrer"
+            />) if a value was passed and, if{" "}
+            <span class="shl-inline">
+              .getInteger()
+            </span>{" "}
+            returns us{" "}
+            <span class="shl-inline">
+              null
+            </span>
+            , then then the{" "}
+            <GradientLink
+              link="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing"
+              title="Nullish Coalescence (MDN Docs)"
+              content="Javascript Nullish Coalescence"
+              customRel="noopener noreferrer"
+            />{" "}
+            operator <span class="shl-inline">??</span> will set the value to
+            {" "}
+            <span class="shl-inline">
+              undefined
+            </span>
+            .
+          </p>
+          <q className="custom-quote italic self-start">
+            userLimit: voiceChannelUserLimit
+          </q>
+          <p class="my-2 text-justify">
+            Passing{" "}
+            <span class="shl-inline">
+              undefined
+            </span>{" "}
+            to the{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel?scrollTo=userLimit"
+              title="userLimit property (D.JS Docs)"
+              content="userLimit"
+              customRel="noopener noreferrer"
+            />{" "}
+            key when creating a{" "}
+            <GradientLink
+              link="https://discord.js.org/#/docs/discord.js/main/class/VoiceChannel"
+              title="VoiceChannel (D.JS Docs)"
+              content="Voice Channel"
+              customRel="noopener noreferrer"
+            />{" "}
+            will make it unlimited, while any integer would be used as the
+            actual limit.
+          </p>
+
+          {/* Next post: Categories */}
+          <p class="mt-4 text-justify self-start">
+            Next post: Creating Categories in Discord.JS V14
+          </p>
+          {/* Post author */}
+          <footer class="mt-auto w-full text-right text-sm">
+            Written with 💞 by TheYuriG
+          </footer>
+        </article>
+      </Base>
+    </>
+  );
+}

--- a/routes/blog/how-create-voice-channels-discord-v14.tsx
+++ b/routes/blog/how-create-voice-channels-discord-v14.tsx
@@ -761,7 +761,7 @@ export default function Home() {
             />{" "}
             to be unlimited if they don't.
           </p>
-          <q className="custom-quote italic self-start">
+          <q class="custom-quote italic self-start">
             const voiceChannelUserLimit =
             interaction.options.getInteger('voiceuserlimit') ?? undefined;
           </q>
@@ -800,7 +800,7 @@ export default function Home() {
             </span>
             .
           </p>
-          <q className="custom-quote italic self-start">
+          <q class="custom-quote italic self-start">
             userLimit: voiceChannelUserLimit
           </q>
           <p class="my-2 text-justify">

--- a/routes/blog/index.tsx
+++ b/routes/blog/index.tsx
@@ -11,14 +11,16 @@ import BlogPostSummaryProperties from "../../types/BlogPostSummaryProperties.ts"
 //? Import posts
 import { createFreshThemeSwitcher } from "../../data/blog/how-create-theme-switcher-deno-fresh.ts";
 import { stopThemeFlickering } from "../../data/blog/stopping-theme-flickering-deno-fresh.ts";
-import { createChannelPost } from "../../data/blog/how-create-text-channels-discord-v14.ts";
-createChannelPost;
+import { createTextChannelPost } from "../../data/blog/how-create-text-channels-discord-v14.ts";
+createTextChannelPost;
+import { createVoiceChannelPost } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
 
 //? All posts so far
 const createdPosts: Array<BlogPostSummaryProperties> = [
   stopThemeFlickering,
   createFreshThemeSwitcher,
-  createChannelPost,
+  createVoiceChannelPost,
+  createTextChannelPost,
 ];
 
 export default function Home() {

--- a/routes/blog/index.tsx
+++ b/routes/blog/index.tsx
@@ -8,21 +8,15 @@ import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 import { BlogPostSummary } from "../../components/blog/BlogPostSummary.tsx";
 //? Import the types so that it doesn't need to be interfaced twice
 import BlogPostSummaryProperties from "../../types/BlogPostSummaryProperties.ts";
+//? Import posts
+import { createFreshThemeSwitcher } from "../../data/blog/how-create-theme-switcher-deno-fresh.ts";
+import { stopThemeFlickering } from "../../data/blog/stopping-theme-flickering-deno-fresh.ts";
 
 //? All posts so far
-const createdPosts: Array<BlogPostSummaryProperties> = [{
-  link: "/how-create-theme-switcher-deno-fresh",
-  title: "How to Create a Theme Switcher with Fresh",
-  shortSummary:
-    "A guide on how to create your own Theme Switcher using Deno and Fresh",
-  date: 1684849328672,
-}, {
-  link: "/stopping-theme-flickering-deno-fresh",
-  title: "How to stop Theme flickering in Fresh",
-  shortSummary:
-    "A guide on how to make your Theme Switcher stop flickering when the page loads",
-  date: 1684951466007,
-}];
+const createdPosts: Array<BlogPostSummaryProperties> = [
+  stopThemeFlickering,
+  createFreshThemeSwitcher,
+];
 
 export default function Home() {
   return (

--- a/routes/blog/index.tsx
+++ b/routes/blog/index.tsx
@@ -14,11 +14,13 @@ import { stopThemeFlickering } from "../../data/blog/stopping-theme-flickering-d
 import { createTextChannelPost } from "../../data/blog/how-create-text-channels-discord-v14.ts";
 createTextChannelPost;
 import { createVoiceChannelPost } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
+import { createCategoryPost } from "../../data/blog/how-create-categories-discord-v14.ts";
 
 //? All posts so far
 const createdPosts: Array<BlogPostSummaryProperties> = [
   stopThemeFlickering,
   createFreshThemeSwitcher,
+  createCategoryPost,
   createVoiceChannelPost,
   createTextChannelPost,
 ];

--- a/routes/blog/index.tsx
+++ b/routes/blog/index.tsx
@@ -11,11 +11,14 @@ import BlogPostSummaryProperties from "../../types/BlogPostSummaryProperties.ts"
 //? Import posts
 import { createFreshThemeSwitcher } from "../../data/blog/how-create-theme-switcher-deno-fresh.ts";
 import { stopThemeFlickering } from "../../data/blog/stopping-theme-flickering-deno-fresh.ts";
+import { createChannelPost } from "../../data/blog/how-create-text-channels-discord-v14.ts";
+createChannelPost;
 
 //? All posts so far
 const createdPosts: Array<BlogPostSummaryProperties> = [
   stopThemeFlickering,
   createFreshThemeSwitcher,
+  createChannelPost,
 ];
 
 export default function Home() {

--- a/routes/blog/index.tsx
+++ b/routes/blog/index.tsx
@@ -12,14 +12,15 @@ import BlogPostSummaryProperties from "../../types/BlogPostSummaryProperties.ts"
 import { createFreshThemeSwitcher } from "../../data/blog/how-create-theme-switcher-deno-fresh.ts";
 import { stopThemeFlickering } from "../../data/blog/stopping-theme-flickering-deno-fresh.ts";
 import { createTextChannelPost } from "../../data/blog/how-create-text-channels-discord-v14.ts";
-createTextChannelPost;
 import { createVoiceChannelPost } from "../../data/blog/how-create-voice-channels-discord-v14.ts";
 import { createCategoryPost } from "../../data/blog/how-create-categories-discord-v14.ts";
+import { createRolesPost } from "../../data/blog/how-create-roles-discord-v14.ts";
 
 //? All posts so far
 const createdPosts: Array<BlogPostSummaryProperties> = [
   stopThemeFlickering,
   createFreshThemeSwitcher,
+  createRolesPost,
   createCategoryPost,
   createVoiceChannelPost,
   createTextChannelPost,

--- a/routes/blog/stopping-theme-flickering-deno-fresh.tsx
+++ b/routes/blog/stopping-theme-flickering-deno-fresh.tsx
@@ -11,14 +11,17 @@ import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
 //? Create a greek list of contents
 import { GreekList } from "../../components/UI/GreekList.tsx";
+//? Import posts
+import { stopThemeFlickering as postSummary } from "../../data/blog/stopping-theme-flickering-deno-fresh.ts";
+import { createFreshThemeSwitcher as previousPost } from "../../data/blog/how-create-theme-switcher-deno-fresh.ts";
 
 export default function Home() {
   return (
     <>
       <CustomHead
-        title="How to stop Theme flickering in Fresh"
-        description="A guide on how to make your Theme Switcher to no longer flicker when the page loads."
-        link="https://www.theyurig.com/blog/stopping-theme-flickering-deno-fresh"
+        title={postSummary.title}
+        description={postSummary.shortSummary}
+        link={"https://www.theyurig.com" + postSummary.link}
       >
       </CustomHead>
       {/* Base page layout with theme switching and footer outside of accent box */}
@@ -26,16 +29,16 @@ export default function Home() {
         {/* Back button */}
         <NavigationButtons
           back={{
-            title: "Read again: Part 1 - Creating a Theme Switcher",
-            link: "/blog/how-create-theme-switcher-deno-fresh",
+            title: previousPost.title,
+            link: previousPost.link,
           }}
         />
         <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
           {/* Title header */}
-          <StyledHeader title="How to stop Theme flickering in Fresh" />
+          <StyledHeader title={postSummary.title} />
           {/* Post creation date */}
           <p class="text-sm mb-2 w-full text-center">
-            {new Date(1684951466007).toLocaleString()}
+            {new Date(postSummary.date).toLocaleString()}
           </p>
           {/* Blog post opening image */}
           <img
@@ -48,8 +51,8 @@ export default function Home() {
           <p class="my-2 text-justify">
             In the{" "}
             <GradientLink
-              link="/blog/how-create-theme-switcher-deno-fresh"
-              title="Part 1 of this blog post. You read that before, right...?"
+              link={previousPost.link}
+              title={previousPost.title}
               content="previous post"
               customRel="prev"
             />

--- a/routes/blog/stopping-theme-flickering-deno-fresh.tsx
+++ b/routes/blog/stopping-theme-flickering-deno-fresh.tsx
@@ -171,7 +171,13 @@ export default function Home() {
             Let's have a look:
           </p>
           {/* Code block with initial implementation */}
-          <div class="shl-block">
+          <div class="shl-block self-start">
+            <span class="shl-kwd">import</span> &#123;{" "}
+            <span class="shl-class">Head</span> &#125;{" "}
+            <span class="shl-kwd">from</span>{" "}
+            <span class="shl-str">"$fresh/runtime.ts"</span>;{`
+            
+`}
             <span class="shl-cmnt">
               // /routes/index.tsx (but can be any page){`
 `}
@@ -221,7 +227,7 @@ export default function Home() {
           <p class="my-2 text-justify self-start">
             And inside the script file:
           </p>
-          <div class="shl-block">
+          <div class="shl-block self-start">
             <span class="shl-cmnt">
               // /static/themeSwitcher.js{`
 `}
@@ -345,7 +351,7 @@ export default function Home() {
           <p class="my-2 text-justify self-start">
             Now all we gotta do is update our component and we are done!
           </p>
-          <div class="shl-block">
+          <div class="shl-block self-start">
             <span class="shl-cmnt">
               // /islands/themeSwitcher.tsx (updated){`
 `}

--- a/routes/blog/stopping-theme-flickering-deno-fresh.tsx
+++ b/routes/blog/stopping-theme-flickering-deno-fresh.tsx
@@ -9,6 +9,8 @@ import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? A HTML Link component to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+//? Create a greek list of contents
+import { GreekList } from "../../components/UI/GreekList.tsx";
 
 export default function Home() {
   return (
@@ -131,31 +133,18 @@ export default function Home() {
             It's possible that we can ship the required Javascript on every
             page, but in doing so, you need to understand the tradeoffs:
           </p>
-          <ol
-            start={1}
-            class="self-start list-[lower-greek]"
-          >
-            <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
-              You introduce consistent overhead to every page load, which will
-              progressively worsen your Lighthouse page performance score, the
-              more you do it.
-            </li>
-            <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
-              You are deviating from the main design choice for the framework,
-              which means that you will not find a lot of resources to do things
-              this way from this point onwards. If you have questions, you will
-              have to mostly figure something out by yourself.
-            </li>
-          </ol>
-          <p class="my-2 text-justify">
-            At this point, I have to ask you: Is this feature essential for your
-            project? Is the design of your website impossible to be done in a
-            happy medium between Light and Dark modes? If the answer to both of
-            these questions is "yes", we can now start looking into how to break
-            the rules.
-          </p>
+          <GreekList
+            items={[
+              "You introduce consistent overhead to every page load, which will progressively worsen your Lighthouse page performance score, the more you do it.",
+              "You are deviating from the main design choice for the framework, which means that you will not find a lot of resources to do things this way from this point onwards. If you have questions, you will have to mostly figure something out by yourself.",
+            ]}
+          />
+          At this point, I have to ask you: Is this feature essential for your
+          project? Is the design of your website impossible to be done in a
+          happy medium between Light and Dark modes? If the answer to both of
+          these questions is "yes", we can now start looking into how to break
+          the rules.
           {/* Script tag warning */}
-          {/*  */}
           <StyledSubHeader title="Adding a script file to every response" />
           <p class="my-2 text-justify">
             Be very careful about the <code class="shl-inline">script</code>
@@ -229,7 +218,9 @@ export default function Home() {
     `});{`
 `}&#125;
           </div>
-          <p class="my-2 text-justify">And inside the script file:</p>
+          <p class="my-2 text-justify self-start">
+            And inside the script file:
+          </p>
           <div class="shl-block">
             <span class="shl-cmnt">
               // /static/themeSwitcher.js{`
@@ -318,38 +309,40 @@ export default function Home() {
             <span class="shl-str">"rgb(220 38 38)"</span>);{`
 `}&#125;
           </div>
-          <p class="my-2 text-justify">In order:</p>
-          <ol
-            start={1}
-            class="self-start list-[lower-greek]"
-          >
-            <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
-              Check if there is a theme already saved on{" "}
-              <code class="shl-inline">localStorage</code>. If there isn't one,
-              check what's the user preferred color scheme, save it, and set
-              {" "}
-              <code class="shl-inline">
-                window.showDarkMode
-              </code>
-              . If there is, you just set{" "}
-              <code class="shl-inline">window.showDarkMode</code>{" "}
-              on/off based on the saved theme.
-            </li>
-            <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
-              Check window.showDarkMode and apply the colors to the{" "}
-              <code class="shl-inline">root</code>{"  "}
-              element for either mode based on that being{" "}
-              <code class="shl-inline">
-                true
-              </code>{" "}
-              or{" "}
-              <code class="shl-inline">
-                false
-              </code>
-              .
-            </li>
-          </ol>
-          <p class="my-2 text-justify">
+          <p class="my-2 text-justify self-start">In order:</p>
+          <GreekList
+            items={[
+              <p>
+                Check if there is a theme already saved on{" "}
+                <code class="shl-inline">localStorage</code>. If there isn't
+                one, check what's the user preferred color scheme, save it, and
+                set{" "}
+                <code class="shl-inline">
+                  window.showDarkMode
+                </code>
+                . If there is, you just set{" "}
+                <code class="shl-inline">window.showDarkMode</code>{" "}
+                on/off based on the saved theme.
+              </p>,
+              <p>
+                Check{" "}
+                <code class="shl-inline">
+                  window.showDarkMode
+                </code>{" "}
+                and apply the colors to the <code class="shl-inline">root</code>
+                {"  "}element for either mode based on that being{" "}
+                <code class="shl-inline">
+                  true
+                </code>{" "}
+                or{" "}
+                <code class="shl-inline">
+                  false
+                </code>
+                .
+              </p>,
+            ]}
+          />
+          <p class="my-2 text-justify self-start">
             Now all we gotta do is update our component and we are done!
           </p>
           <div class="shl-block">

--- a/routes/blog/stopping-theme-flickering-deno-fresh.tsx
+++ b/routes/blog/stopping-theme-flickering-deno-fresh.tsx
@@ -11,6 +11,8 @@ import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
 //? Create a greek list of contents
 import { GreekList } from "../../components/UI/GreekList.tsx";
+//? Display a link to view the source code on GitHub
+import { ViewOnGitHub } from "../../components/misc/ViewOnGithub.tsx";
 //? Import posts
 import { stopThemeFlickering as postSummary } from "../../data/blog/stopping-theme-flickering-deno-fresh.ts";
 import { createFreshThemeSwitcher as previousPost } from "../../data/blog/how-create-theme-switcher-deno-fresh.ts";
@@ -227,14 +229,7 @@ export default function Home() {
     `});{`
 `}&#125;
           </div>
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/deno_how_to_stop_theme_flickering/routes/index.tsx"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/deno_how_to_stop_theme_flickering/routes/index.tsx" />
           <p class="my-2 text-justify self-start">
             And inside the script file:
           </p>
@@ -326,14 +321,7 @@ export default function Home() {
             <span class="shl-str">"rgb(220 38 38)"</span>);{`
 `}&#125;
           </div>
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/deno_how_to_stop_theme_flickering/static/themeSwitcher.js"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/deno_how_to_stop_theme_flickering/static/themeSwitcher.js" />
           <p class="my-2 text-justify self-start">In order:</p>
           <GreekList
             items={[
@@ -417,14 +405,7 @@ export default function Home() {
 `}
             <span class="shl-oper">...</span>
           </div>
-          <p class="self-start mb-4">
-            <GradientLink
-              link="https://github.com/TheYuriG/blog_lessons/blob/master/deno_how_to_stop_theme_flickering/islands/finalThemeSwitcher.tsx"
-              title="Link to this file on GitHub"
-              content="View/Download file"
-              customRel="noopener noreferrer"
-            />
-          </p>
+          <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/deno_how_to_stop_theme_flickering/islands/finalThemeSwitcher.tsx" />
           <p class="my-2 text-justify">
             Because{" "}
             <code class="shl-inline">

--- a/routes/blog/stopping-theme-flickering-deno-fresh.tsx
+++ b/routes/blog/stopping-theme-flickering-deno-fresh.tsx
@@ -172,14 +172,14 @@ export default function Home() {
           </p>
           {/* Code block with initial implementation */}
           <div class="shl-block self-start">
-            <span class="shl-kwd">import</span> &#123;{" "}
-            <span class="shl-class">Head</span> &#125;{" "}
-            <span class="shl-kwd">from</span>{" "}
-            <span class="shl-str">"$fresh/runtime.ts"</span>;{`
-            
-`}
             <span class="shl-cmnt">
               // /routes/index.tsx (but can be any page){`
+`}
+              <span class="shl-kwd">import</span> &#123;{" "}
+              <span class="shl-class">Head</span> &#125;{" "}
+              <span class="shl-kwd">from</span>{" "}
+              <span class="shl-str">"$fresh/runtime.ts"</span>;{`
+            
 `}
             </span>
             <span class="shl-kwd">export</span>{" "}
@@ -224,6 +224,14 @@ export default function Home() {
     `});{`
 `}&#125;
           </div>
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/deno_how_to_stop_theme_flickering/routes/index.tsx"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
           <p class="my-2 text-justify self-start">
             And inside the script file:
           </p>
@@ -315,6 +323,14 @@ export default function Home() {
             <span class="shl-str">"rgb(220 38 38)"</span>);{`
 `}&#125;
           </div>
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/deno_how_to_stop_theme_flickering/static/themeSwitcher.js"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
           <p class="my-2 text-justify self-start">In order:</p>
           <GreekList
             items={[
@@ -398,6 +414,14 @@ export default function Home() {
 `}
             <span class="shl-oper">...</span>
           </div>
+          <p class="self-start mb-4">
+            <GradientLink
+              link="https://github.com/TheYuriG/blog_lessons/blob/master/deno_how_to_stop_theme_flickering/islands/finalThemeSwitcher.tsx"
+              title="Link to this file on GitHub"
+              content="View/Download file"
+              customRel="noopener noreferrer"
+            />
+          </p>
           <p class="my-2 text-justify">
             Because{" "}
             <code class="shl-inline">

--- a/routes/tools/index.tsx
+++ b/routes/tools/index.tsx
@@ -6,7 +6,10 @@ import { Base } from "../../components/base/Base.tsx";
 import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
+//? A HTML Link component to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+//? Create a greek list of contents
+import { GreekList } from "../../components/UI/GreekList.tsx";
 
 export default function Home() {
   return (
@@ -29,38 +32,31 @@ export default function Home() {
             one that exactly fit my needs, so I've built those things myself.
           </p>
           {/* Row of tools */}
-          <ol
-            start={1}
-            class="self-start list-[lower-greek]"
-          >
-            {/* Syntax highlighter */}
-            <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
+          <GreekList
+            items={[
+              //? Syntax highlighter
               <GradientLink
                 content="Syntax Highlight"
                 title="Create a HTML+CSS version of syntax highlight that you can paste into your React/Preact files."
                 link="/tools/syntax-highlight"
                 newTab={false}
-              />
-            </li>
-            {/* Retirement calculator */}
-            <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
+              />,
+              //? Retirement calculator
               <GradientLink
                 content="Retirement Calculator"
                 title="I love planning how to save/invest money and I love watching interest compound, so I've built a tool that helps me visualise that over time."
                 link="/tools/retirement-calculator"
                 newTab={false}
-              />
-            </li>
-            {/* Whatsapp messaging link generator */}
-            <li class="ml-10 lg:ml-0 transition-[margin-left] ease-in-out duration-500">
+              />,
+              //? Whatsapp messaging Link Generator
               <GradientLink
-                content="Whatsapp Message link generator"
+                content="Whatsapp Message Link Generator"
                 title="When I used to work with marketing, I could not find a good resouce to generate a link to message someone in WhatsApp. This tool does what I needed done back then. This tool helps manual messaging, but if this is something you are doing constantly, I suggest automating this process in another way instead or hiring someone to create a chatbot for you."
                 link="/tools/whatsapp-message-link-generator"
                 newTab={false}
-              />
-            </li>
-          </ol>
+              />,
+            ]}
+          />
         </article>
       </Base>
     </>

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -1,221 +1,118 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-
-   <url>
-
-      <loc>https://www.theyurig.com/</loc>
-
-      <lastmod>2023-06-24</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/work</loc>
-
-      <lastmod>2023-05-22</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/work/form</loc>
-
-      <lastmod>2023-05-22</lastmod>
-
-      <changefreq>monthly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/certificates</loc>
-
-      <lastmod>2023-05-22</lastmod>
-
-      <changefreq>monthly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/tools</loc>
-
-      <lastmod>2023-06-24</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/tools/syntax-highlight</loc>
-
-      <lastmod>2023-06-24</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/tools/retirement-calculator</loc>
-
-      <lastmod>2023-06-24</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/projects</loc>
-
-      <lastmod>2023-06-24</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/projects/expenses-tracker</loc>
-
-      <lastmod>2023-06-24</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/projects/food-order</loc>
-
-      <lastmod>2023-06-24</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/toys</loc>
-
-      <lastmod>2023-06-24</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/toys/spinners</loc>
-
-      <lastmod>2023-05-22</lastmod>
-
-      <changefreq>monthly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/toys/insanity</loc>
-
-      <lastmod>2023-05-22</lastmod>
-
-      <changefreq>monthly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/blog</loc>
-
-      <lastmod>2023-05-22</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/blog/how-create-theme-switcher-deno-fresh</loc>
-
-      <lastmod>2023-05-22</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/blog/stopping-theme-flickering-deno-fresh</loc>
-
-      <lastmod>2023-05-22</lastmod>
-
-      <changefreq>weekly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/me</loc>
-
-      <lastmod>2023-05-22</lastmod>
-
-      <changefreq>monthly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-   <url>
-
-      <loc>https://www.theyurig.com/what-is-this</loc>
-
-      <lastmod>2023-05-22</lastmod>
-
-      <changefreq>monthly</changefreq>
-
-      <priority>0.8</priority>
-
-   </url>
-
-</urlset> 
+    <!-- Main -->
+    <url>
+        <loc>https://www.theyurig.com/</loc>
+        <lastmod>2023-06-24</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <!-- Misc -->
+    <url>
+        <loc>https://www.theyurig.com/certificates</loc>
+        <lastmod>2023-05-22</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/me</loc>
+        <lastmod>2023-05-22</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/what-is-this</loc>
+        <lastmod>2023-05-22</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <!-- Work -->
+    <url>
+        <loc>https://www.theyurig.com/work</loc>
+        <lastmod>2023-05-22</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <!-- Tools -->
+    <url>
+        <loc>https://www.theyurig.com/tools</loc>
+        <lastmod>2023-06-24</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/tools/syntax-highlight</loc>
+        <lastmod>2023-06-24</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/tools/retirement-calculator</loc>
+        <lastmod>2023-06-24</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <!-- Projects -->
+    <url>
+        <loc>https://www.theyurig.com/projects</loc>
+        <lastmod>2023-06-24</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/projects/expenses-tracker</loc>
+        <lastmod>2023-06-24</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/projects/food-order</loc>
+        <lastmod>2023-06-24</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/projects/stimulus-check</loc>
+        <lastmod>2023-06-24</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <!-- Toys -->
+    <url>
+        <loc>https://www.theyurig.com/toys</loc>
+        <lastmod>2023-06-24</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/toys/spinners</loc>
+        <lastmod>2023-05-22</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/toys/insanity</loc>
+        <lastmod>2023-05-22</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <!-- Blog -->
+    <url>
+        <loc>https://www.theyurig.com/blog</loc>
+        <lastmod>2023-05-22</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/blog/how-create-theme-switcher-deno-fresh</loc>
+        <lastmod>2023-05-22</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/blog/stopping-theme-flickering-deno-fresh</loc>
+        <lastmod>2023-05-22</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+</urlset>

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -115,4 +115,28 @@
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
+    <url>
+        <loc>https://www.theyurig.com/blog/how-create-text-channels-discord-v14</loc>
+        <lastmod>2023-07-05</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/blog/how-create-voice-channels-discord-v14</loc>
+        <lastmod>2023-07-05</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/blog/how-create-categories-discord-v14</loc>
+        <lastmod>2023-07-05</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.theyurig.com/blog/how-create-roles-discord-v14</loc>
+        <lastmod>2023-07-05</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
 </urlset>

--- a/twind.config.ts
+++ b/twind.config.ts
@@ -446,11 +446,16 @@ export default {
       return { transition: transitions.join(", ") };
     },
     // Custom quote styling (should be applied on <q> HTML element)
+    //! Same 'background-color', 'color' and 'box-shadow' as syntax highlight block
     "custom-quote": {
       quotes: "none",
       "margin-left": "1em",
+      "padding": "0.5em 1em 0.5em 1em",
+      "background-color": "rgb(255, 246, 239)",
+      color: "#112",
+      "box-shadow": "0 0 1em 0.3em grey",
       "border-left": "0.25em solid var(--accent-color)",
-      "padding-left": "1em",
+      "border-radius": "0.25em",
     },
     // Button types
     "custom-button": ([buttonType]: Array<string>) => {
@@ -572,9 +577,10 @@ export default {
             "border-radius": "0.5em",
           };
         case "block":
+          //! Same 'background-color', 'color' and 'box-shadow' as custom quote
           return {
             "white-space": "pre-wrap",
-            background: "rgb(255, 246, 239)",
+            "background-color": "rgb(255, 246, 239)",
             color: "#112",
             "line-height": "1.3em",
             margin: "1em 0",

--- a/twind.config.ts
+++ b/twind.config.ts
@@ -447,14 +447,10 @@ export default {
     },
     // Custom quote styling (should be applied on <q> HTML element)
     "custom-quote": {
-      "&": {
-        quotes: "none",
-        "margin-left": "1em",
-      },
-      "&::before": {
-        "margin-right": "1em",
-        "border-left": "0.25em solid var(--accent-color)",
-      },
+      quotes: "none",
+      "margin-left": "1em",
+      "border-left": "0.25em solid var(--accent-color)",
+      "padding-left": "1em",
     },
     // Button types
     "custom-button": ([buttonType]: Array<string>) => {

--- a/twind.config.ts
+++ b/twind.config.ts
@@ -445,6 +445,17 @@ export default {
       }
       return { transition: transitions.join(", ") };
     },
+    // Custom quote styling (should be applied on <q> HTML element)
+    "custom-quote": {
+      "&": {
+        quotes: "none",
+        "margin-left": "1em",
+      },
+      "&::before": {
+        "margin-right": "1em",
+        "border-left": "0.25em solid var(--accent-color)",
+      },
+    },
     // Button types
     "custom-button": ([buttonType]: Array<string>) => {
       switch (buttonType) {


### PR DESCRIPTION
Brought post from [Medium](https://medium.com/@yuri03042/how-to-create-categories-text-channels-threads-voice-channels-and-roles-in-discord-js-v14-1f2664546433) to the `/blog` section of my website.

Additionally, this PR also does the following:
- Greek lists now use a component that handles all the classes and structure.
- Updated `sitemap.xml`.

Closes #91.