### PR TITLE
Responsive Comparison Table and README Link Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Here you will find the code that powers the website
 
 📝 All of the code is written in Typescript and CSS, powered by Deno, Fresh,
 Preact and Twind and served as static HTML files using the Islands architecture
-(you can see a more broad overview [here](https://www.theyurig.com/this)).
+(you can see a more broad overview [here](https://www.theyurig.com/what-is-this)).
 
 ☀️🌒 The website hosts all of my projects and some of my history. Feel free to
 visit the site and poke around. All related code is well commented, so if you

--- a/components/blog/ComparisonTable.tsx
+++ b/components/blog/ComparisonTable.tsx
@@ -54,11 +54,11 @@ export function ComparisonTable(
             {/* Label */}
             <td class="custom-bo-ac hidden md:table-cell py-1 px-2">{label}</td>
             {/* Item 1 */}
-            <td class="custom-bo-ac py-1 px-2 text-left whitespace-pre-wrap">
+            <td class="custom-bo-ac py-1 px-2 text-left whitespace-pre-wrap break-words max-w-[35vw]">
               {itemOne}
             </td>
             {/* Item 2 */}
-            <td class="custom-bo-ac py-1 px-2 text-left whitespace-pre-wrap">
+            <td class="custom-bo-ac py-1 px-2 text-left whitespace-pre-wrap break-words max-w-[35vw]">
               {itemTwo}
             </td>
             {/* Note about the difference, if provided */}

--- a/components/tools/retirement-calculator/RetirementCalculationTable.tsx
+++ b/components/tools/retirement-calculator/RetirementCalculationTable.tsx
@@ -93,11 +93,11 @@ export function RetirementCalculationTable(
             {/* Age */}
             <td class="custom-bo-ac">{yearCalculation.age}</td>
             {/* Total saved */}
-            <td class="custom-bo-ac">
+            <td class="custom-bo-ac break-words max-w-[20vw]">
               ${Math.floor(yearCalculation.totalSaved).toLocaleString()}
             </td>
             {/* Interest returns from last year */}
-            <td class="custom-bo-ac">
+            <td class="custom-bo-ac break-words max-w-[20vw]">
               ${Math.floor(yearCalculation.lastYearCompound).toLocaleString() +
                 (+values.additionalIncome > 0 &&
                     yearCalculation.lastYearCompound >= +values.compensation

--- a/routes/blog/javascript-python-syntax.tsx
+++ b/routes/blog/javascript-python-syntax.tsx
@@ -1441,13 +1441,18 @@ a == b // True`,
               link="https://github.com/lino-levan"
               customRel="nofollow noreferrer"
               title="Thank you for the error checking!"
-            />{" "}
-            and{" "}
+            />{", "}
             <GradientLink
               content="u/nekokattt"
               link="https://www.reddit.com/r/learnpython/comments/14yf19y/comment/jrshjh0/?utm_source=reddit&utm_medium=web2x&context=3"
               customRel="nofollow noreferrer"
               title="Thank you for the suggestions!"
+            />
+            {" "} and {" "}
+            <GradientLink
+              content="@spidersouris"
+              link="https://github.com/spidersouris"
+              customRel="nofollow noreferrer"
             />. You can check this{" "}
             <GradientLink
               content="issue"


### PR DESCRIPTION
Hi! Saw your post on r/learnpython yesterday and I noticed the mobile layout was a bit off so here's a quick fix. This breaks one-liners that are too long on mobile (such as `BigInt(bigNumberString)` in the Data Types column).

Please let me know if that works for you! I've also fixed your website's what-is-this link in the README.