### PR TITLE
refactor: only use GradientLink for external links

### DIFF
--- a/assets/ExternalLinkIcon.tsx
+++ b/assets/ExternalLinkIcon.tsx
@@ -1,0 +1,22 @@
+//? Import IconProperties for props typecasting
+import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+
+//? Renders an External Link Icon with fill
+export function ExternalLinkIcon(
+  { iconHeight, iconWidth, iconFillColor, classes }: IconProperties & {
+    classes?: string;
+  },
+) {
+  return (
+    <svg
+      class={`custom-tr-fi ${classes}`}
+      height={iconHeight}
+      width={iconWidth}
+      fill={iconFillColor ?? "var(--neutral-color)"}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+    >
+      <path d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32h82.7L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3V192c0 17.7 14.3 32 32 32s32-14.3 32-32V32c0-17.7-14.3-32-32-32H320zM80 32C35.8 32 0 67.8 0 112V432c0 44.2 35.8 80 80 80H400c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32V432c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16H192c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z" />
+    </svg>
+  );
+}

--- a/components/UI/DottedLink.tsx
+++ b/components/UI/DottedLink.tsx
@@ -1,0 +1,20 @@
+//? Define the required and optional properties of a decorated Link
+import { DecoratedLinkProperties } from "../../types/component-properties/DecoratedLinkProperties.ts";
+
+//? Exports an anchor tag with default styling for custom-underline-dotted, while
+//? using the other attributes provided
+export function DottedLink(
+  { link, title, customRel, content }: DecoratedLinkProperties,
+) {
+  return (
+    <a
+      class="inline-flex items-center custom-underline-dotted hover:custom-tx-ac"
+      href={link}
+      title={title}
+      target="_self"
+      rel={customRel}
+    >
+      {content}
+    </a>
+  );
+}

--- a/components/UI/GradientLink.tsx
+++ b/components/UI/GradientLink.tsx
@@ -1,26 +1,20 @@
 //? Import ExternalLinkIcon to add the GradientLink
 import { ExternalLinkIcon } from "../../assets/ExternalLinkIcon.tsx";
 
-//? Define the required and optional properties of a Gradient Link
-interface GradientLinkProperties {
-  link: string;
-  title?: string;
-  newTab?: boolean;
-  customRel?: string;
-  content: string;
-}
+//? Define the required and optional properties of a Decorated Link
+import { DecoratedLinkProperties } from "../../types/component-properties/DecoratedLinkProperties.ts";
 
 //? Exports an anchor tag with default styling for custom-underline-gradient, while
 //? using the other attributes provided
 export function GradientLink(
-  { link, title, newTab = true, customRel, content }: GradientLinkProperties,
+  { link, title, customRel, content }: DecoratedLinkProperties,
 ) {
   return (
     <a
       class="inline-flex items-center custom-underline-gradient hover:custom-tx-ac"
       href={link}
       title={title}
-      target={newTab ? "_blank" : "_self"}
+      target="_blank"
       rel={customRel}
     >
       {content}

--- a/components/UI/GradientLink.tsx
+++ b/components/UI/GradientLink.tsx
@@ -1,3 +1,6 @@
+//? Import ExternalLinkIcon to add the GradientLink
+import { ExternalLinkIcon } from "../../assets/ExternalLinkIcon.tsx";
+
 //? Define the required and optional properties of a Gradient Link
 interface GradientLinkProperties {
   link: string;
@@ -14,13 +17,14 @@ export function GradientLink(
 ) {
   return (
     <a
-      class="custom-underline-gradient hover:custom-tx-ac"
+      class="inline-flex items-center custom-underline-gradient hover:custom-tx-ac"
       href={link}
       title={title}
       target={newTab ? "_blank" : "_self"}
       rel={customRel}
     >
       {content}
+      <ExternalLinkIcon iconHeight="1em" iconWidth="1em" classes="ml-1" />
     </a>
   );
 }

--- a/components/home/HomeContent.tsx
+++ b/components/home/HomeContent.tsx
@@ -41,7 +41,6 @@ export function HomeContent() {
         <GradientLink
           content="Trophy Place"
           link="https://trophy.place"
-          newTab={true}
         />{" "}
         and blogging
         {/* Blinking caret */}

--- a/components/tools/WhatsappLinksList.tsx
+++ b/components/tools/WhatsappLinksList.tsx
@@ -53,7 +53,6 @@ export function WhatsappLinksList(
 
       return (
         <GradientLink
-          newTab={true}
           content={`+${countryCode} (${areaCode}) ${phoneNumber}`}
           link={`https://wa.me/${countryCode}${areaCode}${phoneNumber}${
             messageText !== ""

--- a/routes/blog/experience-deno-fresh.tsx
+++ b/routes/blog/experience-deno-fresh.tsx
@@ -7,8 +7,9 @@ import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
-//? A HTML Link component to pre-format links and reduce boiletplate
+//? Link components to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+import { DottedLink } from "../../components/UI/DottedLink.tsx";
 //? Create a greek list of contents
 import { GreekList } from "../../components/UI/GreekList.tsx";
 //? Import the default post footer
@@ -46,18 +47,16 @@ export default function Home() {
             </strong>{" "}
             the developer experience of working with Deno and I have no
             intention to going back to Node. While the{" "}
-            <GradientLink
+            <DottedLink
               link="#good-parts"
               content="good parts"
               title="Scroll page to the good parts"
-              newTab={false}
             />{" "}
             section might be smaller than the{" "}
-            <GradientLink
+            <DottedLink
               link="#bad-parts"
               content="bad parts"
               title="Scroll page to the bad parts"
-              newTab={false}
             />{" "}
             section, I'm 100% aware that there are only{" "}
             <GradientLink
@@ -306,9 +305,9 @@ export default function Home() {
           {/* I've made a tool for this */}
           <p class="my-2 text-justify">
             If you have already visited my{" "}
-            <GradientLink
+            <DottedLink
               link="/tools"
-              content="/tools"
+              content="tools"
               title="My creations"
             />{" "}
             page, you might be wondering why I've created that. Well, this is
@@ -347,7 +346,7 @@ export default function Home() {
           {/* So I've created Syntax Highlighter */}
           <p class="my-2 text-justify">
             So that's why Ive created{" "}
-            <GradientLink
+            <DottedLink
               link="/tools/syntax-highlight"
               content="Syntax Highlight"
               title="The solution to my problem"

--- a/routes/blog/experience-deno-fresh.tsx
+++ b/routes/blog/experience-deno-fresh.tsx
@@ -64,7 +64,6 @@ export default function Home() {
               content="two types of languages"
               title="Quote by Bjarne Stroustrup"
               customRel="noopener noreferrer"
-              newTab={true}
             />.
           </p>
 
@@ -143,7 +142,6 @@ export default function Home() {
               content="happens in other languages"
               title="It's not a race to the bottom"
               customRel="noopener noreferrer"
-              newTab={true}
             />/runtimes, it sucks when it happens and it does happen a lot here.
           </p>
           {/* Why do these packages get abandoned? */}
@@ -161,7 +159,6 @@ export default function Home() {
               content="Ryan Dahl"
               title="Original creator of Node.JS"
               customRel="noopener noreferrer"
-              newTab={true}
             />, the original creator of Node. If someone out there understands
             about writing Javascript runtimes, it is the guy who made
             three<sup class="hover:custom-tx-ac custom-tr-tx underline">
@@ -420,7 +417,6 @@ export default function Home() {
               content="Deno Deploy"
               title="A runtime to deploy web applications at scale, on the edge."
               customRel="noopener noreferrer"
-              newTab={true}
             />{" "}
             is the third runtime, if you are wondering.
           </p>

--- a/routes/blog/how-create-categories-discord-v14.tsx
+++ b/routes/blog/how-create-categories-discord-v14.tsx
@@ -7,8 +7,9 @@ import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
-//? A HTML Link component to pre-format links and reduce boiletplate
+//? Link components to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+import { DottedLink } from "../../components/UI/DottedLink.tsx";
 //? Display a link to view the source code on GitHub
 import { ViewOnGitHub } from "../../components/misc/ViewOnGithub.tsx";
 //? Import the default post footer
@@ -46,12 +47,11 @@ export default function Home() {
           <p class="mb-4 self-start text-xs">
             This is the third (of four) parts of the Discord.JS V14 tutorial
             that I've published. You can read the{" "}
-            <GradientLink
+            <DottedLink
               link={previousPost.link}
               title={previousPost.title}
               content="second part"
               customRel="prev"
-              newTab={false}
             />{" "}
             here. You can also read the full version of this tutorial on{" "}
             <GradientLink
@@ -286,11 +286,10 @@ export default function Home() {
           <ViewOnGitHub githubLink="https://github.com/TheYuriG/blog_lessons/blob/master/discord_create_channels/commands/createcategory.js" />
           <p class="my-2 text-justify">
             You might have noticed if you went through the{" "}
-            <GradientLink
+            <DottedLink
               link={createTextChannelPost.link}
               title={createTextChannelPost.title}
               content="Create a Text Channel with Dynamic Names"
-              newTab={false}
             />{" "}
             lesson that very little was changed. We have renamed our variable,
             updated the command and the option name, and changed the type of
@@ -780,12 +779,11 @@ export default function Home() {
           {/* Next post: Roles */}
           <p class="mt-4 text-justify self-start">
             Next post:{" "}
-            <GradientLink
+            <DottedLink
               link={nextPost.link}
               title={nextPost.title}
               content={nextPost.title}
               customRel="next"
-              newTab={false}
             />.
           </p>
           {/* Post author */}

--- a/routes/blog/how-create-roles-discord-v14.tsx
+++ b/routes/blog/how-create-roles-discord-v14.tsx
@@ -7,8 +7,9 @@ import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
-//? A HTML Link component to pre-format links and reduce boiletplate
+//? Link components to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+import { DottedLink } from "../../components/UI/DottedLink.tsx";
 //? Display a link to view the source code on GitHub
 import { ViewOnGitHub } from "../../components/misc/ViewOnGithub.tsx";
 //? Import the default post footer
@@ -43,12 +44,11 @@ export default function Home() {
           <p class="mb-4 self-start text-xs">
             This is the fourth and last part of the Discord.JS V14 tutorial that
             I've published. You can read the{" "}
-            <GradientLink
+            <DottedLink
               link={previousPost.link}
               title={previousPost.title}
               content="third part"
               customRel="prev"
-              newTab={false}
             />{" "}
             here. You can also read the full version of this tutorial on{" "}
             <GradientLink

--- a/routes/blog/how-create-text-channels-discord-v14.tsx
+++ b/routes/blog/how-create-text-channels-discord-v14.tsx
@@ -7,8 +7,9 @@ import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
-//? A HTML Link component to pre-format links and reduce boiletplate
+//? Link components to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+import { DottedLink } from "../../components/UI/DottedLink.tsx";
 //? Create a greek list of contents
 import { GreekList } from "../../components/UI/GreekList.tsx";
 //? Display a link to view the source code on GitHub
@@ -1718,11 +1719,10 @@ export default function Home() {
           {/* Next post: voice channels */}
           <p class="mt-4 text-justify self-start">
             Next post:{" "}
-            <GradientLink
+            <DottedLink
               content={nextPost.title}
               link={nextPost.link}
               customRel="next"
-              newTab={false}
             />.
           </p>
           {/* Post author */}

--- a/routes/blog/how-create-theme-switcher-deno-fresh.tsx
+++ b/routes/blog/how-create-theme-switcher-deno-fresh.tsx
@@ -7,8 +7,9 @@ import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
-//? A HTML Link component to pre-format links and reduce boiletplate
+//? Link components to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+import { DottedLink } from "../../components/UI/DottedLink.tsx";
 //? Create a greek list of contents
 import { GreekList } from "../../components/UI/GreekList.tsx";
 //? Display a link to view the source code on GitHub
@@ -498,11 +499,10 @@ export default function Home() {
             issues with it, like flickering on first load or the inability to
             check for user preferences. Let's address those problems on those on
             the{" "}
-            <GradientLink
+            <DottedLink
               link={nextPost.link}
               title={nextPost.title}
               content="next blog post"
-              newTab={false}
               customRel="next"
             />.
           </p>

--- a/routes/blog/how-create-voice-channels-discord-v14.tsx
+++ b/routes/blog/how-create-voice-channels-discord-v14.tsx
@@ -7,8 +7,9 @@ import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
-//? A HTML Link component to pre-format links and reduce boiletplate
+//? Link components to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+import { DottedLink } from "../../components/UI/DottedLink.tsx";
 //? Display a link to view the source code on GitHub
 import { ViewOnGitHub } from "../../components/misc/ViewOnGithub.tsx";
 //? Import the default post footer
@@ -45,12 +46,11 @@ export default function Home() {
           <p class="mb-4 self-start text-xs">
             This is the second (of four) parts of the Discord.JS V14 tutorial
             that I've published. You can read the{" "}
-            <GradientLink
+            <DottedLink
               link={previousPost.link}
               title={previousPost.title}
               content="first part"
               customRel="prev"
-              newTab={false}
             />{" "}
             here. You can also read the full version of this tutorial on{" "}
             <GradientLink
@@ -819,11 +819,10 @@ export default function Home() {
           {/* Next post: Categories */}
           <p class="mt-4 text-justify self-start">
             Next post:{" "}
-            <GradientLink
+            <DottedLink
               link={nextPost.link}
               title={nextPost.title}
               content={nextPost.title}
-              newTab={false}
             />
           </p>
           {/* Post author */}

--- a/routes/certificates.tsx
+++ b/routes/certificates.tsx
@@ -45,7 +45,6 @@ export default function Home() {
             <GradientLink
               content="Trophy Place"
               link="https://trophy.place"
-              newTab={true}
             />.
           </p>
           <StyledSubHeader title="React (+NextJS)" />

--- a/routes/projects/index.tsx
+++ b/routes/projects/index.tsx
@@ -34,7 +34,6 @@ export default function Home() {
             <GradientLink
               content="React - The Complete Guide"
               link="https://www.udemy.com/course/react-the-complete-guide-incl-redux/"
-              newTab={true}
               title="React couse, by Academind"
               customRel="noopener noreferrer"
             />{" "}
@@ -51,7 +50,6 @@ export default function Home() {
               <GradientLink
                 content="not knowing what I don't know"
                 link="https://hbr.org/2012/05/discover-what-you-need-to-know"
-                newTab={true}
                 customRel="noopener noreferrer"
                 title="It's not about impostor syndrome, but about being aware that you will always not know more about things than you actually know about them"
               />

--- a/routes/projects/index.tsx
+++ b/routes/projects/index.tsx
@@ -4,7 +4,9 @@ import { CustomHead } from "../../components/base/CustomHead.tsx";
 import { Base } from "../../components/base/Base.tsx";
 //? Default styled header
 import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
+//? Link component to pre-format links and reduce boiletplate
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
+import { DottedLink } from "../../components/UI/DottedLink.tsx";
 //? Navigation Buttons to go back to the previous page or to the next article
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? Component to create a column grid of projects created
@@ -73,7 +75,7 @@ export default function Home() {
             <span class="shl-inline">Portals</span> and{" "}
             <span class="shl-inline">Context</span>, it was mostly nice-to-know
             course for me. Check{" "}
-            <GradientLink
+            <DottedLink
               content="tools"
               link="/tools"
               title="The things I've built alone"

--- a/routes/tools/index.tsx
+++ b/routes/tools/index.tsx
@@ -6,8 +6,8 @@ import { Base } from "../../components/base/Base.tsx";
 import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
-//? A HTML Link component to pre-format links and reduce boiletplate
-import { GradientLink } from "../../components/UI/GradientLink.tsx";
+//? Link component to pre-format links and reduce boiletplate
+import { DottedLink } from "../../components/UI/DottedLink.tsx";
 //? Create a greek list of contents
 import { GreekList } from "../../components/UI/GreekList.tsx";
 
@@ -35,32 +35,28 @@ export default function Home() {
           <GreekList
             items={[
               //? Syntax highlighter
-              <GradientLink
+              <DottedLink
                 content="Syntax Highlight"
                 title="Create a HTML+CSS version of syntax highlight that you can paste into your React/Preact files."
                 link="/tools/syntax-highlight"
-                newTab={false}
               />,
               //? Retirement calculator
-              <GradientLink
+              <DottedLink
                 content="Retirement Calculator"
                 title="I love planning how to save/invest money and I love watching interest compound, so I've built a tool that helps me visualise that over time."
                 link="/tools/retirement-calculator"
-                newTab={false}
               />,
               //? Whatsapp messaging Link Generator
-              <GradientLink
+              <DottedLink
                 content="Whatsapp Message Link Generator"
                 title="When I used to work with marketing, I could not find a good resouce to generate a link to message someone in WhatsApp. This tool does what I needed done back then. This tool helps manual messaging, but if this is something you are doing constantly, I suggest automating this process in another way instead or hiring someone to create a chatbot for you."
                 link="/tools/whatsapp-message-link-generator"
-                newTab={false}
               />,
               //? Mathematical expression visualizer
-              <GradientLink
+              <DottedLink
                 content="Expression Visualizer"
                 title="This is something that the teacher of the Automating the Boring Stuff used at some point in his classes. Thought it was really interesting, so I'm spinning up my own version of it for anyone to use."
                 link="/tools/expression-visualizer"
-                newTab={false}
               />,
             ]}
           />

--- a/routes/what-is-this.tsx
+++ b/routes/what-is-this.tsx
@@ -47,13 +47,11 @@ export default function Home() {
             <DottedLink
               content="thoughts"
               link="/blog"
-              newTab={true}
             />{" "}
             and{" "}
             <DottedLink
               content="creative expression"
               link="/toys"
-              newTab={true}
             />
             . It was built using Deno, Fresh, Preact and Typescript.
           </p>
@@ -73,7 +71,6 @@ export default function Home() {
             <GradientLink
               content="Bun"
               link="https://bun.sh/"
-              newTab={true}
               customRel="noopener noreferrer"
             />{" "}
             also allows developers to run Typescript natively since that also
@@ -95,7 +92,6 @@ export default function Home() {
             <GradientLink
               content="Islands"
               link="https://www.patterns.dev/posts/islands-architecture"
-              newTab={true}
               customRel="noopener noreferrer"
             />{" "}
             architecture.

--- a/routes/what-is-this.tsx
+++ b/routes/what-is-this.tsx
@@ -4,7 +4,9 @@ import { CustomHead } from "../components/base/CustomHead.tsx";
 import { Base } from "../components/base/Base.tsx";
 //? Default styled header
 import { StyledHeader } from "../components/UI/StyledHeader.tsx";
+//? Link component to pre-format links and reduce boiletplate
 import { GradientLink } from "../components/UI/GradientLink.tsx";
+import { DottedLink } from "../components/UI/DottedLink.tsx";
 //? Navigation Buttons to go back to the previous page or to the next page (optional)
 import { NavigationButtons } from "../components/misc/NavigationButtons.tsx";
 
@@ -42,13 +44,13 @@ export default function Home() {
           <StyledHeader title="Ok, so what is this?" />
           <p class="text-justify">
             This website is meant to be an outlet for my{" "}
-            <GradientLink
+            <DottedLink
               content="thoughts"
               link="/blog"
               newTab={true}
             />{" "}
             and{" "}
-            <GradientLink
+            <DottedLink
               content="creative expression"
               link="/toys"
               newTab={true}

--- a/routes/work/index.tsx
+++ b/routes/work/index.tsx
@@ -33,7 +33,6 @@ export default function Home() {
             I am the creator of{" "}
             <GradientLink
               content="Yura"
-              newTab={true}
               link="https://discordapp.com/invite/j55v7pD"
               title="My Discord bot's support server."
             />, a PSN-related Discord bot, based on PSNProfiles.com data
@@ -53,21 +52,18 @@ export default function Home() {
             I've created{" "}
             <GradientLink
               content="RotMG Utility"
-              newTab={true}
               link="https://github.com/TheYuriG/RotMG-Utility/releases"
               customRel="noopener noreferrer"
               title="Release repository for the RotMG app"
             />, a helper to managing trades from{" "}
             <GradientLink
               content="RealmEye.com"
-              newTab={true}
               link="https://www.realmeye.com/current-offers"
               customRel="noopener noreferrer"
               title="RealmEye.com, the website that has everything related to Realm Of The Mad God game."
             />, the community website around{" "}
             <GradientLink
               content="Realm of the Mad God"
-              newTab={true}
               link="https://www.realmofthemadgod.com/"
               customRel="noopener noreferrer"
               title="Realm of the Mad God, the game I made the app for."
@@ -84,7 +80,6 @@ export default function Home() {
             Discord to a{" "}
             <GradientLink
               content="mobile/desktop app"
-              newTab={true}
               link="https://github.com/TheYuriG/yura_app_repository"
               customRel="noopener noreferrer"
               title="Release repository for the Yura, as an app"
@@ -109,7 +104,6 @@ export default function Home() {
             starting{" "}
             <GradientLink
               content="Trophy Place"
-              newTab={true}
               link="https://my.trophy.place/"
               title="More than just a passion project, Trophy Place will eventually become the defacto website for trophy hunting on PSN."
             />. My partner took over the frontend and I take care of the
@@ -121,7 +115,6 @@ export default function Home() {
             studying and my agency contract jobs are my daily{" "}
             <GradientLink
               content="coding routine"
-              newTab={true}
               link="https://github.com/TheYuriG"
               title="My GitHub profile page."
             />.

--- a/types/component-properties/DecoratedLinkProperties.ts
+++ b/types/component-properties/DecoratedLinkProperties.ts
@@ -1,0 +1,7 @@
+//? Define essential properties to a decorated (gradient, dotted) link
+export interface DecoratedLinkProperties {
+  link: string;
+  title?: string;
+  customRel?: string;
+  content: string;
+}


### PR DESCRIPTION
The user experience was really confusing since all links looked the same, but some opened a new tab and others would redirect to another internal page.

This PR improves on this UX by clearly separating which links are external and which links are internal. All external links will use `<GradientLink />`, while all internal links will use `<DottedLink />`.

To make it extremely clear, all `<GradientLink />` will also show the  `<ExternalLinkIcon />`, while `<DottedLink />` won't.

Closes #107.