### PR TITLE
feat: created a simplified version of expression-visualizer

### DIFF
--- a/assets/ArrowUpIcon.tsx
+++ b/assets/ArrowUpIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders an Arrow Up Icon with fill
 export function ArrowUpIcon(

--- a/assets/CartIcon.tsx
+++ b/assets/CartIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a Cart Icon with fill
 export function CartIcon(

--- a/assets/ChevronIcon.tsx
+++ b/assets/ChevronIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a chevron Icon with fill, can be rotated using transform
 export function ChevronIcon(

--- a/assets/CircleIcon.tsx
+++ b/assets/CircleIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconPropertiesWithStroke for props typecasting
-import { IconPropertiesWithStroke } from "../types/asset-properties/IconProperties.ts";
+import type { IconPropertiesWithStroke } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a Circle Icon with fill, stroke and stroke-width
 export function CircleIcon(

--- a/assets/CreditCardIcon.tsx
+++ b/assets/CreditCardIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a Credit Card Icon with fill
 export function CreditCardIcon(

--- a/assets/DeliveryIcon.tsx
+++ b/assets/DeliveryIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a delivery truck Icon with fill
 export function DeliveryIcon(

--- a/assets/ExternalLinkIcon.tsx
+++ b/assets/ExternalLinkIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders an External Link Icon with fill and can take extra classes
 export function ExternalLinkIcon(

--- a/assets/InformationIcon.tsx
+++ b/assets/InformationIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders an Information Icon with fill
 export function InformationIcon(

--- a/assets/LoadingAnimation.tsx
+++ b/assets/LoadingAnimation.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconPropertiesWithStroke } from "../types/asset-properties/IconProperties.ts";
+import type { IconPropertiesWithStroke } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a spinning animation with fill
 export function LoadingAnimation(

--- a/assets/MealIcon.tsx
+++ b/assets/MealIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a Knife and Fork Icon with fill
 export function MealIcon(

--- a/assets/MinusIcon.tsx
+++ b/assets/MinusIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a Minus Icon with fill
 export function MinusIcon(

--- a/assets/MoonIcon.tsx
+++ b/assets/MoonIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a Moon Icon with fill
 export function MoonIcon(

--- a/assets/PaypalIcon.tsx
+++ b/assets/PaypalIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a Paypal Icon with fill
 export function PaypalIcon(

--- a/assets/PlusIcon.tsx
+++ b/assets/PlusIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a Plus Icon with fill color
 export function PlusIcon(

--- a/assets/PullRequestIcon.tsx
+++ b/assets/PullRequestIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a Pull Request Icon with fill, stroke and stroke-width
 export function PullRequestIcon(

--- a/assets/SunIcon.tsx
+++ b/assets/SunIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconProperties } from "../types/asset-properties/IconProperties.ts";
+import type { IconProperties } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a Sun Icon with fill
 export function SunIcon(

--- a/assets/XMarkIcon.tsx
+++ b/assets/XMarkIcon.tsx
@@ -1,5 +1,5 @@
 //? Import IconProperties for props typecasting
-import { IconPropertiesWithStroke } from "../types/asset-properties/IconProperties.ts";
+import type { IconPropertiesWithStroke } from "../types/asset-properties/IconProperties.ts";
 
 //? Renders a XMark Icon with fill, stroke and stroke-width
 export function XMarkIcon(

--- a/components/UI/DottedLink.tsx
+++ b/components/UI/DottedLink.tsx
@@ -1,5 +1,5 @@
 //? Define the required and optional properties of a decorated Link
-import { DecoratedLinkProperties } from "../../types/component-properties/DecoratedLinkProperties.ts";
+import type { DecoratedLinkProperties } from "../../types/component-properties/DecoratedLinkProperties.ts";
 
 //? Exports an anchor tag with default styling for custom-underline-dotted, while
 //? using the other attributes provided

--- a/components/UI/GradientLink.tsx
+++ b/components/UI/GradientLink.tsx
@@ -2,7 +2,7 @@
 import { ExternalLinkIcon } from "../../assets/ExternalLinkIcon.tsx";
 
 //? Define the required and optional properties of a Decorated Link
-import { DecoratedLinkProperties } from "../../types/component-properties/DecoratedLinkProperties.ts";
+import type { DecoratedLinkProperties } from "../../types/component-properties/DecoratedLinkProperties.ts";
 
 //? Exports an anchor tag with default styling for custom-underline-gradient, while
 //? using the other attributes provided

--- a/components/projects/ProjectDisplay.tsx
+++ b/components/projects/ProjectDisplay.tsx
@@ -1,5 +1,5 @@
 //? Properties requires to create a ProjectDisplay
-import type { ProjectDisplayProperties } from "../../types/ProjectDisplayProperties.ts";
+import type { ProjectDisplayProperties } from "../../types/component-properties/projects/ProjectDisplayProperties.ts";
 
 //? Creates a project to be displayed on ProjectsGrid
 export function ProjectDisplay(

--- a/components/projects/food-order/CartModal.tsx
+++ b/components/projects/food-order/CartModal.tsx
@@ -15,8 +15,8 @@ import {
   reduceCartItemByOne,
 } from "../../../services/food-order/updateFoodOrder.ts";
 //? Import types for typecasting
-import type { foodCartItemsMap } from "../../../types/food-order/foodCartItemsMap.ts";
-import type { updateCartFunction } from "../../../types/food-order/updateCartFunction.ts";
+import type { foodCartItemsMap } from "../../../types/component-properties/projects/food-order/foodCartItemsMap.ts";
+import type { updateCartFunction } from "../../../types/component-properties/projects/food-order/updateCartFunction.ts";
 
 //? Define Cart Modal properties
 interface CartModalProperties {

--- a/components/projects/food-order/FoodItem.tsx
+++ b/components/projects/food-order/FoodItem.tsx
@@ -3,7 +3,7 @@ import { MealIcon } from "../../../assets/MealIcon.tsx";
 //? Import the StyledButton to enable users to add the current FoodItem to the cart
 import { StyledButton } from "../../UI/StyledButton.tsx";
 //? Import Food type to typecast the data received
-import type { Food } from "../../../types/food-order/Food.ts";
+import type { Food } from "../../../types/component-properties/projects/food-order/Food.ts";
 
 //? Renders a single FoodItem with image, name, description and button to add to Cart
 export function FoodItem(

--- a/data/blog/how-create-theme-switcher-deno-fresh.ts
+++ b/data/blog/how-create-theme-switcher-deno-fresh.ts
@@ -1,5 +1,5 @@
 //? Import required properties for a blog post
-import BlogPostSummaryProperties from "../../types/blog/BlogPostSummaryProperties.ts";
+import type { BlogPostSummaryProperties } from "../../types/blog/BlogPostSummaryProperties.ts";
 
 //? Export object with blog post summary data
 export const createFreshThemeSwitcher: BlogPostSummaryProperties = {

--- a/data/blog/how-create-voice-channels-discord-v14.ts
+++ b/data/blog/how-create-voice-channels-discord-v14.ts
@@ -1,5 +1,5 @@
 //? Import required properties for a blog post
-import BlogPostSummaryProperties from "../../types/blog/BlogPostSummaryProperties.ts";
+import type { BlogPostSummaryProperties } from "../../types/blog/BlogPostSummaryProperties.ts";
 
 //? Export object with blog post summary data
 export const createVoiceChannelPost: BlogPostSummaryProperties = {

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -25,16 +25,17 @@ import * as $19 from "./routes/projects/food-order/success.tsx";
 import * as $20 from "./routes/projects/index.tsx";
 import * as $21 from "./routes/projects/stimulus-check.tsx";
 import * as $22 from "./routes/projects/tictactoe.tsx";
-import * as $23 from "./routes/tools/expression-visualizer.tsx";
-import * as $24 from "./routes/tools/highlighted-text/[text].tsx";
-import * as $25 from "./routes/tools/index.tsx";
-import * as $26 from "./routes/tools/retirement-calculator.tsx";
-import * as $27 from "./routes/tools/syntax-highlight.tsx";
-import * as $28 from "./routes/tools/whatsapp-message-link-generator.tsx";
-import * as $29 from "./routes/toys/index.tsx";
-import * as $30 from "./routes/toys/spinners.tsx";
-import * as $31 from "./routes/what-is-this.tsx";
-import * as $32 from "./routes/work/index.tsx";
+import * as $23 from "./routes/tools/expression-visualizer-advanced.tsx";
+import * as $24 from "./routes/tools/expression-visualizer.tsx";
+import * as $25 from "./routes/tools/highlighted-text/[text].tsx";
+import * as $26 from "./routes/tools/index.tsx";
+import * as $27 from "./routes/tools/retirement-calculator.tsx";
+import * as $28 from "./routes/tools/syntax-highlight.tsx";
+import * as $29 from "./routes/tools/whatsapp-message-link-generator.tsx";
+import * as $30 from "./routes/toys/index.tsx";
+import * as $31 from "./routes/toys/spinners.tsx";
+import * as $32 from "./routes/what-is-this.tsx";
+import * as $33 from "./routes/work/index.tsx";
 import * as $$0 from "./islands/UI/DigitalTimer.tsx";
 import * as $$1 from "./islands/UI/Modal.tsx";
 import * as $$2 from "./islands/misc/Collapsible.tsx";
@@ -50,10 +51,11 @@ import * as $$11 from "./islands/projects/FormWithValidation.tsx";
 import * as $$12 from "./islands/projects/TicTacToeBoard.tsx";
 import * as $$13 from "./islands/tools/ExpressionVisualizationList.tsx";
 import * as $$14 from "./islands/tools/ExpressionVisualizer.tsx";
-import * as $$15 from "./islands/tools/HighlightedCode.tsx";
-import * as $$16 from "./islands/tools/RetirementCalculationForm.tsx";
-import * as $$17 from "./islands/tools/RetirementCalculator.tsx";
-import * as $$18 from "./islands/tools/WhatsappLinkGenerator.tsx";
+import * as $$15 from "./islands/tools/ExpressionVisualizerAdvanced.tsx";
+import * as $$16 from "./islands/tools/HighlightedCode.tsx";
+import * as $$17 from "./islands/tools/RetirementCalculationForm.tsx";
+import * as $$18 from "./islands/tools/RetirementCalculator.tsx";
+import * as $$19 from "./islands/tools/WhatsappLinkGenerator.tsx";
 
 const manifest = {
   routes: {
@@ -80,16 +82,17 @@ const manifest = {
     "./routes/projects/index.tsx": $20,
     "./routes/projects/stimulus-check.tsx": $21,
     "./routes/projects/tictactoe.tsx": $22,
-    "./routes/tools/expression-visualizer.tsx": $23,
-    "./routes/tools/highlighted-text/[text].tsx": $24,
-    "./routes/tools/index.tsx": $25,
-    "./routes/tools/retirement-calculator.tsx": $26,
-    "./routes/tools/syntax-highlight.tsx": $27,
-    "./routes/tools/whatsapp-message-link-generator.tsx": $28,
-    "./routes/toys/index.tsx": $29,
-    "./routes/toys/spinners.tsx": $30,
-    "./routes/what-is-this.tsx": $31,
-    "./routes/work/index.tsx": $32,
+    "./routes/tools/expression-visualizer-advanced.tsx": $23,
+    "./routes/tools/expression-visualizer.tsx": $24,
+    "./routes/tools/highlighted-text/[text].tsx": $25,
+    "./routes/tools/index.tsx": $26,
+    "./routes/tools/retirement-calculator.tsx": $27,
+    "./routes/tools/syntax-highlight.tsx": $28,
+    "./routes/tools/whatsapp-message-link-generator.tsx": $29,
+    "./routes/toys/index.tsx": $30,
+    "./routes/toys/spinners.tsx": $31,
+    "./routes/what-is-this.tsx": $32,
+    "./routes/work/index.tsx": $33,
   },
   islands: {
     "./islands/UI/DigitalTimer.tsx": $$0,
@@ -107,10 +110,11 @@ const manifest = {
     "./islands/projects/TicTacToeBoard.tsx": $$12,
     "./islands/tools/ExpressionVisualizationList.tsx": $$13,
     "./islands/tools/ExpressionVisualizer.tsx": $$14,
-    "./islands/tools/HighlightedCode.tsx": $$15,
-    "./islands/tools/RetirementCalculationForm.tsx": $$16,
-    "./islands/tools/RetirementCalculator.tsx": $$17,
-    "./islands/tools/WhatsappLinkGenerator.tsx": $$18,
+    "./islands/tools/ExpressionVisualizerAdvanced.tsx": $$15,
+    "./islands/tools/HighlightedCode.tsx": $$16,
+    "./islands/tools/RetirementCalculationForm.tsx": $$17,
+    "./islands/tools/RetirementCalculator.tsx": $$18,
+    "./islands/tools/WhatsappLinkGenerator.tsx": $$19,
   },
   baseUrl: import.meta.url,
 };

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -42,20 +42,20 @@ import * as $$2 from "./islands/misc/Collapsible.tsx";
 import * as $$3 from "./islands/misc/CopyTextAreaToClipboard.tsx";
 import * as $$4 from "./islands/misc/ScrollToTop.tsx";
 import * as $$5 from "./islands/misc/ThemeSwitcher.tsx";
-import * as $$6 from "./islands/projects/AddNewExpense.tsx";
-import * as $$7 from "./islands/projects/ExpensesTracker.tsx";
-import * as $$8 from "./islands/projects/ExpensesYearSelect.tsx";
-import * as $$9 from "./islands/projects/FoodOrder.tsx";
-import * as $$10 from "./islands/projects/FoodOrderCheckout.tsx";
-import * as $$11 from "./islands/projects/FormWithValidation.tsx";
-import * as $$12 from "./islands/projects/TicTacToeBoard.tsx";
-import * as $$13 from "./islands/tools/ExpressionVisualizationList.tsx";
-import * as $$14 from "./islands/tools/ExpressionVisualizer.tsx";
-import * as $$15 from "./islands/tools/ExpressionVisualizerAdvanced.tsx";
-import * as $$16 from "./islands/tools/HighlightedCode.tsx";
-import * as $$17 from "./islands/tools/RetirementCalculationForm.tsx";
-import * as $$18 from "./islands/tools/RetirementCalculator.tsx";
-import * as $$19 from "./islands/tools/WhatsappLinkGenerator.tsx";
+import * as $$6 from "./islands/projects/expenses-tracker/AddNewExpense.tsx";
+import * as $$7 from "./islands/projects/expenses-tracker/ExpensesTracker.tsx";
+import * as $$8 from "./islands/projects/expenses-tracker/ExpensesYearSelect.tsx";
+import * as $$9 from "./islands/projects/food-order/FoodOrder.tsx";
+import * as $$10 from "./islands/projects/food-order/FoodOrderCheckout.tsx";
+import * as $$11 from "./islands/projects/stimulus-check/StimulusCheckForm.tsx";
+import * as $$12 from "./islands/projects/tic-tac-toe/TicTacToeBoard.tsx";
+import * as $$13 from "./islands/tools/expression-visualizer/ExpressionVisualizationList.tsx";
+import * as $$14 from "./islands/tools/expression-visualizer/ExpressionVisualizer.tsx";
+import * as $$15 from "./islands/tools/expression-visualizer/ExpressionVisualizerAdvanced.tsx";
+import * as $$16 from "./islands/tools/retirement-calculator/RetirementCalculationForm.tsx";
+import * as $$17 from "./islands/tools/retirement-calculator/RetirementCalculator.tsx";
+import * as $$18 from "./islands/tools/syntax-highlight/HighlightedCode.tsx";
+import * as $$19 from "./islands/tools/whatsapp-message-link-generator/WhatsappLinkGenerator.tsx";
 
 const manifest = {
   routes: {
@@ -101,20 +101,23 @@ const manifest = {
     "./islands/misc/CopyTextAreaToClipboard.tsx": $$3,
     "./islands/misc/ScrollToTop.tsx": $$4,
     "./islands/misc/ThemeSwitcher.tsx": $$5,
-    "./islands/projects/AddNewExpense.tsx": $$6,
-    "./islands/projects/ExpensesTracker.tsx": $$7,
-    "./islands/projects/ExpensesYearSelect.tsx": $$8,
-    "./islands/projects/FoodOrder.tsx": $$9,
-    "./islands/projects/FoodOrderCheckout.tsx": $$10,
-    "./islands/projects/FormWithValidation.tsx": $$11,
-    "./islands/projects/TicTacToeBoard.tsx": $$12,
-    "./islands/tools/ExpressionVisualizationList.tsx": $$13,
-    "./islands/tools/ExpressionVisualizer.tsx": $$14,
-    "./islands/tools/ExpressionVisualizerAdvanced.tsx": $$15,
-    "./islands/tools/HighlightedCode.tsx": $$16,
-    "./islands/tools/RetirementCalculationForm.tsx": $$17,
-    "./islands/tools/RetirementCalculator.tsx": $$18,
-    "./islands/tools/WhatsappLinkGenerator.tsx": $$19,
+    "./islands/projects/expenses-tracker/AddNewExpense.tsx": $$6,
+    "./islands/projects/expenses-tracker/ExpensesTracker.tsx": $$7,
+    "./islands/projects/expenses-tracker/ExpensesYearSelect.tsx": $$8,
+    "./islands/projects/food-order/FoodOrder.tsx": $$9,
+    "./islands/projects/food-order/FoodOrderCheckout.tsx": $$10,
+    "./islands/projects/stimulus-check/StimulusCheckForm.tsx": $$11,
+    "./islands/projects/tic-tac-toe/TicTacToeBoard.tsx": $$12,
+    "./islands/tools/expression-visualizer/ExpressionVisualizationList.tsx":
+      $$13,
+    "./islands/tools/expression-visualizer/ExpressionVisualizer.tsx": $$14,
+    "./islands/tools/expression-visualizer/ExpressionVisualizerAdvanced.tsx":
+      $$15,
+    "./islands/tools/retirement-calculator/RetirementCalculationForm.tsx": $$16,
+    "./islands/tools/retirement-calculator/RetirementCalculator.tsx": $$17,
+    "./islands/tools/syntax-highlight/HighlightedCode.tsx": $$18,
+    "./islands/tools/whatsapp-message-link-generator/WhatsappLinkGenerator.tsx":
+      $$19,
   },
   baseUrl: import.meta.url,
 };

--- a/islands/projects/expenses-tracker/AddNewExpense.tsx
+++ b/islands/projects/expenses-tracker/AddNewExpense.tsx
@@ -1,18 +1,18 @@
 //? Import from Preact to be able to change state
 import { useState } from "preact/hooks";
 //? Default styled header
-import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
+import { StyledSubHeader } from "../../../components/UI/StyledSubHeader.tsx";
 //? Responsive and styled Label + Input
-import { StyledInput } from "../../components/UI/StyledInput.tsx";
+import { StyledInput } from "../../../components/UI/StyledInput.tsx";
 //? Styled Button to confirm sending the form
-import { StyledButton } from "../../components/UI/StyledButton.tsx";
+import { StyledButton } from "../../../components/UI/StyledButton.tsx";
 //? Types for typecasting
-import { validationStatus } from "../../types/forms/validationStatus.ts";
+import { validationStatus } from "../../../types/forms/validationStatus.ts";
 //? Validation functions
-import { validateExpenseDescription } from "../../services/form-validation/validateExpenseDescription.ts";
-import { validateExpenseDate } from "../../services/form-validation/validateExpenseDate.ts";
-import { validateOneOrGreater } from "../../services/form-validation/validateOneOrGreater.ts";
-import { patternValidation } from "../../services/form-validation/patternValidation.ts";
+import { validateExpenseDescription } from "../../../services/form-validation/validateExpenseDescription.ts";
+import { validateExpenseDate } from "../../../services/form-validation/validateExpenseDate.ts";
+import { validateOneOrGreater } from "../../../services/form-validation/validateOneOrGreater.ts";
+import { patternValidation } from "../../../services/form-validation/patternValidation.ts";
 
 //* Date formatted as YYYY-MM-DD
 const [timezonelessDate, timezoneDateGap] = new Date().toISOString().split("T");

--- a/islands/projects/expenses-tracker/ExpensesTracker.tsx
+++ b/islands/projects/expenses-tracker/ExpensesTracker.tsx
@@ -1,14 +1,14 @@
 //? Import from Preact to be able to change state
 import { useState } from "preact/hooks";
 //? Import IndividualExpenses component to display expenses
-import { IndividualExpense } from "../../components/projects/expenses-tracker/IndividualExpense.tsx";
+import { IndividualExpense } from "../../../components/projects/expenses-tracker/IndividualExpense.tsx";
 //? Import expense creation form
 import AddNewExpense from "./AddNewExpense.tsx";
 //? Import the Expense type for casting
-import type { Expense } from "../../types/component-properties/projects/expenses-tracker/Expense.ts";
+import type { Expense } from "../../../types/component-properties/projects/expenses-tracker/Expense.ts";
 import ExpensesYearSelect from "./ExpensesYearSelect.tsx";
-import { ExpenseChart } from "../../components/projects/expenses-tracker/ExpensesChart.tsx";
-import { postNewExpense } from "../../services/expenses-tracker/postNewExpense.ts";
+import { ExpenseChart } from "../../../components/projects/expenses-tracker/ExpensesChart.tsx";
+import { postNewExpense } from "../../../services/expenses-tracker/postNewExpense.ts";
 
 //? Filters expenses by year
 function filterExpensesByYear(year: string, savedExpenses: Expense[]) {

--- a/islands/projects/expenses-tracker/ExpensesYearSelect.tsx
+++ b/islands/projects/expenses-tracker/ExpensesYearSelect.tsx
@@ -1,5 +1,5 @@
 //? Import the Expense type for casting
-import { StyledSelect } from "../../components/UI/StyledSelect.tsx";
+import { StyledSelect } from "../../../components/UI/StyledSelect.tsx";
 
 //? Define component properties
 interface ExpensesYearSelectProperties {

--- a/islands/projects/food-order/FoodOrder.tsx
+++ b/islands/projects/food-order/FoodOrder.tsx
@@ -1,19 +1,19 @@
 //? Import from Preact to be able to change state
 import { useEffect, useRef, useState } from "preact/hooks";
 //? Import Food type to typecast the data received
-import type { Food } from "../../types/component-properties/projects/food-order/Food.ts";
+import type { Food } from "../../../types/component-properties/projects/food-order/Food.ts";
 //? Renders invidual food items on the page
-import { FoodItem } from "../../components/projects/food-order/FoodItem.tsx";
+import { FoodItem } from "../../../components/projects/food-order/FoodItem.tsx";
 //? Cart Button that opens the current Cart as a Modal
-import CartButton from "../../components/projects/food-order/CartButton.tsx";
+import CartButton from "../../../components/projects/food-order/CartButton.tsx";
 //? Content of the current Cart in a modal for the user to view Cart Items
-import CartModal from "../../components/projects/food-order/CartModal.tsx";
+import CartModal from "../../../components/projects/food-order/CartModal.tsx";
 //? Import accent button to create the Order now! button at the bottom
-import { AccentButton } from "../../components/UI/AccentButton.tsx";
+import { AccentButton } from "../../../components/UI/AccentButton.tsx";
 //? Default styled header
-import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
+import { StyledSubHeader } from "../../../components/UI/StyledSubHeader.tsx";
 //? Creates a modal with a shaded/blurred backdrop over the content behind it
-import Modal from "../UI/Modal.tsx";
+import Modal from "../../UI/Modal.tsx";
 
 //? Define properties required for this component
 interface FoodOrderProperties {

--- a/islands/projects/food-order/FoodOrderCheckout.tsx
+++ b/islands/projects/food-order/FoodOrderCheckout.tsx
@@ -1,9 +1,11 @@
 //? Import from Preact to manage state
 import { useEffect, useState } from "preact/hooks";
 //? Loading animation while cart is being loaded or request is being processed
-import { LoadingAnimation } from "../../assets/LoadingAnimation.tsx";
-import { FoodOrderCheckoutItemsList } from "../../components/projects/food-order/FoodOrderCheckoutItemsList.tsx";
-import { FoodOrderCheckoutPaymentForm } from "../../components/projects/food-order/FoodOrderCheckoutPaymentForm.tsx";
+import { LoadingAnimation } from "../../../assets/LoadingAnimation.tsx";
+//? Brief summary of cart items
+import { FoodOrderCheckoutItemsList } from "../../../components/projects/food-order/FoodOrderCheckoutItemsList.tsx";
+//? Form to pick payment method
+import { FoodOrderCheckoutPaymentForm } from "../../../components/projects/food-order/FoodOrderCheckoutPaymentForm.tsx";
 
 //? Instantiate default initial state for the cart
 const starterCartState = {

--- a/islands/projects/stimulus-check/StimulusCheckForm.tsx
+++ b/islands/projects/stimulus-check/StimulusCheckForm.tsx
@@ -1,29 +1,29 @@
 //? Import from Preact to be able to change state
 import { useState } from "preact/hooks";
 //? Responsive and styled Label + Input
-import { StyledInput } from "../../components/UI/StyledInput.tsx";
+import { StyledInput } from "../../../components/UI/StyledInput.tsx";
 //? Styled Button to confirm sending the form
-import { StyledButton } from "../../components/UI/StyledButton.tsx";
+import { StyledButton } from "../../../components/UI/StyledButton.tsx";
 //? Styled Select for Employment Status dropdown
-import { StyledSelect } from "../../components/UI/StyledSelect.tsx";
+import { StyledSelect } from "../../../components/UI/StyledSelect.tsx";
 //? Styled radio for Welfare option
-import { StyledRadio } from "../../components/UI/StyledRadio.tsx";
+import { StyledRadio } from "../../../components/UI/StyledRadio.tsx";
 //? Styled checkbox for Stimulus Check option
-import { StyledCheckboxGroup } from "../../components/UI/StyledCheckboxGroup.tsx";
+import { StyledCheckboxGroup } from "../../../components/UI/StyledCheckboxGroup.tsx";
 //? Import text area to display the submit results
-import { StyledTextArea } from "../../components/UI/StyledTextArea.tsx";
+import { StyledTextArea } from "../../../components/UI/StyledTextArea.tsx";
 //? Display error in as an ErrorAlert
-import { ErrorAlert } from "../../components/UI/ErrorAlert.tsx";
+import { ErrorAlert } from "../../../components/UI/ErrorAlert.tsx";
 
 //? Types for typecasting
-import { validationStatus } from "../../types/forms/validationStatus.ts";
-import type { stimulusCheckboxOptions } from "../../types/forms/stimulusCheckboxOptions.ts";
+import { validationStatus } from "../../../types/forms/validationStatus.ts";
+import type { stimulusCheckboxOptions } from "../../../types/forms/stimulusCheckboxOptions.ts";
 
 //? Validation functions
-import { validateName } from "../../services/form-validation/validateName.ts";
-import { validateAge } from "../../services/form-validation/validateAge.ts";
-import { validateProfession } from "../../services/form-validation/validateProfession.ts";
-import { patternValidation } from "../../services/form-validation/patternValidation.ts";
+import { validateName } from "../../../services/form-validation/validateName.ts";
+import { validateAge } from "../../../services/form-validation/validateAge.ts";
+import { validateProfession } from "../../../services/form-validation/validateProfession.ts";
+import { patternValidation } from "../../../services/form-validation/patternValidation.ts";
 
 //? Placeholder text to be used on the textArea before any data got sent
 const textAreaPlaceholder = 'Data will be displayed here as you click "Send".' +
@@ -69,7 +69,7 @@ const defaultFormValidation = {
 };
 
 //? Creates a form that uses RegExp validation
-export default function FormWithValidation() {
+export default function StimulusCheckForm() {
   //? Manages current state for form data
   const [formValues, setValues] = useState(defaultFormValues);
   //? Manages the validation of form fields

--- a/islands/projects/tic-tac-toe/TicTacToeBoard.tsx
+++ b/islands/projects/tic-tac-toe/TicTacToeBoard.tsx
@@ -1,22 +1,22 @@
 //? Manage the current board status
 import { useState } from "preact/hooks";
 //? Render an individual tile on the board
-import { TicTacToeTile } from "../../components/projects/tictactoe/TicTacToeTile.tsx";
+import { TicTacToeTile } from "../../../components/projects/tictactoe/TicTacToeTile.tsx";
 //? Tracker of who won the game or if the game tied
-import { TicTacToeGameStatus } from "../../components/projects/tictactoe/TicTacToeGameStatus.tsx";
+import { TicTacToeGameStatus } from "../../../components/projects/tictactoe/TicTacToeGameStatus.tsx";
 //? Render the button to reset the game once it ends with a tie or win
-import { StyledButton } from "../../components/UI/StyledButton.tsx";
+import { StyledButton } from "../../../components/UI/StyledButton.tsx";
 //? Import maximum number of tiles in a board
-import { MAX_TICTACTOE_TILES } from "../../data/projects/tictactoe/maxTiles.ts";
+import { MAX_TICTACTOE_TILES } from "../../../data/projects/tictactoe/maxTiles.ts";
 //? Import interface for typecasting
-import type { BoardTile } from "../../types/component-properties/projects/tictactoe/BoardTile.ts";
+import type { BoardTile } from "../../../types/component-properties/projects/tictactoe/BoardTile.ts";
 //? Utility function to reset a board array to 0 indices, then
 //? populate it with 9 tiles
-import { resetBoardFunction } from "../../services/tictactoe/resetBoardFunction.ts";
+import { resetBoardFunction } from "../../../services/tictactoe/resetBoardFunction.ts";
 //? Calculates if the board met a winning condition
-import { shouldGameEnd } from "../../services/tictactoe/shouldGameEnd.ts";
+import { shouldGameEnd } from "../../../services/tictactoe/shouldGameEnd.ts";
 //? Toggles player turn
-import { changePlayers } from "../../services/tictactoe/changePlayers.ts";
+import { changePlayers } from "../../../services/tictactoe/changePlayers.ts";
 
 //? Initialize an empty board that gets filled by 'resetBoard()'
 const baseBoardMarks: BoardTile[] = [];

--- a/islands/tools/ExpressionVisualizerAdvanced.tsx
+++ b/islands/tools/ExpressionVisualizerAdvanced.tsx
@@ -1,0 +1,141 @@
+//? State management
+import { useState } from "preact/hooks";
+//? Components
+import { StyledButton } from "../../components/UI/StyledButton.tsx";
+import { StyledInput } from "../../components/UI/StyledInput.tsx";
+import ExpressionVisualizationList from "./ExpressionVisualizationList.tsx";
+//? Validation
+import { validationStatus } from "../../types/forms/validationStatus.ts";
+import { validateNonEmptyText } from "../../services/form-validation/validateNonEmptyText.ts";
+//? Type
+import type { visualizer } from "../../types/component-properties/tools/expression-visualizer/Visualizer.ts";
+type ValidationStatuses<K extends keyof visualizer> = Record<
+  K,
+  validationStatus
+>;
+
+//? Set base state values
+const baseState: visualizer = {
+  //   leadingText: "",
+  leadingText: "const b = ",
+  //   expressionText: "",
+  expressionText: "5 * 5",
+  //   evaluatedText: "",
+  evaluatedText: "25",
+  //   trailingText: "",
+  trailingText: ";",
+};
+const baseValidation: ValidationStatuses<"expressionText" | "evaluatedText"> = {
+  expressionText: validationStatus.Unchanged,
+  evaluatedText: validationStatus.Unchanged,
+};
+
+export default function ExpressionVisualizerAdvanced() {
+  //? Manages current state for form data
+  const [formValues, setValues] = useState<visualizer>(baseState);
+  //? Manages the form validation state
+  const [formValidation, setValidation] = useState(baseValidation);
+  //? Manages visualization data
+  const [visualization, setVisualization] = useState<visualizer[]>([]);
+
+  //   console.log(formValues);
+  return (
+    <>
+      <form class="w-full mb-4 flex flex-col" htmlFor="visualization">
+        {/* Leading text. Displays before the expression */}
+        <StyledInput
+          key="leading-text"
+          inputType="text"
+          label="Leading text"
+          labelLink="leading-text"
+          name="leading"
+          value={formValues.leadingText}
+          inputFunction={(input) => {
+            setValues((currentState) => ({
+              ...currentState,
+              leadingText: input,
+            }));
+          }}
+          validationReference={validationStatus.Unchanged}
+          validationFunction={() => validationStatus.Unchanged}
+        />
+        {/* Expression text. Fades out and becomes the evaluated text */}
+        <StyledInput
+          key="expression-text"
+          inputType="text"
+          label="Expression"
+          labelLink="expression-text"
+          name="expression"
+          value={formValues.expressionText}
+          inputFunction={(input) => {
+            setValues((currentState) => ({
+              ...currentState,
+              expressionText: input,
+            }));
+            setValidation((current) => ({
+              ...current,
+              expressionText: validateNonEmptyText(input),
+            }));
+          }}
+          validationReference={formValidation.expressionText}
+          validationFunction={(input) => validateNonEmptyText(input.toString())}
+        />
+        {/* Evaluation text. Fades in after the Expression text fades out */}
+        <StyledInput
+          key="evaluated-text"
+          inputType="text"
+          label="Result"
+          labelLink="evaluated-text"
+          name="evaluated"
+          value={formValues.evaluatedText}
+          inputFunction={(input) => {
+            setValues((currentState) => ({
+              ...currentState,
+              evaluatedText: input,
+            }));
+            setValidation((current) => ({
+              ...current,
+              evaluatedText: validateNonEmptyText(input),
+            }));
+          }}
+          validationReference={formValidation.evaluatedText}
+          validationFunction={() => validationStatus.Unchanged}
+        />
+        {/* Trailing text. Displays after the expression */}
+        <StyledInput
+          key="trailing-text"
+          inputType="text"
+          label="Trailing text"
+          labelLink="trailing-text"
+          name="trailing"
+          value={formValues.trailingText}
+          inputFunction={(input) => {
+            setValues((currentState) => ({
+              ...currentState,
+              trailingText: input,
+            }));
+          }}
+          validationReference={validationStatus.Unchanged}
+          validationFunction={() => validationStatus.Unchanged}
+        />
+        {/* Add validation step button */}
+        <StyledButton
+          text="Add step"
+          classes="self-center m-4"
+          onClickFunction={() => {
+            setVisualization((current) => [...current, formValues]);
+            setValues((current) => ({
+              leadingText: current.leadingText +
+                current.evaluatedText + current.trailingText,
+              expressionText: "",
+              evaluatedText: "",
+              trailingText: "",
+            }));
+          }}
+        />
+      </form>
+      {/* Display steps */}
+      <ExpressionVisualizationList visualizationList={visualization} />
+    </>
+  );
+}

--- a/islands/tools/expression-visualizer/ExpressionVisualizationList.tsx
+++ b/islands/tools/expression-visualizer/ExpressionVisualizationList.tsx
@@ -3,9 +3,9 @@ import type { JSX } from "preact";
 //? State management
 import { useState } from "preact/hooks";
 //? Component
-import { ExpressionVisualizationListItem } from "../../components/tools/expression-visualizer/ExpressionVisualizationListItem.tsx";
+import { ExpressionVisualizationListItem } from "../../../components/tools/expression-visualizer/ExpressionVisualizationListItem.tsx";
 //? Type
-import type { visualizer } from "../../types/component-properties/tools/expression-visualizer/Visualizer.ts";
+import type { visualizer } from "../../../types/component-properties/tools/expression-visualizer/Visualizer.ts";
 
 //? Renders an Expression list
 export default function ExpressionVisualizationList(

--- a/islands/tools/expression-visualizer/ExpressionVisualizer.tsx
+++ b/islands/tools/expression-visualizer/ExpressionVisualizer.tsx
@@ -1,17 +1,17 @@
 //? State management
 import { useState } from "preact/hooks";
 //? Components
-import { StyledButton } from "../../components/UI/StyledButton.tsx";
-import { StyledInput } from "../../components/UI/StyledInput.tsx";
+import { StyledButton } from "../../../components/UI/StyledButton.tsx";
+import { StyledInput } from "../../../components/UI/StyledInput.tsx";
 import ExpressionVisualizationList from "./ExpressionVisualizationList.tsx";
 //? Validation
-import { validationStatus } from "../../types/forms/validationStatus.ts";
-import { validateNonEmptyText } from "../../services/form-validation/validateNonEmptyText.ts";
+import { validationStatus } from "../../../types/forms/validationStatus.ts";
+import { validateNonEmptyText } from "../../../services/form-validation/validateNonEmptyText.ts";
 //? Diff function
-import { differenceBetweenStrings } from "../../services/expression-visualizer/differenceBetweenStrings.ts";
+import { differenceBetweenStrings } from "../../../services/expression-visualizer/differenceBetweenStrings.ts";
 
 //? Types
-import type { visualizer } from "../../types/component-properties/tools/expression-visualizer/Visualizer.ts";
+import type { visualizer } from "../../../types/component-properties/tools/expression-visualizer/Visualizer.ts";
 type partialVisualizer = Pick<visualizer, "expressionText" | "evaluatedText">;
 type ValidationStatuses<K extends keyof partialVisualizer> = Record<
   K,

--- a/islands/tools/expression-visualizer/ExpressionVisualizerAdvanced.tsx
+++ b/islands/tools/expression-visualizer/ExpressionVisualizerAdvanced.tsx
@@ -1,14 +1,14 @@
 //? State management
 import { useState } from "preact/hooks";
 //? Components
-import { StyledButton } from "../../components/UI/StyledButton.tsx";
-import { StyledInput } from "../../components/UI/StyledInput.tsx";
+import { StyledButton } from "../../../components/UI/StyledButton.tsx";
+import { StyledInput } from "../../../components/UI/StyledInput.tsx";
 import ExpressionVisualizationList from "./ExpressionVisualizationList.tsx";
 //? Validation
-import { validationStatus } from "../../types/forms/validationStatus.ts";
-import { validateNonEmptyText } from "../../services/form-validation/validateNonEmptyText.ts";
+import { validationStatus } from "../../../types/forms/validationStatus.ts";
+import { validateNonEmptyText } from "../../../services/form-validation/validateNonEmptyText.ts";
 //? Type
-import type { visualizer } from "../../types/component-properties/tools/expression-visualizer/Visualizer.ts";
+import type { visualizer } from "../../../types/component-properties/tools/expression-visualizer/Visualizer.ts";
 type ValidationStatuses<K extends keyof visualizer> = Record<
   K,
   validationStatus

--- a/islands/tools/retirement-calculator/RetirementCalculationForm.tsx
+++ b/islands/tools/retirement-calculator/RetirementCalculationForm.tsx
@@ -1,21 +1,21 @@
 //? State management
 import { StateUpdater, useState } from "preact/hooks";
 //? Components
-import { StyledInput } from "../../components/UI/StyledInput.tsx";
-import { StyledButton } from "../../components/UI/StyledButton.tsx";
-import { ErrorAlert } from "../../components/UI/ErrorAlert.tsx";
+import { StyledInput } from "../../../components/UI/StyledInput.tsx";
+import { StyledButton } from "../../../components/UI/StyledButton.tsx";
+import { ErrorAlert } from "../../../components/UI/ErrorAlert.tsx";
 //? Validation
-import { validationStatus } from "../../types/forms/validationStatus.ts";
-import { patternValidation } from "../../services/form-validation/patternValidation.ts";
-import { validateAge as validateCurrentAge } from "../../services/form-validation/validateAge.ts";
-import { validateRetiringAge } from "../../services/form-validation/validateRetirementAge.ts";
-import { validateCompensation } from "../../services/form-validation/validateCompensation.ts";
-import { validateYearlyInvestment } from "../../services/form-validation/validateInvestment.ts";
-import { validateOneOrGreater } from "../../services/form-validation/validateOneOrGreater.ts";
-import { validateZeroOrGreater } from "../../services/form-validation/validateZeroOrGreater.ts";
+import { validationStatus } from "../../../types/forms/validationStatus.ts";
+import { patternValidation } from "../../../services/form-validation/patternValidation.ts";
+import { validateAge as validateCurrentAge } from "../../../services/form-validation/validateAge.ts";
+import { validateRetiringAge } from "../../../services/form-validation/validateRetirementAge.ts";
+import { validateCompensation } from "../../../services/form-validation/validateCompensation.ts";
+import { validateYearlyInvestment } from "../../../services/form-validation/validateInvestment.ts";
+import { validateOneOrGreater } from "../../../services/form-validation/validateOneOrGreater.ts";
+import { validateZeroOrGreater } from "../../../services/form-validation/validateZeroOrGreater.ts";
 
 //? Base state data
-import { baseRetirementStats } from "../../data/tools/retirement-calculator/baseRetirementStats.ts";
+import { baseRetirementStats } from "../../../data/tools/retirement-calculator/baseRetirementStats.ts";
 const defaultFormValidation = {
   currentAge: validationStatus.Unchanged,
   plannedRetiringAge: validationStatus.Unchanged,

--- a/islands/tools/retirement-calculator/RetirementCalculator.tsx
+++ b/islands/tools/retirement-calculator/RetirementCalculator.tsx
@@ -2,10 +2,10 @@
 import { useMemo, useState } from "preact/hooks";
 //? Components/Islands
 import RetirementCalculatorForm from "./RetirementCalculationForm.tsx";
-import { RetirementCalculationTable } from "../../components/tools/retirement-calculator/RetirementCalculationTable.tsx";
-import { StyledSubHeader } from "../../components/UI/StyledSubHeader.tsx";
+import { RetirementCalculationTable } from "../../../components/tools/retirement-calculator/RetirementCalculationTable.tsx";
+import { StyledSubHeader } from "../../../components/UI/StyledSubHeader.tsx";
 //? Data
-import { baseRetirementStats } from "../../data/tools/retirement-calculator/baseRetirementStats.ts";
+import { baseRetirementStats } from "../../../data/tools/retirement-calculator/baseRetirementStats.ts";
 
 export default function RetirementCalculator() {
   //? Manages current state for form data

--- a/islands/tools/syntax-highlight/HighlightedCode.tsx
+++ b/islands/tools/syntax-highlight/HighlightedCode.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useRef, useState } from "preact/hooks";
 //? Function to copy content to clipboard
-import { copyToClipboard } from "../../services/copyToClipboard.ts";
+import { copyToClipboard } from "../../../services/copyToClipboard.ts";
 //? Import type for typecasting useState
-import type { booleanOrUndefined } from "../../types/misc/booleanOrUndefined.ts";
+import type { booleanOrUndefined } from "../../../types/misc/booleanOrUndefined.ts";
 //? Import status report toggle
-import { CopyStatus } from "../../components/misc/CopyStatus.tsx";
+import { CopyStatus } from "../../../components/misc/CopyStatus.tsx";
 
 //? Define function that will try to copy the edited content to
 //? clipboard and then update the success state

--- a/islands/tools/whatsapp-message-link-generator/WhatsappLinkGenerator.tsx
+++ b/islands/tools/whatsapp-message-link-generator/WhatsappLinkGenerator.tsx
@@ -1,23 +1,23 @@
 //? Manage form state
 import { useEffect, useRef, useState } from "preact/hooks";
 //? Styled components
-import { StyledInput } from "../../components/UI/StyledInput.tsx";
-import { StyledButton } from "../../components/UI/StyledButton.tsx";
-import { CountryPhoneCodeSelect } from "../../components/UI/CountryPhoneCodeSelect.tsx";
+import { StyledInput } from "../../../components/UI/StyledInput.tsx";
+import { StyledButton } from "../../../components/UI/StyledButton.tsx";
+import { CountryPhoneCodeSelect } from "../../../components/UI/CountryPhoneCodeSelect.tsx";
 //? Types for typecasting
-import { validationStatus } from "../../types/forms/validationStatus.ts";
-import type { WhatsappLinkData } from "../../types/component-properties/tools/whatsapp-link-generator/whatsapp-link-data.ts";
-import { WhatsappMessagePreview } from "../../components/tools/whatsapp-message-link-generator/WhatsappMessagePreview.tsx";
+import { validationStatus } from "../../../types/forms/validationStatus.ts";
+import type { WhatsappLinkData } from "../../../types/component-properties/tools/whatsapp-link-generator/whatsapp-link-data.ts";
+import { WhatsappMessagePreview } from "../../../components/tools/whatsapp-message-link-generator/WhatsappMessagePreview.tsx";
 
 //? Validation functions
-import { patternValidation } from "../../services/form-validation/patternValidation.ts";
-import { validateAreaCode } from "../../services/form-validation/validateAreaCode.ts";
-import { validatePhoneNumber } from "../../services/form-validation/validatePhoneNumber.ts";
-import { WhatsappLinksList } from "../../components/tools/whatsapp-message-link-generator/WhatsappLinksList.tsx";
-import { StyledTextArea } from "../../components/UI/StyledTextArea.tsx";
+import { patternValidation } from "../../../services/form-validation/patternValidation.ts";
+import { validateAreaCode } from "../../../services/form-validation/validateAreaCode.ts";
+import { validatePhoneNumber } from "../../../services/form-validation/validatePhoneNumber.ts";
+import { WhatsappLinksList } from "../../../components/tools/whatsapp-message-link-generator/WhatsappLinksList.tsx";
+import { StyledTextArea } from "../../../components/UI/StyledTextArea.tsx";
 
 //? Defined variable to replace in message body
-import { WHATSAPP_MESSAGE_VARIABLE_PLACEHOLDER } from "../../data/tools/whatsapp-link-generator/whatsapp-message-variable-placeholder.ts";
+import { WHATSAPP_MESSAGE_VARIABLE_PLACEHOLDER } from "../../../data/tools/whatsapp-link-generator/whatsapp-message-variable-placeholder.ts";
 
 //? Default form values and validation
 const baseLinkData: WhatsappLinkData = {

--- a/islands/tools/whatsapp-message-link-generator/WhatsappLinkGenerator.tsx
+++ b/islands/tools/whatsapp-message-link-generator/WhatsappLinkGenerator.tsx
@@ -4,10 +4,11 @@ import { useEffect, useRef, useState } from "preact/hooks";
 import { StyledInput } from "../../../components/UI/StyledInput.tsx";
 import { StyledButton } from "../../../components/UI/StyledButton.tsx";
 import { CountryPhoneCodeSelect } from "../../../components/UI/CountryPhoneCodeSelect.tsx";
+//? Preview component
+import { WhatsappMessagePreview } from "../../../components/tools/whatsapp-message-link-generator/WhatsappMessagePreview.tsx";
 //? Types for typecasting
 import { validationStatus } from "../../../types/forms/validationStatus.ts";
 import type { WhatsappLinkData } from "../../../types/component-properties/tools/whatsapp-link-generator/whatsapp-link-data.ts";
-import { WhatsappMessagePreview } from "../../../components/tools/whatsapp-message-link-generator/WhatsappMessagePreview.tsx";
 
 //? Validation functions
 import { patternValidation } from "../../../services/form-validation/patternValidation.ts";

--- a/routes/projects/expenses-tracker.tsx
+++ b/routes/projects/expenses-tracker.tsx
@@ -9,7 +9,7 @@ import { Base } from "../../components/base/Base.tsx";
 //? Navigation Buttons to go back to the previous page or to the next article
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? Import the component responsible for tracking all expenses
-import ExpensesTracker from "../../islands/projects/ExpensesTracker.tsx";
+import ExpensesTracker from "../../islands/projects/expenses-tracker/ExpensesTracker.tsx";
 //? Import middleware responsible for pulling expenses tracked
 import { expensesTrackerMiddleware } from "../../middleware/projects/__expenses-tracker.ts";
 

--- a/routes/projects/food-order/checkout.tsx
+++ b/routes/projects/food-order/checkout.tsx
@@ -6,7 +6,7 @@ import { Base } from "../../../components/base/Base.tsx";
 import { NavigationButtons } from "../../../components/misc/NavigationButtons.tsx";
 //? Header to display page name
 import { StyledHeader } from "../../../components/UI/StyledHeader.tsx";
-import FoodOrderCheckout from "../../../islands/projects/FoodOrderCheckout.tsx";
+import FoodOrderCheckout from "../../../islands/projects/food-order/FoodOrderCheckout.tsx";
 
 //? Renders the food-order checkout page
 export default function Home() {

--- a/routes/projects/food-order/index.tsx
+++ b/routes/projects/food-order/index.tsx
@@ -7,7 +7,7 @@ import { Base } from "../../../components/base/Base.tsx";
 //? Navigation Buttons to go back to the previous page
 import { NavigationButtons } from "../../../components/misc/NavigationButtons.tsx";
 //? Component responsible for rendering the food list and modals
-import FoodOrder from "../../../islands/projects/FoodOrder.tsx";
+import FoodOrder from "../../../islands/projects/food-order/FoodOrder.tsx";
 //? Import Food type to typecast the data received
 import { Food } from "../../../types/component-properties/projects/food-order/Food.ts";
 //? Import middleware responsible for pulling food items

--- a/routes/projects/food-order/index.tsx
+++ b/routes/projects/food-order/index.tsx
@@ -9,7 +9,7 @@ import { NavigationButtons } from "../../../components/misc/NavigationButtons.ts
 //? Component responsible for rendering the food list and modals
 import FoodOrder from "../../../islands/projects/food-order/FoodOrder.tsx";
 //? Import Food type to typecast the data received
-import { Food } from "../../../types/component-properties/projects/food-order/Food.ts";
+import type { Food } from "../../../types/component-properties/projects/food-order/Food.ts";
 //? Import middleware responsible for pulling food items
 import { foodOrderMiddleware } from "../../../middleware/projects/__food-order.ts";
 

--- a/routes/projects/stimulus-check.tsx
+++ b/routes/projects/stimulus-check.tsx
@@ -7,7 +7,7 @@ import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 //? Navigation Buttons to go back to the previous page or to the next article
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? Stylized and functional Form Island
-import FormWithValidation from "../../islands/projects/FormWithValidation.tsx";
+import StimulusCheckForm from "../../islands/projects/stimulus-check/StimulusCheckForm.tsx";
 
 export default function Home() {
   return (
@@ -26,7 +26,7 @@ export default function Home() {
         <article class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
           {/* Title header */}
           <StyledHeader title="Stimulus Checks Eligibility Form" />
-          <FormWithValidation />
+          <StimulusCheckForm />
         </article>
       </Base>
     </>

--- a/routes/projects/tictactoe.tsx
+++ b/routes/projects/tictactoe.tsx
@@ -10,7 +10,7 @@ import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 import { GradientLink } from "../../components/UI/GradientLink.tsx";
 //? Renders the game board with play tiles, current player
 //? turn and game completion status
-import TicTacToeBoard from "../../islands/projects/TicTacToeBoard.tsx";
+import TicTacToeBoard from "../../islands/projects/tic-tac-toe/TicTacToeBoard.tsx";
 
 export default function Home() {
   return (

--- a/routes/tools/expression-visualizer-advanced.tsx
+++ b/routes/tools/expression-visualizer-advanced.tsx
@@ -6,7 +6,7 @@ import { Base } from "../../components/base/Base.tsx";
 import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 //? Navigation Buttons to go back to the tools page
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
-import ExpressionVisualizerAdvanced from "../../islands/tools/ExpressionVisualizerAdvanced.tsx";
+import ExpressionVisualizerAdvanced from "../../islands/tools/expression-visualizer/ExpressionVisualizerAdvanced.tsx";
 
 export default function Home() {
   return (

--- a/routes/tools/expression-visualizer-advanced.tsx
+++ b/routes/tools/expression-visualizer-advanced.tsx
@@ -1,0 +1,40 @@
+//? Head component with all Meta tags pre-set
+import { CustomHead } from "../../components/base/CustomHead.tsx";
+//? Create visualizer content inside Base component
+import { Base } from "../../components/base/Base.tsx";
+//? Default styled header
+import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
+//? Navigation Buttons to go back to the tools page
+import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
+import ExpressionVisualizerAdvanced from "../../islands/tools/ExpressionVisualizerAdvanced.tsx";
+
+export default function Home() {
+  return (
+    <>
+      {
+        /* Base Head with all common required imports, plus added
+        meta-tags and imports required for this specific route */
+      }
+      <CustomHead
+        title="Expression Visualizer Plus"
+        description="Handcraft a step-by-step visualizer of how an expression develops over time so you can show to others in slow-motion how the computer processes an expression."
+        link="https://www.theyurig.com/tools/expression-visualizer-advanced"
+      >
+      </CustomHead>
+      {/* Base page layout with theme switching and footer outside of accent box */}
+      <Base>
+        <NavigationButtons
+          back={{
+            title: "Switch back to the base mode",
+            link: "/tools/expression-visualizer",
+          }}
+        />
+        <section class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
+          <StyledHeader title="Advanced Expression Visualizer" />
+          {/* Advanced Expression Visualizer */}
+          <ExpressionVisualizerAdvanced />
+        </section>
+      </Base>
+    </>
+  );
+}

--- a/routes/tools/expression-visualizer.tsx
+++ b/routes/tools/expression-visualizer.tsx
@@ -7,7 +7,7 @@ import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 //? Navigation Buttons to go back to the tools page
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? Expression Visualizer component
-import ExpressionVisualizer from "../../islands/tools/ExpressionVisualizer.tsx";
+import ExpressionVisualizer from "../../islands/tools/expression-visualizer/ExpressionVisualizer.tsx";
 
 export default function Home() {
   return (

--- a/routes/tools/expression-visualizer.tsx
+++ b/routes/tools/expression-visualizer.tsx
@@ -6,6 +6,7 @@ import { Base } from "../../components/base/Base.tsx";
 import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 //? Navigation Buttons to go back to the tools page
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
+//? Expression Visualizer component
 import ExpressionVisualizer from "../../islands/tools/ExpressionVisualizer.tsx";
 
 export default function Home() {
@@ -25,6 +26,10 @@ export default function Home() {
       <Base>
         <NavigationButtons
           back={{ title: "Return to tools", link: "/tools" }}
+          next={{
+            title: "Expression Visualizer Plus (Advanced mode)",
+            link: "/tools/expression-visualizer-advanced",
+          }}
         />
         <section class="flex flex-col h-full w-full max-w-4xl mx-auto items-center">
           <StyledHeader title="Expression Visualizer" />

--- a/routes/tools/highlighted-text/[text].tsx
+++ b/routes/tools/highlighted-text/[text].tsx
@@ -13,7 +13,7 @@ import DigitalTimer from "../../../islands/UI/DigitalTimer.tsx";
 //? Imports middleware responsible for processing GET/POST requests to this route
 import { highlightTextMiddleware } from "../../../middleware/tools/__highlighted-text.tsx";
 //? Import interface that defines what are the required properties for this content
-import type { HighlightText } from "../../../types/syntax-highlight/HighlightText.ts";
+import type { HighlightText } from "../../../types/component-properties/tools/syntax-highlight/HighlightText.ts";
 //? Import component that creates a clickable textarea that copies the inner content to clipboard
 import CopyTextAreaToClipboard from "../../../islands/misc/CopyTextAreaToClipboard.tsx";
 //? Import CSS classes text example

--- a/routes/tools/highlighted-text/[text].tsx
+++ b/routes/tools/highlighted-text/[text].tsx
@@ -7,7 +7,7 @@ import { StyledHeader } from "../../../components/UI/StyledHeader.tsx";
 //? Navigation Buttons to go back to the previous page or to the next article
 import { NavigationButtons } from "../../../components/misc/NavigationButtons.tsx";
 //? Import the component responsible for adding the content that will eventually be highlighted
-import HighlightedCode from "../../../islands/tools/HighlightedCode.tsx";
+import HighlightedCode from "../../../islands/tools/syntax-highlight/HighlightedCode.tsx";
 //? Shows timer remaining on hover
 import DigitalTimer from "../../../islands/UI/DigitalTimer.tsx";
 //? Imports middleware responsible for processing GET/POST requests to this route

--- a/routes/tools/retirement-calculator.tsx
+++ b/routes/tools/retirement-calculator.tsx
@@ -7,7 +7,7 @@ import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 //? Navigation Buttons to go back to the tools page
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
 //? Retirement calculator form and table
-import RetirementCalculator from "../../islands/tools/RetirementCalculator.tsx";
+import RetirementCalculator from "../../islands/tools/retirement-calculator/RetirementCalculator.tsx";
 
 //? Renders the retirement calculator page, with a form to calculate your retirement plan
 export default function Home() {

--- a/routes/tools/whatsapp-message-link-generator.tsx
+++ b/routes/tools/whatsapp-message-link-generator.tsx
@@ -6,7 +6,7 @@ import { Base } from "../../components/base/Base.tsx";
 import { StyledHeader } from "../../components/UI/StyledHeader.tsx";
 //? Navigation Buttons to go back to the tools page
 import { NavigationButtons } from "../../components/misc/NavigationButtons.tsx";
-import WhatsappLinkGenerator from "../../islands/tools/WhatsappLinkGenerator.tsx";
+import WhatsappLinkGenerator from "../../islands/tools/whatsapp-message-link-generator/WhatsappLinkGenerator.tsx";
 
 //? Renders the food-order page, with a list of items and a cart
 export default function Home() {

--- a/services/expression-visualizer/commonLeadingIndexesInArrays.ts
+++ b/services/expression-visualizer/commonLeadingIndexesInArrays.ts
@@ -1,0 +1,14 @@
+//? Parses two arrays and returns an array with the indexes that are equal between then, starting from the first index in both and stopping when the first unmatching index is found
+export function commonLeadingIndexesInArrays<T>(
+  firstArray: Array<T>,
+  secondArray: Array<T>,
+): Array<T> {
+  const commonLeadingArray: Array<T> = [];
+  for (let index = 0; index < firstArray.length; index++) {
+    if (firstArray[index] !== secondArray[index]) {
+      break;
+    }
+    commonLeadingArray.push(firstArray[index]);
+  }
+  return commonLeadingArray;
+}

--- a/services/expression-visualizer/commonTrailingIndexesInArrays.ts
+++ b/services/expression-visualizer/commonTrailingIndexesInArrays.ts
@@ -1,0 +1,19 @@
+//? Parses two arrays and returns an array with the indexes that are equal between then, starting from the last index in both and stopping when the first unmatching index is found
+export function commonTrailingIndexesInArrays<T>(
+  firstArray: Array<T>,
+  secondArray: Array<T>,
+): Array<T> {
+  const commonTrailingArray: Array<T> = [];
+  const firstArrayLength = firstArray.length;
+  const secondArrayLength = secondArray.length;
+  for (let index = 0; index < firstArrayLength; index++) {
+    if (
+      firstArray[firstArrayLength - index - 1] !==
+        secondArray[secondArrayLength - index - 1]
+    ) {
+      break;
+    }
+    commonTrailingArray.unshift(firstArray[firstArrayLength - index - 1]);
+  }
+  return commonTrailingArray;
+}

--- a/services/expression-visualizer/differenceBetweenStrings.ts
+++ b/services/expression-visualizer/differenceBetweenStrings.ts
@@ -1,0 +1,49 @@
+//? Diff functions
+import { commonTrailingIndexesInArrays } from "./commonTrailingIndexesInArrays.ts";
+import { commonLeadingIndexesInArrays } from "./commonLeadingIndexesInArrays.ts";
+
+//? Given two strings, return an array with the leading common text, the different text in the first string, the different text in the second string and trailing common text
+//! The character sequence "&;" can be used in the second string to force a difference that isn't returned by the function
+export function differenceBetweenStrings(
+  firstString: string,
+  secondString: string,
+): [string, string, string, string] {
+  //? If different strings weren't provided, return the first string and empty strings
+  if (firstString === secondString) {
+    return [firstString, "", "", ""];
+  }
+
+  //? Convert parameters to arrays
+  const firstStringArray = firstString.split("");
+  const secondStringArray = secondString.split("");
+
+  //? Get leading text common to both strings
+  const leadingText = commonLeadingIndexesInArrays(
+    firstStringArray,
+    secondStringArray,
+  )
+    .join("");
+  //? Get trailing text common to both strings
+  const trailingText = commonTrailingIndexesInArrays(
+    firstStringArray,
+    secondStringArray,
+  )
+    .join("");
+
+  //? Separate substrings that are different for each string
+  const firstStringDifference: string = firstString.substring(
+    0,
+    firstString.length - trailingText.length,
+  ).substring(leadingText.length);
+  const secondStringDifference: string = secondString.substring(
+    0,
+    secondString.length - trailingText.length,
+  ).substring(leadingText.length).replace(/&;/g, "");
+
+  return [
+    leadingText,
+    firstStringDifference,
+    secondStringDifference,
+    trailingText,
+  ];
+}

--- a/services/tictactoe/resetBoardFunction.ts
+++ b/services/tictactoe/resetBoardFunction.ts
@@ -1,7 +1,7 @@
 //? Import maximum number of tiles in a board
 import { MAX_TICTACTOE_TILES } from "../../data/projects/tictactoe/maxTiles.ts";
 //? Import interface for typecasting
-import { BoardTile } from "../../types/component-properties/projects/tictactoe/BoardTile.ts";
+import type { BoardTile } from "../../types/component-properties/projects/tictactoe/BoardTile.ts";
 
 //? Reset the board and populate it with 9 empty elements to render new tiles
 export function resetBoardFunction(board: BoardTile[]) {

--- a/services/tictactoe/shouldGameEnd.ts
+++ b/services/tictactoe/shouldGameEnd.ts
@@ -1,5 +1,5 @@
 //? Import interface for typecasting
-import { BoardTile } from "../../types/component-properties/projects/tictactoe/BoardTile.ts";
+import type { BoardTile } from "../../types/component-properties/projects/tictactoe/BoardTile.ts";
 
 //? Checks if the current board meets any condition to complete with a victory
 export function shouldGameEnd(boardMarks: BoardTile[]) {


### PR DESCRIPTION
Closes #112.

Additionally, this PR also does the following:
- Creates an additional page for the "advanced" expression visualizer (`/tools/expression-visualizer-advanced`).
- Nest islands in their proper folders, something that was meant to be enabled with 1.2 but ended up requiring an additional patch.
- Fixed issues with importing types (additionally, realized some of the files in `/types` shouldn't be there, like error handling and validation).